### PR TITLE
docs: Add feature documentation pages with linked comparison chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ Works with **Claude Code**, **Cursor**, **Windsurf**, **Claude Desktop**, **Zed*
 | **DOM queries** | ✅ | ✅ | ✅ | ✅ |
 | **Screenshots** | ✅ | ✅ | ✅ | ✅ |
 | | | | | |
-| **Web Vitals** | ✅ LCP, CLS, INP, FCP | ❌ | ❌ | ❌ |
-| **Regression detection** | ✅ Automatic | ❌ | ❌ | ❌ |
-| **API schema inference** | ✅ OpenAPI from traffic | ❌ | ❌ | ❌ |
-| **Accessibility audits** | ✅ WCAG + SARIF | ❌ | ❌ | ❌ |
-| **Session checkpoints** | ✅ Named + auto | ❌ | ❌ | ❌ |
-| **Noise filtering** | ✅ Auto-detect | ❌ | ❌ | ❌ |
+| **[Web Vitals](https://cookwithgasoline.com/web-vitals/)** | ✅ LCP, CLS, INP, FCP | ❌ | ❌ | ❌ |
+| **[Regression detection](https://cookwithgasoline.com/regression-detection/)** | ✅ Automatic | ❌ | ❌ | ❌ |
+| **[API schema inference](https://cookwithgasoline.com/api-schema/)** | ✅ OpenAPI from traffic | ❌ | ❌ | ❌ |
+| **[Accessibility audits](https://cookwithgasoline.com/accessibility-audit/)** | ✅ WCAG + SARIF | ❌ | ❌ | ❌ |
+| **[Session checkpoints](https://cookwithgasoline.com/session-checkpoints/)** | ✅ Named + auto | ❌ | ❌ | ❌ |
+| **[Noise filtering](https://cookwithgasoline.com/noise-filtering/)** | ✅ Auto-detect | ❌ | ❌ | ❌ |
 | | | | | |
-| **Test generation** | ✅ Playwright | ❌ | ❌ | ❌ |
-| **Reproduction scripts** | ✅ From actions | ❌ | ❌ | ❌ |
-| **PR summaries** | ✅ Perf impact | ❌ | ❌ | ❌ |
-| **HAR export** | ✅ | ❌ | ❌ | ❌ |
+| **[Test generation](https://cookwithgasoline.com/generate-test/)** | ✅ Playwright | ❌ | ❌ | ❌ |
+| **[Reproduction scripts](https://cookwithgasoline.com/reproduction-scripts/)** | ✅ From actions | ❌ | ❌ | ❌ |
+| **[PR summaries](https://cookwithgasoline.com/pr-summaries/)** | ✅ Perf impact | ❌ | ❌ | ❌ |
+| **[HAR export](https://cookwithgasoline.com/har-export/)** | ✅ | ❌ | ❌ | ❌ |
 | | | | | |
 | **Zero dependencies** | ✅ Single Go binary | ❌ Node.js + Chrome flags | ❌ Node.js + Puppeteer | ❌ Electron |
 | **Vendor neutral** | ✅ Any MCP tool | ⚠️ Any MCP tool | ⚠️ Any MCP tool | ❌ Cursor only |
@@ -116,6 +116,12 @@ Works with **Claude Code**, **Cursor**, **Windsurf**, **Claude Desktop**, **Zed*
 
 **[Privacy details →](https://cookwithgasoline.com/privacy/)**
 
+## Performance
+
+See [latest benchmarks](benchmarks/latest-benchmark.md) for current performance data.
+
+Last benchmarked: 2026-01-24 on darwin/arm64 (v4.6.0)
+
 ## Development
 
 ```bash
@@ -123,6 +129,8 @@ make test                              # Go server tests
 node --test extension-tests/*.test.js  # Extension tests
 make dev                               # Build for current platform
 ```
+
+**[Release process & quality gates →](RELEASE.md)**
 
 ## License
 

--- a/docs/api-schema.md
+++ b/docs/api-schema.md
@@ -1,0 +1,129 @@
+---
+title: "API Schema Inference"
+description: "Automatically discover your API schema from live network traffic. Gasoline observes HTTP requests and infers endpoints, methods, status codes, and response shapes — no OpenAPI file required."
+keywords: "API schema inference, OpenAPI generation, API discovery, network traffic analysis, endpoint detection, API documentation, response shape"
+permalink: /api-schema/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "No OpenAPI file? No problem. Gasoline infers it from traffic."
+toc: true
+toc_sticky: true
+---
+
+Gasoline watches your app's network traffic and automatically builds an API schema — endpoints, methods, status codes, and response shapes — without any manual configuration.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+Your AI assistant is debugging a failed API call, but it doesn't know what endpoints your app uses, what they expect, or what they return. Without an OpenAPI spec (which most projects don't maintain), the AI is flying blind.
+
+It could read your backend source code, but that's slow and may not reflect the actual runtime behavior. What if the frontend calls third-party APIs too? What if the backend has middleware that transforms responses?
+
+Gasoline solves this by observing what actually happens on the wire.
+
+## <i class="fas fa-project-diagram"></i> How It Works
+
+1. <i class="fas fa-globe"></i> The extension captures every HTTP request/response as you use your app
+2. <i class="fas fa-brain"></i> The server groups requests by endpoint pattern (normalizing path parameters)
+3. <i class="fas fa-shapes"></i> Response shapes are inferred from JSON bodies
+4. <i class="fas fa-file-code"></i> Your AI queries the schema via `analyze` with `target: "api"`
+
+The schema improves with every request — the more you use your app, the more complete it becomes.
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+// Get inferred API schema
+{ "tool": "analyze", "arguments": { "target": "api" } }
+
+// Filter to specific endpoints
+{ "tool": "analyze", "arguments": { "target": "api", "url_filter": "/api/users" } }
+
+// Only show endpoints observed 3+ times
+{ "tool": "analyze", "arguments": { "target": "api", "min_observations": 3 } }
+
+// Get OpenAPI stub format
+{ "tool": "analyze", "arguments": { "target": "api", "format": "openapi_stub" } }
+```
+
+## <i class="fas fa-sitemap"></i> What Gets Inferred
+
+For each endpoint, Gasoline tracks:
+
+| Field | Description |
+|-------|-------------|
+| **Path pattern** | URL with path parameters normalized (e.g., `/api/users/:id`) |
+| **Methods** | HTTP methods observed (GET, POST, PUT, DELETE) |
+| **Status codes** | Response codes seen (200, 201, 404, 500) |
+| **Response shape** | JSON structure with types (string, number, array, object) |
+| **Observation count** | How many times this endpoint was called |
+| **Content types** | Response content types (application/json, text/html) |
+
+## <i class="fas fa-code"></i> Output Formats
+
+### Gasoline Format (default)
+
+Compact, AI-friendly format optimized for context windows:
+
+```json
+{
+  "endpoints": [
+    {
+      "path": "/api/users/:id",
+      "methods": ["GET", "PUT"],
+      "statuses": [200, 404],
+      "observations": 8,
+      "responseShape": {
+        "id": "number",
+        "name": "string",
+        "email": "string",
+        "roles": ["string"]
+      }
+    }
+  ]
+}
+```
+
+### OpenAPI Stub
+
+Standard OpenAPI 3.0 structure for integration with other tools:
+
+```json
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/users/{id}": {
+      "get": {
+        "responses": {
+          "200": { "description": "OK" },
+          "404": { "description": "Not Found" }
+        }
+      }
+    }
+  }
+}
+```
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Understand the API without docs** — "Your app uses 12 endpoints. The `/api/orders` endpoint returns paginated results with `items[]` and `totalCount`."
+- **Debug mismatches** — "The frontend expects `user.firstName` but the API returns `user.first_name`. This is likely the cause of the undefined error."
+- **Suggest missing error handling** — "The `/api/payments` endpoint has returned 500 errors 3 times. Your frontend doesn't handle this status code."
+- **Generate types** — "Based on observed responses, here's a TypeScript interface for the User endpoint."
+
+## <i class="fas fa-filter"></i> Path Normalization
+
+Gasoline automatically normalizes dynamic path segments:
+
+| Observed URLs | Inferred Pattern |
+|--------------|-----------------|
+| `/api/users/123`, `/api/users/456` | `/api/users/:id` |
+| `/api/orders/abc-def/items` | `/api/orders/:id/items` |
+
+This prevents endpoint explosion from dynamic routes.
+
+## <i class="fas fa-link"></i> Related
+
+- [Network Bodies](/network-bodies/) — Full request/response payload capture
+- [HAR Export](/har-export/) — Export raw traffic as HTTP Archive
+- [Test Generation](/generate-test/) — Generate tests with API assertions

--- a/docs/har-export.md
+++ b/docs/har-export.md
@@ -1,0 +1,132 @@
+---
+title: "HAR Export"
+description: "Export captured network traffic as HTTP Archive (HAR) files. Standard format compatible with Chrome DevTools, Charles Proxy, and any HAR viewer for sharing and analysis."
+keywords: "HAR export, HTTP Archive, network traffic export, HAR file, traffic recording, network debugging, request export, API traffic"
+permalink: /har-export/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Export your network traffic. Standard format, any viewer."
+toc: true
+toc_sticky: true
+---
+
+Gasoline exports captured network traffic as HAR (HTTP Archive) files — the standard format supported by Chrome DevTools, Firefox, Charles Proxy, and dozens of analysis tools.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+You captured a complex bug involving multiple API calls. Now you need to:
+- Share the network trace with a backend developer
+- Attach it to a bug report
+- Analyze it in a specialized tool
+- Compare it against a known-good recording
+
+Browser DevTools can export HAR, but only if you had the Network tab open at the time. If you missed it, the data is gone. Gasoline captures everything automatically, and you can export at any time.
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+// Export all captured network traffic as HAR
+{ "tool": "generate", "arguments": { "format": "har" } }
+
+// Export only requests to a specific API
+{ "tool": "generate", "arguments": {
+  "format": "har",
+  "url": "/api/orders"
+} }
+
+// Export only failed requests
+{ "tool": "generate", "arguments": {
+  "format": "har",
+  "status_min": 400
+} }
+
+// Filter by method
+{ "tool": "generate", "arguments": {
+  "format": "har",
+  "method": "POST"
+} }
+
+// Save directly to a file
+{ "tool": "generate", "arguments": {
+  "format": "har",
+  "save_to": "./debug/session-traffic.har"
+} }
+```
+
+## <i class="fas fa-file-code"></i> HAR Format
+
+The exported file follows the [HAR 1.2 specification](http://www.softwareishard.com/blog/har-12-spec/):
+
+```json
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "Gasoline", "version": "4.6.0" },
+    "entries": [
+      {
+        "startedDateTime": "2024-01-15T10:30:00.000Z",
+        "request": {
+          "method": "POST",
+          "url": "https://api.example.com/orders",
+          "headers": [...],
+          "postData": { "mimeType": "application/json", "text": "{...}" }
+        },
+        "response": {
+          "status": 201,
+          "headers": [...],
+          "content": { "mimeType": "application/json", "text": "{...}" }
+        },
+        "time": 245
+      }
+    ]
+  }
+}
+```
+
+## <i class="fas fa-tools"></i> Compatible Tools
+
+HAR files can be opened in:
+
+| Tool | Use Case |
+|------|----------|
+| Chrome DevTools (Network tab) | Import and replay |
+| Firefox DevTools | Import and analyze |
+| Charles Proxy | Deep request inspection |
+| Fiddler | Windows traffic analysis |
+| [HAR Viewer](http://www.softwareishard.com/har/viewer/) | Browser-based visualization |
+| Postman | Import as collection |
+
+## <i class="fas fa-filter"></i> Filtering Options
+
+Combine filters to export exactly what you need:
+
+| Filter | Description |
+|--------|-------------|
+| `url` | Substring match on request URL |
+| `method` | HTTP method (GET, POST, PUT, DELETE) |
+| `status_min` | Minimum response status code |
+| `status_max` | Maximum response status code |
+
+Example: Export only failed POST requests to the payments API:
+
+```json
+{ "tool": "generate", "arguments": {
+  "format": "har",
+  "url": "/api/payments",
+  "method": "POST",
+  "status_min": 400
+} }
+```
+
+## <i class="fas fa-shield-alt"></i> Privacy
+
+- Auth headers (`Authorization`, `Cookie`) are automatically stripped from exports
+- Sensitive request/response bodies can be filtered using URL patterns
+- HAR files are written locally — never transmitted over the network
+
+## <i class="fas fa-link"></i> Related
+
+- [Network Bodies](/network-bodies/) — Full request/response payload capture
+- [API Schema Inference](/api-schema/) — Auto-discover API structure from traffic
+- [Reproduction Scripts](/reproduction-scripts/) — Generate runnable scripts instead of passive recordings

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,17 +48,17 @@ Gasoline is a **browser extension + local MCP server** that streams real-time br
 | **DOM queries** | ✅ | ✅ | ✅ | ✅ |
 | **Screenshots** | ✅ | ✅ | ✅ | ✅ |
 | | | | | |
-| **Web Vitals** | ✅ LCP, CLS, INP, FCP | ❌ | ❌ | ❌ |
-| **Regression detection** | ✅ Automatic | ❌ | ❌ | ❌ |
-| **API schema inference** | ✅ OpenAPI from traffic | ❌ | ❌ | ❌ |
-| **Accessibility audits** | ✅ WCAG + SARIF | ❌ | ❌ | ❌ |
-| **Session checkpoints** | ✅ Named + auto | ❌ | ❌ | ❌ |
-| **Noise filtering** | ✅ Auto-detect | ❌ | ❌ | ❌ |
+| **[Web Vitals](/web-vitals/)** | ✅ LCP, CLS, INP, FCP | ❌ | ❌ | ❌ |
+| **[Regression detection](/regression-detection/)** | ✅ Automatic | ❌ | ❌ | ❌ |
+| **[API schema inference](/api-schema/)** | ✅ OpenAPI from traffic | ❌ | ❌ | ❌ |
+| **[Accessibility audits](/accessibility-audit/)** | ✅ WCAG + SARIF | ❌ | ❌ | ❌ |
+| **[Session checkpoints](/session-checkpoints/)** | ✅ Named + auto | ❌ | ❌ | ❌ |
+| **[Noise filtering](/noise-filtering/)** | ✅ Auto-detect | ❌ | ❌ | ❌ |
 | | | | | |
-| **Test generation** | ✅ Playwright | ❌ | ❌ | ❌ |
-| **Reproduction scripts** | ✅ From actions | ❌ | ❌ | ❌ |
-| **PR summaries** | ✅ Perf impact | ❌ | ❌ | ❌ |
-| **HAR export** | ✅ | ❌ | ❌ | ❌ |
+| **[Test generation](/generate-test/)** | ✅ Playwright | ❌ | ❌ | ❌ |
+| **[Reproduction scripts](/reproduction-scripts/)** | ✅ From actions | ❌ | ❌ | ❌ |
+| **[PR summaries](/pr-summaries/)** | ✅ Perf impact | ❌ | ❌ | ❌ |
+| **[HAR export](/har-export/)** | ✅ | ❌ | ❌ | ❌ |
 | | | | | |
 | **Zero dependencies** | ✅ Single Go binary | ❌ Node.js + Chrome flags | ❌ Node.js + Puppeteer | ❌ Electron |
 | **Vendor neutral** | ✅ Any MCP tool | ⚠️ Any MCP tool | ⚠️ Any MCP tool | ❌ Cursor only |

--- a/docs/noise-filtering.md
+++ b/docs/noise-filtering.md
@@ -1,0 +1,141 @@
+---
+title: "Noise Filtering"
+description: "Automatically detect and dismiss irrelevant console errors, network noise, and WebSocket chatter. Your AI focuses on real issues instead of wading through noise."
+keywords: "noise filtering, error filtering, console noise, irrelevant errors, signal to noise, auto-detect noise, dismiss errors, MCP filtering"
+permalink: /noise-filtering/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Filter the noise. Focus on what matters."
+toc: true
+toc_sticky: true
+---
+
+Gasoline's noise filtering lets your AI automatically identify and suppress irrelevant browser output — third-party script errors, analytics noise, and repetitive warnings — so it can focus on the errors that actually matter.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+A typical web app's console is full of noise:
+- Third-party analytics scripts logging deprecation warnings
+- Ad network errors that have nothing to do with your code
+- Browser extension interference
+- CORS preflight noise from CDNs
+- Repetitive "favicon.ico 404" errors
+
+Your AI assistant sees all of this and wastes tokens (and your time) investigating issues that aren't yours to fix. Noise filtering teaches it what to ignore.
+
+## <i class="fas fa-magic"></i> Auto-Detection
+
+The fastest way to filter noise is automatic detection:
+
+```json
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "auto_detect"
+} }
+```
+
+Gasoline analyzes current buffer contents and identifies patterns that look like noise:
+- High-frequency repeated messages
+- Known third-party script patterns
+- Common browser-generated warnings
+- Errors from domains you don't control
+
+## <i class="fas fa-terminal"></i> Manual Rules
+
+For precise control, add rules matching specific patterns:
+
+```json
+// Dismiss all errors from Google Analytics
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "add",
+  "rules": [{
+    "category": "console",
+    "classification": "third-party-analytics",
+    "matchSpec": {
+      "sourceRegex": "google-analytics\\.com|googletagmanager\\.com"
+    }
+  }]
+} }
+
+// Dismiss 404s to favicon
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "add",
+  "rules": [{
+    "category": "network",
+    "classification": "expected-missing-resource",
+    "matchSpec": {
+      "urlRegex": "favicon\\.ico",
+      "statusMin": 404,
+      "statusMax": 404
+    }
+  }]
+} }
+```
+
+## <i class="fas fa-hand-paper"></i> Quick Dismiss
+
+For one-off noise patterns, use dismiss without creating a persistent rule:
+
+```json
+// Dismiss a specific error pattern for this session
+{ "tool": "configure", "arguments": {
+  "action": "dismiss",
+  "category": "console",
+  "pattern": "ResizeObserver loop limit exceeded",
+  "reason": "Browser-generated, not actionable"
+} }
+```
+
+## <i class="fas fa-list"></i> Managing Rules
+
+```json
+// List all active noise rules
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "list"
+} }
+
+// Remove a specific rule by ID
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "remove",
+  "rule_id": "rule-abc123"
+} }
+
+// Reset all rules
+{ "tool": "configure", "arguments": {
+  "action": "noise_rule",
+  "noise_action": "reset"
+} }
+```
+
+## <i class="fas fa-filter"></i> Match Specifications
+
+Rules can match on multiple criteria:
+
+| Field | Applies To | Description |
+|-------|-----------|-------------|
+| `messageRegex` | console | Regex against log message content |
+| `sourceRegex` | console | Regex against error source URL |
+| `urlRegex` | network, websocket | Regex against request/connection URL |
+| `method` | network | HTTP method (GET, POST, etc.) |
+| `statusMin` | network | Minimum status code |
+| `statusMax` | network | Maximum status code |
+| `level` | console | Log level (error, warn, info) |
+
+Multiple fields in a single rule are AND-matched — all must match for the rule to apply.
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Clean up on first connect** — "I see 47 errors, but 42 are from third-party scripts. Let me auto-detect and filter those."
+- **Focus on your bugs** — "After filtering analytics noise, there are 5 real errors — all from your checkout component."
+- **Reduce token waste** — Filtered entries don't appear in `observe` responses, saving context window space.
+- **Learn over time** — Rules persist for the session, so noise stays filtered as you continue working.
+
+## <i class="fas fa-link"></i> Related
+
+- [Session Checkpoints](/session-checkpoints/) — Diff only meaningful changes after filtering
+- [Web Vitals](/web-vitals/) — Performance data is never filtered

--- a/docs/pr-summaries.md
+++ b/docs/pr-summaries.md
@@ -1,0 +1,91 @@
+---
+title: "PR Summaries"
+description: "Generate pull request performance impact summaries from browser session data. Gasoline compares before and after metrics so reviewers understand the performance implications of code changes."
+keywords: "PR summary, pull request performance, performance impact, code review, performance comparison, before after metrics, deployment impact"
+permalink: /pr-summaries/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Show reviewers the performance impact of your code change."
+toc: true
+toc_sticky: true
+---
+
+Gasoline generates markdown performance summaries for pull requests — comparing baseline metrics against current observations so code reviewers can see the real-world impact of changes.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+Code reviews focus on logic and style, but rarely consider performance impact. A reviewer can't tell from a diff whether:
+- The new API call adds 200ms to page load
+- The refactored component causes layout shifts
+- The bundle size increased by 500KB
+- An endpoint that was fast is now slow
+
+Performance impact is invisible in code review. PR summaries make it visible.
+
+## <i class="fas fa-cogs"></i> How It Works
+
+1. <i class="fas fa-ruler"></i> Gasoline maintains baselines from before your changes (see [Regression Detection](/regression-detection/))
+2. <i class="fas fa-code-branch"></i> You test your feature branch in the browser
+3. <i class="fas fa-file-alt"></i> Your AI calls `generate` with `format: "pr_summary"`
+4. <i class="fas fa-clipboard"></i> A markdown summary is produced, ready to paste into your PR description
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+{ "tool": "generate", "arguments": { "format": "pr_summary" } }
+```
+
+## <i class="fas fa-file-alt"></i> Generated Output
+
+The summary includes:
+
+```markdown
+## Performance Impact
+
+### Page Load Metrics
+| Metric | Baseline | Current | Delta |
+|--------|----------|---------|-------|
+| Load Time | 2100ms | 2450ms | +350ms ⚠️ |
+| LCP | 1800ms | 1900ms | +100ms |
+| CLS | 0.02 | 0.02 | — |
+| FCP | 1200ms | 1250ms | +50ms |
+
+### Network
+| Metric | Baseline | Current | Delta |
+|--------|----------|---------|-------|
+| Requests | 32 | 38 | +6 |
+| Transfer Size | 1.4MB | 1.9MB | +500KB ⚠️ |
+
+### Regressions Detected
+- ⚠️ Load time increased 17% (within threshold but notable)
+- ⚠️ Transfer size increased 36% — new dependencies added
+
+### Endpoints Changed
+| Endpoint | Baseline Latency | Current | Status |
+|----------|-----------------|---------|--------|
+| /api/users | 120ms | 125ms | ✅ |
+| /api/orders | 200ms | 580ms | ⚠️ 2.9× |
+```
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Add to PR descriptions** — Paste the summary so reviewers see performance impact at a glance.
+- **Block regressions early** — "This PR adds 350ms to page load. Should we investigate before merging?"
+- **Validate optimizations** — "The lazy loading PR reduced transfer size by 40% and LCP by 600ms."
+- **Track endpoint impact** — "The new middleware is adding 380ms to the orders endpoint."
+
+## <i class="fas fa-lightbulb"></i> Best Practice
+
+Use with [Session Checkpoints](/session-checkpoints/) for the clearest before/after comparison:
+
+1. Create a checkpoint on the `main` branch: `checkpoint: "main-baseline"`
+2. Switch to your feature branch
+3. Browse the same pages
+4. Generate the PR summary — it compares against the checkpoint
+
+## <i class="fas fa-link"></i> Related
+
+- [Regression Detection](/regression-detection/) — The baseline system that powers summaries
+- [Web Vitals](/web-vitals/) — Core metrics included in summaries
+- [Session Checkpoints](/session-checkpoints/) — Named before/after comparison points

--- a/docs/regression-detection.md
+++ b/docs/regression-detection.md
@@ -1,0 +1,99 @@
+---
+title: "Regression Detection"
+description: "Automatic performance regression detection with adaptive baselines. Gasoline alerts your AI when page load times, Web Vitals, or network patterns degrade."
+keywords: "performance regression detection, baseline comparison, performance alerts, adaptive baselines, performance monitoring, page speed regression"
+permalink: /regression-detection/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Performance regressed? Your AI already knows."
+toc: true
+toc_sticky: true
+---
+
+Gasoline automatically builds performance baselines and flags regressions — so your AI catches slowdowns the moment they happen, not after users complain.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+Performance regressions are silent killers. A new API dependency adds 500ms to page load. A CSS refactor triggers layout shifts. A third-party script bloats transfer size. None of these throw errors — they just quietly degrade the experience.
+
+Without continuous monitoring, you only discover regressions when:
+- A user files a complaint
+- A Lighthouse audit weeks later shows declining scores
+- Core Web Vitals drop in Search Console (30-day delay)
+
+By then, the offending commit is buried under dozens of changes. Gasoline catches it immediately.
+
+## <i class="fas fa-chart-line"></i> How Baselines Work
+
+Gasoline maintains a **running average baseline** for each URL you visit:
+
+1. **First visit** — The snapshot becomes the initial baseline
+2. **Subsequent visits** — Simple average for the first 5 samples
+3. **Established baseline** — Weighted average (80% existing, 20% new) to prevent sudden shifts
+
+This adaptive approach means:
+- Baselines stabilize after ~5 page loads
+- Gradual improvements are reflected over time
+- A single bad load doesn't corrupt the baseline
+- Different pages have independent baselines
+
+## <i class="fas fa-bell"></i> What Triggers an Alert
+
+The `analyze` tool with `target: "changes"` compares the current state against a checkpoint and surfaces performance alerts when:
+
+| Condition | Alert |
+|-----------|-------|
+| Load time > 2× baseline | "Page load time degraded" |
+| LCP > 2× baseline | "LCP regressed" |
+| New long tasks appeared | "Blocking JavaScript detected" |
+| Transfer size > 2× baseline | "Page weight increased" |
+| Endpoint latency > 3× baseline | "API endpoint degraded" |
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+// Analyze performance for a specific URL
+{ "tool": "analyze", "arguments": { "target": "performance", "url": "/dashboard" } }
+```
+
+The response includes current metrics alongside the baseline:
+
+```json
+{
+  "url": "/dashboard",
+  "current": {
+    "timing": { "load": 4200, "lcp": 3100 },
+    "network": { "requestCount": 45, "transferSize": 2800000 }
+  },
+  "baseline": {
+    "timing": { "load": 2100, "lcp": 1800 },
+    "network": { "requestCount": 32, "transferSize": 1400000 },
+    "sampleCount": 12
+  },
+  "regressions": [
+    "Load time 2.0× baseline (4200ms vs 2100ms avg)",
+    "Transfer size 2.0× baseline (2.8MB vs 1.4MB avg)"
+  ]
+}
+```
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Catch regressions immediately** — "Your last code change doubled page load time. The new chart library added 1.4MB of JavaScript."
+- **Identify root causes** — "LCP regressed because `hero-image.png` is now served uncompressed (was 200KB, now 1.8MB)."
+- **Validate fixes** — "After adding lazy loading, load time is back to 2.2s (baseline: 2.1s). Regression resolved."
+- **Track trends** — "Over the last 12 samples, TTFB has been creeping up. Current: 480ms, baseline: 320ms."
+
+## <i class="fas fa-database"></i> Baseline Storage
+
+- **Per-URL baselines** — Each page has its own performance profile
+- **LRU eviction** — Up to 50 baselines stored (least-recently-used eviction)
+- **Session-scoped** — Baselines reset when the server restarts
+- **Resource fingerprinting** — Top 5 resources tracked by transfer size
+
+## <i class="fas fa-link"></i> Related
+
+- [Web Vitals](/web-vitals/) — The metrics that feed into regression detection
+- [Session Checkpoints](/session-checkpoints/) — Named points for before/after comparison
+- [PR Summaries](/pr-summaries/) — Summarize performance impact for code review

--- a/docs/reproduction-scripts.md
+++ b/docs/reproduction-scripts.md
@@ -1,0 +1,115 @@
+---
+title: "Reproduction Scripts"
+description: "Automatically generate Playwright reproduction scripts from recorded user actions. Your AI captures what you did in the browser and produces a runnable script to reproduce bugs."
+keywords: "reproduction script, bug reproduction, Playwright script, user action recording, browser session replay, automated reproduction, bug report"
+permalink: /reproduction-scripts/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "You triggered the bug. Gasoline writes the repro script."
+toc: true
+toc_sticky: true
+---
+
+Gasoline records your browser interactions and generates Playwright scripts that reproduce exactly what you did — clicks, navigation, form input, and all.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+"Steps to reproduce" is the most dreaded section of any bug report. You found a bug, but:
+- You can't remember the exact sequence of clicks
+- The bug only happens after navigating through 5 pages
+- It requires specific form input in a specific order
+- By the time you write it up, you've lost the context
+
+Your AI assistant saw the bug happen in real time through Gasoline. It can generate a reproduction script instantly.
+
+## <i class="fas fa-cogs"></i> How It Works
+
+1. <i class="fas fa-mouse-pointer"></i> Gasoline records every user action: clicks, typing, navigation, scrolls, selects
+2. <i class="fas fa-layer-group"></i> Smart selectors are captured: test IDs, ARIA roles, labels, text, CSS paths
+3. <i class="fas fa-code"></i> Your AI calls `generate` with `format: "reproduction"` to produce a Playwright script
+4. <i class="fas fa-play"></i> The script is immediately runnable with `npx playwright test`
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+// Generate reproduction from all recorded actions
+{ "tool": "generate", "arguments": { "format": "reproduction" } }
+
+// Include error context in the script
+{ "tool": "generate", "arguments": {
+  "format": "reproduction",
+  "error_message": "TypeError: Cannot read property 'id' of null"
+} }
+
+// Only use the last 10 actions
+{ "tool": "generate", "arguments": {
+  "format": "reproduction",
+  "last_n_actions": 10
+} }
+
+// Replace the origin for local testing
+{ "tool": "generate", "arguments": {
+  "format": "reproduction",
+  "base_url": "http://localhost:3000"
+} }
+```
+
+## <i class="fas fa-file-code"></i> Generated Output
+
+```javascript
+import { test, expect } from '@playwright/test';
+
+test('reproduction: TypeError: Cannot read property id of null', async ({ page }) => {
+  await page.goto('http://localhost:3000/dashboard');
+
+  await page.getByRole('button', { name: 'Add User' }).click();
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  // [3s pause]
+  await page.waitForURL('/dashboard/users');
+  await page.getByTestId('user-row-1').click();
+
+  // Error occurred here: TypeError: Cannot read property 'id' of null
+});
+```
+
+## <i class="fas fa-crosshairs"></i> Smart Selectors
+
+Gasoline captures multiple selector strategies and picks the most resilient one:
+
+| Priority | Selector Type | Example |
+|----------|--------------|---------|
+| 1 | Test ID | `getByTestId('submit-btn')` |
+| 2 | ARIA role + name | `getByRole('button', { name: 'Submit' })` |
+| 3 | ARIA label | `getByLabel('Email')` |
+| 4 | Text content | `getByText('Sign In')` |
+| 5 | Element ID | `locator('#user-email')` |
+| 6 | CSS path | `locator('div.form > input')` |
+
+This prioritization follows Playwright's recommended selector strategy — test IDs first, CSS paths as last resort.
+
+## <i class="fas fa-clock"></i> Timing Awareness
+
+The generated script includes pause comments for gaps longer than 2 seconds:
+
+```javascript
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// [3s pause]
+await page.waitForURL('/results');
+```
+
+This helps identify where the app was loading or processing between user actions.
+
+## <i class="fas fa-shield-alt"></i> Privacy
+
+- Sensitive form inputs (passwords) are redacted as `[user-provided]`
+- Scripts use `base_url` replacement so production URLs aren't hardcoded
+- Generated scripts never contain auth tokens or session data
+
+## <i class="fas fa-link"></i> Related
+
+- [Test Generation](/generate-test/) — Full regression tests with API assertions
+- [Session Checkpoints](/session-checkpoints/) — Scope reproduction to a specific time window

--- a/docs/session-checkpoints.md
+++ b/docs/session-checkpoints.md
@@ -1,0 +1,130 @@
+---
+title: "Session Checkpoints"
+description: "Save named checkpoints during your browser session and diff changes since any point in time. Your AI compares before and after states to pinpoint what changed."
+keywords: "session checkpoints, state diff, before after comparison, change detection, debugging sessions, checkpoint diff, browser state tracking"
+permalink: /session-checkpoints/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Save state. Make changes. Diff what happened."
+toc: true
+toc_sticky: true
+---
+
+Gasoline lets your AI save named checkpoints and then diff everything that changed — console errors, network calls, WebSocket events, user actions, and performance — in a single compressed response.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+You're debugging with your AI assistant. It sees 200 console entries, 50 network calls, and a wall of WebSocket messages. Most of that noise existed before the bug. What your AI really needs to know is: *what changed since I last looked?*
+
+Without checkpoints, the AI has to re-read everything and mentally diff it. That wastes context window tokens and makes it harder to spot the signal in the noise.
+
+## <i class="fas fa-flag-checkered"></i> How Checkpoints Work
+
+1. **Save a checkpoint** — Records the current position in every buffer (logs, network, WebSocket, actions)
+2. **Do your work** — Navigate, click, trigger the bug, deploy a fix
+3. **Diff against the checkpoint** — Get only what's new, deduplicated and severity-filtered
+
+The checkpoint stores *positions*, not copies of data. This makes checkpoints lightweight and instant to create.
+
+## <i class="fas fa-terminal"></i> Usage
+
+### Create a Checkpoint
+
+```json
+// Save a named checkpoint
+{ "tool": "analyze", "arguments": { "target": "changes", "checkpoint": "before-fix" } }
+```
+
+The first call with a new name creates the checkpoint. Subsequent calls with the same name return the diff since that point.
+
+### Get Changes Since Checkpoint
+
+```json
+// See what changed since "before-fix"
+{ "tool": "analyze", "arguments": {
+  "target": "changes",
+  "checkpoint": "before-fix"
+} }
+
+// Only show errors (skip info/warning)
+{ "tool": "analyze", "arguments": {
+  "target": "changes",
+  "checkpoint": "before-fix",
+  "severity": "errors_only"
+} }
+
+// Only show network and console changes
+{ "tool": "analyze", "arguments": {
+  "target": "changes",
+  "checkpoint": "before-fix",
+  "include": ["console", "network"]
+} }
+```
+
+### Auto-Checkpoint
+
+If no checkpoint name is provided, Gasoline uses an automatic checkpoint that advances on each call — showing only changes since the last time you asked.
+
+## <i class="fas fa-compress-arrows-alt"></i> Compressed Diff Response
+
+The diff response is designed to be token-efficient:
+
+```json
+{
+  "from": "2024-01-15T10:30:00Z",
+  "to": "2024-01-15T10:35:22Z",
+  "duration_ms": 322000,
+  "severity": "all",
+  "summary": "3 new errors, 12 network requests, 1 degraded endpoint",
+  "token_count": 450,
+  "console": {
+    "total_new": 8,
+    "errors": [
+      { "message": "TypeError: Cannot read property 'id' of null", "count": 3 }
+    ],
+    "warnings": [
+      { "message": "Deprecated API usage", "count": 2 }
+    ]
+  },
+  "network": {
+    "total_new": 12,
+    "errors": [
+      { "url": "/api/users/999", "status": 404, "count": 2 }
+    ]
+  },
+  "performance_alerts": [
+    "Endpoint /api/search latency 3× baseline (900ms vs 300ms)"
+  ]
+}
+```
+
+Key optimizations:
+- **Deduplication** — Repeated errors shown once with a count
+- **Severity filtering** — Skip noise, show only what matters
+- **Token counting** — Response includes approximate token cost
+- **Category filtering** — Request only the categories you care about
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Before/after debugging** — "Create checkpoint 'before-fix', apply the fix, then show me what changed."
+- **Regression testing** — "Since the deploy, 3 new console errors appeared and `/api/orders` started returning 500s."
+- **Focused debugging** — "Only 2 things changed since my last check: a new TypeError and a 404 on the user endpoint."
+- **Performance validation** — "After the optimization, the performance alert for `/api/search` is gone. Latency back to baseline."
+
+## <i class="fas fa-database"></i> Checkpoint Limits
+
+| Limit | Value |
+|-------|-------|
+| Max named checkpoints | 20 |
+| Checkpoint name length | 50 characters |
+| Max diff entries per category | 50 |
+| Message truncation | 200 characters |
+
+Oldest checkpoints are evicted when the limit is reached.
+
+## <i class="fas fa-link"></i> Related
+
+- [Regression Detection](/regression-detection/) — Automatic performance alerts in diffs
+- [Noise Filtering](/noise-filtering/) — Reduce noise before diffing
+- [Web Vitals](/web-vitals/) — Performance metrics included in diffs

--- a/docs/web-vitals.md
+++ b/docs/web-vitals.md
@@ -1,0 +1,82 @@
+---
+title: "Web Vitals"
+description: "Monitor Core Web Vitals (LCP, CLS, INP, FCP) in real time. Your AI assistant sees performance metrics as you browse and identifies pages that need optimization."
+keywords: "Core Web Vitals, LCP, CLS, INP, FCP, performance monitoring, web performance MCP, page speed, user experience metrics"
+permalink: /web-vitals/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Real-time Core Web Vitals, assessed and queryable by your AI."
+toc: true
+toc_sticky: true
+---
+
+Gasoline captures Core Web Vitals as you browse and delivers them to your AI with quality assessments — so it can tell you exactly which pages need work.
+
+## <i class="fas fa-exclamation-circle"></i> The Problem
+
+Google's Core Web Vitals directly impact search ranking and user experience, but most developers don't monitor them during development. You ship a feature, then discover weeks later that LCP regressed from "good" to "poor" because of a new above-the-fold image or an unoptimized API call.
+
+Running Lighthouse manually is slow, requires context-switching, and only shows a snapshot. You need continuous visibility into how your app performs as you build it.
+
+## <i class="fas fa-heartbeat"></i> What Gets Measured
+
+| Metric | What It Measures | Good | Poor |
+|--------|-----------------|------|------|
+| **FCP** | First Contentful Paint — time until first text/image renders | < 1.8s | ≥ 3.0s |
+| **LCP** | Largest Contentful Paint — time until largest element renders | < 2.5s | ≥ 4.0s |
+| **CLS** | Cumulative Layout Shift — visual stability score | < 0.1 | ≥ 0.25 |
+| **INP** | Interaction to Next Paint — input responsiveness | < 200ms | ≥ 500ms |
+
+Each metric is automatically assessed as "good", "needs-improvement", or "poor" based on Google's thresholds.
+
+## <i class="fas fa-cogs"></i> How It Works
+
+1. <i class="fas fa-browser"></i> The extension captures performance timing data from the browser's Performance API
+2. <i class="fas fa-server"></i> Snapshots are sent to the local Gasoline server with full timing breakdowns
+3. <i class="fas fa-robot"></i> Your AI calls `observe` with `what: "vitals"` to see current metrics
+4. <i class="fas fa-chart-line"></i> Each metric includes its value and quality assessment
+
+## <i class="fas fa-terminal"></i> Usage
+
+```json
+// Observe current Web Vitals
+{ "tool": "observe", "arguments": { "what": "vitals" } }
+```
+
+Response includes:
+
+```json
+{
+  "fcp": { "value": 1200, "assessment": "good" },
+  "lcp": { "value": 2800, "assessment": "needs-improvement" },
+  "cls": { "value": 0.05, "assessment": "good" },
+  "inp": { "value": 150, "assessment": "good" },
+  "loadTime": { "value": 3200, "assessment": "needs-improvement" },
+  "url": "https://myapp.com/dashboard"
+}
+```
+
+## <i class="fas fa-search"></i> What Your AI Can Do With This
+
+- **Identify slow pages** — "Your dashboard LCP is 2.8s (needs improvement). The hero image is 2.4MB uncompressed."
+- **Track improvements** — "After lazy-loading the chart, LCP dropped from 2.8s to 1.9s (good)."
+- **Catch regressions** — "The login page CLS jumped from 0.02 to 0.18 after your CSS change."
+- **Prioritize fixes** — "Three pages have poor INP. The settings page is worst at 620ms due to synchronous validation."
+
+## <i class="fas fa-layer-group"></i> Beyond Vitals
+
+In addition to Core Web Vitals, each performance snapshot includes:
+
+- **Navigation timing** — DOMContentLoaded, Load, TTFB, DomInteractive
+- **Network summary** — total request count, transfer size
+- **Long tasks** — count, total blocking time, longest task duration
+- **Top resources** — largest assets by transfer size
+
+This gives your AI full context to diagnose *why* a metric is poor, not just *that* it's poor.
+
+## <i class="fas fa-link"></i> Related
+
+- [Regression Detection](/regression-detection/) — Automatic alerts when vitals degrade
+- [Performance SLOs](/performance-slos/) — Gasoline's own performance budgets
+- [PR Summaries](/pr-summaries/) — Include vitals impact in pull requests


### PR DESCRIPTION
## Summary
- Created 8 dedicated documentation pages for features in the comparison chart: Web Vitals, Regression Detection, API Schema Inference, Session Checkpoints, Noise Filtering, Reproduction Scripts, PR Summaries, and HAR Export
- Each page explains the feature, the problem it solves, how it works, and usage examples
- Updated comparison charts in both `docs/index.md` and `README.md` to link each feature row to its documentation page
- Accessibility Audits and Test Generation already had existing docs and are now linked as well

## Test plan
- [ ] Verify all 10 feature links in `docs/index.md` resolve to valid pages
- [ ] Verify all 10 feature links in `README.md` point to correct cookwithgasoline.com URLs
- [ ] Confirm Jekyll builds successfully with the 8 new markdown files
- [ ] Check each new doc renders correctly with proper front-matter

🤖 Generated with [Claude Code](https://claude.com/claude-code)