### PR TITLE
fix: add final field to async command responses (#92)

### DIFF
--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -301,6 +301,7 @@ func (h *ToolHandler) maybeWaitForCommand(req JSONRPCRequest, correlationID stri
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse(queuedSummary, map[string]any{
 			"status":         "queued",
 			"correlation_id": correlationID,
+			"final":          false,
 		})}
 	}
 
@@ -322,6 +323,7 @@ func (h *ToolHandler) maybeWaitForCommand(req JSONRPCRequest, correlationID stri
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Action still processing", map[string]any{
 			"status":         "still_processing",
 			"correlation_id": correlationID,
+			"final":          false,
 			"message":        "Action is taking longer than 15s. Polling is now required. Use observe({what:'command_result', correlation_id:'" + correlationID + "'}) to check the result.",
 		})}
 	}

--- a/cmd/dev-console/tools_core_sync_test.go
+++ b/cmd/dev-console/tools_core_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dev-console/dev-console/internal/capture"
+	"github.com/dev-console/dev-console/internal/queries"
 )
 
 func TestMaybeWaitForCommand_SyncByDefault(t *testing.T) {
@@ -86,5 +87,119 @@ func TestMaybeWaitForCommand_TimeoutGracefulFallback(t *testing.T) {
 	// Current impl fails fast if extension not connected.
 	if duration > 1*time.Second {
 		t.Errorf("Should have failed fast since extension is not connected, took %v", duration)
+	}
+}
+
+// parseMCPResponseData extracts the JSON data map from an MCP tool response.
+func parseMCPResponseData(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var mcpResult MCPToolResult
+	if err := json.Unmarshal(raw, &mcpResult); err != nil {
+		t.Fatalf("Failed to parse MCPToolResult: %v", err)
+	}
+	if len(mcpResult.Content) == 0 {
+		t.Fatal("MCPToolResult has no content blocks")
+	}
+	jsonStr := extractJSONFromMCPText(mcpResult.Content[0].Text)
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		t.Fatalf("Failed to parse embedded JSON: %v\nText: %s", err, jsonStr)
+	}
+	return data
+}
+
+func TestFormatCommandResult_FinalField(t *testing.T) {
+	cap := capture.NewCapture()
+	server, err := NewServer("/tmp/test-final-field.jsonl", 100)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mcpHandler := NewToolHandler(server, cap)
+	handler := mcpHandler.toolHandler.(*ToolHandler)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+
+	tests := []struct {
+		name      string
+		cmd       queries.CommandResult
+		wantFinal bool
+		wantError bool // true if response uses mcpStructuredError (no final field)
+	}{
+		{
+			name: "complete has final=true",
+			cmd: queries.CommandResult{
+				CorrelationID: "test-1",
+				Status:        "complete",
+				Result:        json.RawMessage(`{"success":true}`),
+				CreatedAt:     time.Now(),
+			},
+			wantFinal: true,
+		},
+		{
+			name: "error has final=true",
+			cmd: queries.CommandResult{
+				CorrelationID: "test-2",
+				Status:        "error",
+				Error:         "element_not_found",
+				CreatedAt:     time.Now(),
+			},
+			wantFinal: true,
+		},
+		{
+			name: "pending has final=false",
+			cmd: queries.CommandResult{
+				CorrelationID: "test-3",
+				Status:        "pending",
+				CreatedAt:     time.Now(),
+			},
+			wantFinal: false,
+		},
+		{
+			name: "expired uses mcpStructuredError",
+			cmd: queries.CommandResult{
+				CorrelationID: "test-4",
+				Status:        "expired",
+				Error:         "timed out",
+				CreatedAt:     time.Now(),
+			},
+			wantError: true,
+		},
+		{
+			name: "timeout uses mcpStructuredError",
+			cmd: queries.CommandResult{
+				CorrelationID: "test-5",
+				Status:        "timeout",
+				Error:         "no response",
+				CreatedAt:     time.Now(),
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := handler.formatCommandResult(req, tt.cmd, tt.cmd.CorrelationID)
+
+			var mcpResult MCPToolResult
+			if err := json.Unmarshal(resp.Result, &mcpResult); err != nil {
+				t.Fatalf("Failed to parse MCPToolResult: %v", err)
+			}
+
+			if tt.wantError {
+				if !mcpResult.IsError {
+					t.Errorf("Expected isError=true for %s status", tt.cmd.Status)
+				}
+				return
+			}
+
+			data := parseMCPResponseData(t, resp.Result)
+
+			finalVal, ok := data["final"].(bool)
+			if !ok {
+				t.Fatalf("Expected final field to be bool, got %T (%v)", data["final"], data["final"])
+			}
+			if finalVal != tt.wantFinal {
+				t.Errorf("Expected final=%v for %s status, got %v", tt.wantFinal, tt.cmd.Status, finalVal)
+			}
+		})
 	}
 }

--- a/cmd/dev-console/tools_interact_draw.go
+++ b/cmd/dev-console/tools_interact_draw.go
@@ -50,6 +50,7 @@ func (h *ToolHandler) handleDrawModeStart(req JSONRPCRequest, args json.RawMessa
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Draw mode activated", map[string]any{
 		"status":         "queued",
 		"correlation_id": correlationID,
+		"final":          false,
 		"message":        "Draw mode activation queued. The user can now draw annotations on the page. Use analyze({what: 'annotations', wait: true}) to block until the user finishes drawing.",
 	})}
 }

--- a/cmd/dev-console/tools_interact_upload.go
+++ b/cmd/dev-console/tools_interact_upload.go
@@ -122,6 +122,7 @@ func (h *ToolHandler) queueUpload(req JSONRPCRequest, params uploadParams, info 
 
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Upload queued", map[string]any{
 		"status": "queued", "correlation_id": correlationID,
+		"final": false,
 		"file_name": fileName, "file_size": fileSize,
 		"mime_type": mimeType, "progress_tier": string(progressTier),
 		"message": "Upload queued for execution. Use observe({what: 'command_result', correlation_id: '" + correlationID + "'}) to get the result.",

--- a/cmd/dev-console/tools_observe_analysis.go
+++ b/cmd/dev-console/tools_observe_analysis.go
@@ -671,12 +671,14 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 
 	switch cmd.Status {
 	case "complete":
+		responseData["final"] = true
 		return h.formatCompleteCommand(req, cmd, corrID, responseData)
 	case "error":
 		if cmd.Error == "" {
 			cmd.Error = "Command failed in extension"
 		}
 		responseData["error"] = cmd.Error
+		responseData["final"] = true
 		if len(cmd.Result) > 0 {
 			responseData["result"] = cmd.Result
 		}
@@ -697,6 +699,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 			h.diagnosticHint(),
 		)}
 	default:
+		responseData["final"] = false
 		summary := fmt.Sprintf("Command %s: %s", corrID, cmd.Status)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse(summary, responseData)}
 	}

--- a/cmd/dev-console/tools_recording_video.go
+++ b/cmd/dev-console/tools_recording_video.go
@@ -175,6 +175,7 @@ func (h *ToolHandler) queueRecordStart(req JSONRPCRequest, fullName, audio, vide
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Recording queued", map[string]any{
 		"status":                "queued",
 		"correlation_id":        correlationID,
+		"final":                 false,
 		"name":                  fullName,
 		"fps":                   fps,
 		"audio":                 audio,
@@ -256,6 +257,7 @@ func (h *ToolHandler) handleRecordStop(req JSONRPCRequest, args json.RawMessage)
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Recording stop queued", map[string]any{
 		"status":         "queued",
 		"correlation_id": correlationID,
+		"final":          false,
 		"message":        "Recording stop queued. Use observe({what: 'command_result', correlation_id: '" + correlationID + "'}) to get the result.",
 	})}
 }


### PR DESCRIPTION
## Summary

- All non-final async responses (`queued`, `still_processing`, `pending`) now include `"final": false`
- All terminal responses (`complete`, `error`) include `"final": true`
- `expired`/`timeout` responses already use `isError: true` via `mcpStructuredError` — unambiguously terminal

This lets agents distinguish "operation accepted" from "operation succeeded" without relying solely on `isError`, which correctly remains `false` for successful queuing operations.

Fixes #92.

## Response contract

| Status | `isError` | `final` | Agent should... |
|--------|-----------|---------|----------------|
| `queued` | `false` | `false` | Poll `command_result` |
| `still_processing` | `false` | `false` | Poll `command_result` |
| `complete` (success) | `false` | `true` | Use the result |
| `complete` (failure) | `true` | `true` | Handle the error |
| `error` | `true` | `true` | Handle the error |
| `expired`/`timeout` | `true` | n/a | Handle the error (mcpStructuredError) |

## Test plan

- [x] `go build ./cmd/dev-console/` compiles clean
- [x] Pre-existing test failures confirmed unrelated (fail on base branch too)
- [ ] Manual: `interact({action: "click", selector: ".missing", background: true})` → response includes `final: false`
- [ ] Manual: poll `command_result` for failed command → response includes `final: true`, `isError: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)