### PR TITLE
fix(mcp): harden JSON-RPC id handling + 2025-06-18 negotiation

### DIFF
--- a/cmd/dev-console/bridge_runmode_unit_test.go
+++ b/cmd/dev-console/bridge_runmode_unit_test.go
@@ -33,7 +33,7 @@ func TestRunBridgeModeWithExistingServer(t *testing.T) {
 			runBridgeMode(port, "", 0)
 		})
 	})
-	if !strings.Contains(output, `"protocolVersion":"2025-06-18"`) && !strings.Contains(output, `"protocolVersion":"2024-11-05"`) {
-		t.Fatalf("runBridgeMode output missing initialize response with supported protocolVersion: %q", output)
+	if !strings.Contains(output, `"protocolVersion":"2025-06-18"`) {
+		t.Fatalf("runBridgeMode output missing initialize response: %q", output)
 	}
 }

--- a/cmd/dev-console/protocol_version.go
+++ b/cmd/dev-console/protocol_version.go
@@ -1,0 +1,26 @@
+package main
+
+import "encoding/json"
+
+const (
+	mcpProtocolVersionLatest = "2025-06-18"
+	mcpProtocolVersionLegacy = "2024-11-05"
+)
+
+// negotiateProtocolVersion returns the protocol version selected for initialize.
+// Supports latest and one legacy version for backward compatibility.
+func negotiateProtocolVersion(rawParams json.RawMessage) string {
+	var params struct {
+		ProtocolVersion string `json:"protocolVersion"` // SPEC:MCP
+	}
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &params)
+	}
+
+	switch params.ProtocolVersion {
+	case mcpProtocolVersionLatest, mcpProtocolVersionLegacy:
+		return params.ProtocolVersion
+	default:
+		return mcpProtocolVersionLatest
+	}
+}


### PR DESCRIPTION
## Summary
- harden JSON-RPC request id parsing (track id presence vs explicit null)
- return `-32600` for invalid/null request ids instead of silently treating them as notifications
- fix HTTP read-error path to use null id instead of string fallback
- add protocol version negotiation helper with latest `2025-06-18` plus legacy `2024-11-05` compatibility
- update bridge fast path initialize response to use negotiated protocol version
- add regression tests for null-id handling and notification semantics in handler + bridge
- refresh MCP tools-list golden snapshot

## Tracking
- Closes #125

## Validation
- `GOCACHE=/tmp/gocache go test ./cmd/dev-console -run 'TestMCPHandlerHandleRequestCorePaths|TestMCPHandlerHandleHTTP$|TestMCPHandlerHandleHTTP_ReadErrorUsesNullID|TestMCPHandlerHandleHTTP_IDNullIsInvalidRequest|TestBridgeFastPathStaticAndFallbackErrors|TestBridgeFastPathFramedInitializeAndToolsList|TestBridgeFastPathNotificationWithoutIDHasNoResponse|TestBridgeFastPathNullIDReturnsInvalidRequest|TestGoldenInitialize|TestGoldenToolsList' -count=1`
