### PR TITLE
chore: fix eslint scanning .venv-build

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default [
       'server/',
       'docs/',
       'demo/',
+      '.venv-build/',
       // Compiled TypeScript output (linted at the .ts source level)
       'extension/background/',
       'extension/content/',

--- a/packages/gasoline-ci/gasoline-ci.js
+++ b/packages/gasoline-ci/gasoline-ci.js
@@ -162,10 +162,10 @@
       var keys = Object.keys(value).slice(0, 50)
       for (var i = 0; i < keys.length; i++) {
         try {
-          // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+           
           result[keys[i]] = safeSerialize(value[keys[i]], depth + 1, seen)
         } catch (_e) {
-          // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+           
           result[keys[i]] = '[unserializable]'
         }
       }
@@ -180,13 +180,13 @@
     var originals = {}
 
     for (var level of levels) {
-      // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+       
       originals[level] = console[level]
-      // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+       
       console[level] = (function (capturedLevel) {
         return function () {
           var args = Array.prototype.slice.call(arguments)
-          // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+           
           originals[capturedLevel].apply(console, args)
 
           emit('GASOLINE_LOG', {
@@ -427,15 +427,15 @@
       return {}
     }
     for (var i = 0; i < entries.length; i++) {
-      // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+       
       var key = entries[i][0]
-      // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+       
       var value = entries[i][1]
       if (SENSITIVE_HEADERS.indexOf(key.toLowerCase()) !== -1) {
-        // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+         
         filtered[key] = '[REDACTED]'
       } else {
-        // eslint-disable-next-line security/detect-object-injection -- bracket access on trusted internal telemetry data
+         
         filtered[key] = value
       }
     }

--- a/scripts/build-crx.js
+++ b/scripts/build-crx.js
@@ -21,7 +21,7 @@ const TEMP_ZIP = path.join(BUILD_DIR, `.gasoline-temp-${Date.now()}.zip`)
 async function buildCRX() {
   try {
     // Check for key file
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     if (!fs.existsSync(KEY_FILE)) {
       console.error(`❌ Private key not found at ${KEY_FILE}`)
       // CLI script exits with error status on fatal failure
@@ -47,7 +47,7 @@ async function buildCRX() {
           fs.unlinkSync(nativeCrx)
 
           // Extract and display extension ID
-          // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+           
           const data = fs.readFileSync(OUTPUT_CRX)
           const headerLen = data.readUInt32LE(8)
           const headerProto = data.slice(12, 12 + headerLen)
@@ -55,7 +55,7 @@ async function buildCRX() {
           let length1 = 0
           let shift = 0
           while (offset < headerProto.length) {
-            // eslint-disable-next-line security/detect-object-injection -- bracket access on local config object
+             
             const byte = headerProto[offset]
             length1 |= (byte & 0x7f) << shift
             offset++
@@ -80,9 +80,9 @@ async function buildCRX() {
     try {
       console.log('🔧 Using crx (Rust tool) for packing...')
       await exec(`crx pack "${path.resolve(EXTENSION_DIR)}" -o "${OUTPUT_CRX}" -k "${KEY_FILE}"`)
-      // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+       
       if (fs.existsSync(OUTPUT_CRX)) {
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script reads from hardcoded extension directory
+         
         const data = fs.readFileSync(OUTPUT_CRX)
         const headerLen = data.readUInt32LE(8)
         const headerProto = data.slice(12, 12 + headerLen)
@@ -125,14 +125,14 @@ async function buildCRX() {
       process.exit(1)
     }
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     if (!fs.existsSync(TEMP_ZIP)) {
       console.error('❌ Failed to create extension zip')
       process.exit(1)
     }
 
     console.log('🔐 Reading private key...')
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     const keyContent = fs.readFileSync(KEY_FILE, 'utf-8')
 
     // Extract public key and compute extension ID
@@ -152,7 +152,7 @@ async function buildCRX() {
 
     // Read and sign the header (not the zip!)
     console.log('✍️  Signing extension...')
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     const zipData = fs.readFileSync(TEMP_ZIP)
 
     // Create the signed header data first
@@ -177,11 +177,11 @@ async function buildCRX() {
     const crxBuffer = Buffer.concat([magic, version, headerLen, headerProto, zipData])
 
     // Write CRX file
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     fs.writeFileSync(OUTPUT_CRX, crxBuffer)
 
     // Cleanup
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     fs.unlinkSync(TEMP_ZIP)
 
     console.log(`\n✨ CRX file created: ${OUTPUT_CRX}`)
@@ -194,7 +194,7 @@ async function buildCRX() {
     console.log(`📦 Extension ID: ${extensionId}`)
   } catch (err) {
     console.error('❌ Error building CRX:', err.message)
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+     
     if (fs.existsSync(TEMP_ZIP)) fs.unlinkSync(TEMP_ZIP)
     process.exit(1)
   }
@@ -250,7 +250,7 @@ function toBase32(buf) {
   let value = 0
 
   for (let i = 0; i < buf.length; i++) {
-    // eslint-disable-next-line security/detect-object-injection -- bracket access on local config object
+     
     value = (value << 8) | buf[i]
     bits += 8
     while (bits >= 5) {
@@ -295,7 +295,7 @@ function getChromeCommand() {
     try {
       // For macOS paths with spaces, check if file exists directly
       if (cmd.startsWith('/Applications')) {
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths are hardcoded constants
+         
         if (fs.existsSync(cmd)) {
           return cmd
         }

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -34,7 +34,7 @@ const colors = {
 }
 
 function log(color, prefix, message) {
-  // eslint-disable-next-line security/detect-object-injection -- bracket access on ANSI color map
+   
   console.log(`${colors[color]}${prefix}${colors.reset} ${message}`)
   return
 }
@@ -61,7 +61,7 @@ function findVersionReferences(oldVersion, searchDir = ROOT) {
 
   function walk(dir) {
     try {
-      // eslint-disable-next-line security/detect-non-literal-fs-filename -- version bump script, paths from local file discovery
+       
       const entries = fs.readdirSync(dir, { withFileTypes: true })
       for (const entry of entries) {
         if (ignore.has(entry.name)) continue
@@ -71,7 +71,7 @@ function findVersionReferences(oldVersion, searchDir = ROOT) {
           walk(fullPath)
         } else if (ext.has(path.extname(entry.name))) {
           try {
-            // eslint-disable-next-line security/detect-non-literal-fs-filename -- version bump script, paths from local file discovery
+             
             const content = fs.readFileSync(fullPath, 'utf8')
             if (content.includes(oldVersion)) {
               files.push(fullPath)
@@ -106,7 +106,7 @@ const CRITICAL_FILES = [
 ]
 
 function updateVersionInFile(filePath, oldVersion, newVersion) {
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- version bump script, paths from local file discovery
+   
   const content = fs.readFileSync(filePath, 'utf8')
   let updated = content
 
@@ -114,124 +114,124 @@ function updateVersionInFile(filePath, oldVersion, newVersion) {
   if (filePath.endsWith('.json')) {
     // JSON files: "version": "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`"version":\\s*"${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `"version": "${newVersion}"`
     )
     // optionalDependencies: "@package": "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`"(@\\w+/[^"]+)":\\s*"${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `"$1": "${newVersion}"`
     )
     // JSON example values: "example": "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`"example":\\s*"${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `"example": "${newVersion}"`
     )
   } else if (filePath.endsWith('.go')) {
     // Go: var version = "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version = "${newVersion}"`
     )
     // Go const
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`const version = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `const version = "${newVersion}"`
     )
     // Go User-Agent: "Gasoline/6.0.3 ..."
-    // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+     
     updated = updated.replace(new RegExp(`Gasoline/${oldVersion.replace(/\./g, '\\.')}`, 'g'), `Gasoline/${newVersion}`) // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
   } else if (filePath.endsWith('.js') || filePath.endsWith('.ts')) {
     // JavaScript/TypeScript: version: '6.0.1' or version: "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version:\\s*'${oldVersion.replace(/\./g, '\\.')}'`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version: '${newVersion}'`
     )
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version:\\s*"${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version: "${newVersion}"`
     )
     // __version__ = "0.7.2"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`__version__ = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `__version__ = "${newVersion}"`
     )
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`__version__ = '${oldVersion.replace(/\./g, '\\.')}'`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `__version__ = '${newVersion}'`
     )
     // const VERSION = '0.7.2' or const VERSION = "0.7.2"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`const VERSION = '${oldVersion.replace(/\./g, '\\.')}'`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `const VERSION = '${newVersion}'`
     )
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`const VERSION = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `const VERSION = "${newVersion}"`
     )
   } else if (filePath.endsWith('.py')) {
     // Python: __version__ = "0.7.2"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`__version__ = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `__version__ = "${newVersion}"`
     )
   } else if (filePath.endsWith('.toml')) {
     // TOML: version = "6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version = "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version = "${newVersion}"`
     )
     // Dependencies in TOML (PEP 440: ==6.0.3)
-    // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+     
     updated = updated.replace(new RegExp(`==${oldVersion.replace(/\./g, '\\.')}`, 'g'), `==${newVersion}`) // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
   } else if (filePath.endsWith('.md')) {
     // Markdown: version-6.0.1-green or just 6.0.1
-    // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+     
     updated = updated.replace(new RegExp(oldVersion.replace(/\./g, '\\.'), 'g'), newVersion) // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
   } else if (filePath.endsWith('.yaml') || filePath.endsWith('.yml')) {
     // YAML: version: 6.0.1 or version: "6.0.1"
-    // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+     
     updated = updated.replace(new RegExp(`version: ${oldVersion.replace(/\./g, '\\.')}`, 'g'), `version: ${newVersion}`) // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version: "${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version: "${newVersion}"`
     )
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`version: '${oldVersion.replace(/\./g, '\\.')}'`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `version: '${newVersion}'`
     )
   } else if (filePath.endsWith('.sh')) {
     // Shell: VERSION="6.0.1"
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`VERSION="${oldVersion.replace(/\./g, '\\.')}"`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `VERSION="${newVersion}"`
     )
     // Shell: VERSION='6.0.1'
     updated = updated.replace(
-      // eslint-disable-next-line security/detect-non-literal-regexp -- RegExp constructed from trusted local version string, not user input
+       
       new RegExp(`VERSION='${oldVersion.replace(/\./g, '\\.')}'`, 'g'), // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp, javascript_dos_rule-non-literal-regexp -- RegExp from trusted local version string
       `VERSION='${newVersion}'`
     )
   }
 
   if (updated !== content) {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- version bump script, paths from local file discovery
+     
     fs.writeFileSync(filePath, updated, 'utf8')
     return true
   }
@@ -384,7 +384,7 @@ async function main() {
 
   for (const file of CRITICAL_FILES) {
     const filePath = path.join(ROOT, file)
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- version bump script reads file from local discovery
+     
     const content = fs.readFileSync(filePath, 'utf8')
     if (content.includes(newVersion)) {
       log('green', '✓', file)

--- a/scripts/fix-imports.js
+++ b/scripts/fix-imports.js
@@ -17,7 +17,7 @@ const EXTENSION_DIR = path.join(__dirname, '../extension')
  * Fix imports in a JavaScript file by adding .js extensions to relative imports.
  */
 function fixImportsInFile(filePath) {
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths derived from local directory traversal
+   
   let content = fs.readFileSync(filePath, 'utf8')
   const original = content
 
@@ -49,7 +49,7 @@ function fixImportsInFile(filePath) {
   })
 
   if (content !== original) {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths derived from local directory traversal
+     
     fs.writeFileSync(filePath, content, 'utf8')
     console.log(`Fixed imports in: ${path.relative(process.cwd(), filePath)}`)
   }
@@ -60,12 +60,12 @@ function fixImportsInFile(filePath) {
  * Recursively process all .js files in a directory.
  */
 function processDirectory(dir) {
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths derived from local directory traversal
+   
   const files = fs.readdirSync(dir)
 
   for (const file of files) {
     const filePath = path.join(dir, file)
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- build script paths derived from local directory traversal
+     
     const stat = fs.statSync(filePath)
 
     if (stat.isDirectory()) {


### PR DESCRIPTION
## Summary

- Add `.venv-build/` to eslint ignores — was scanning vendored JS inside a Python virtual env, causing 148 false errors from `docutils` and `urllib3`
- Remove stale `eslint-disable` directives in `scripts/` and `packages/` (53 warnings)
- Result: 0 errors, 0 warnings

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)