### PR TITLE
feat: API improvements — strict validation, scope filtering, workflows

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -35,6 +35,18 @@
           ],
           "type": "string"
         },
+        "format": {
+          "description": "Screenshot format (screenshot)",
+          "enum": [
+            "png",
+            "jpeg"
+          ],
+          "type": "string"
+        },
+        "full_page": {
+          "description": "Capture full scrollable page (screenshot)",
+          "type": "boolean"
+        },
         "include": {
           "description": "Categories to include (timeline)",
           "items": {
@@ -80,6 +92,10 @@
           "description": "Original recording ID (log_diff_report)",
           "type": "string"
         },
+        "quality": {
+          "description": "Screenshot JPEG quality 1-100 (screenshot)",
+          "type": "number"
+        },
         "recording_id": {
           "description": "Recording ID (recording_actions, playback_results)",
           "type": "string"
@@ -91,6 +107,18 @@
         "restart_on_eviction": {
           "description": "Auto-restart if cursor expired",
           "type": "boolean"
+        },
+        "scope": {
+          "description": "Filter scope: current_page (default) filters by tracked tab, all returns everything (errors, logs)",
+          "enum": [
+            "current_page",
+            "all"
+          ],
+          "type": "string"
+        },
+        "selector": {
+          "description": "Capture specific element by CSS selector (screenshot)",
+          "type": "string"
         },
         "since_cursor": {
           "description": "Return all entries newer than cursor (no limit)",
@@ -120,6 +148,10 @@
         "url": {
           "description": "Filter by URL substring",
           "type": "string"
+        },
+        "wait_for_stable": {
+          "description": "Wait for layout to stabilize before capture (screenshot)",
+          "type": "boolean"
         },
         "what": {
           "enum": [
@@ -1079,6 +1111,7 @@
             "playback",
             "log_diff",
             "telemetry",
+            "describe_capabilities",
             "diff_sessions",
             "audit_log"
           ],
@@ -1316,6 +1349,11 @@
             "key_press",
             "paste",
             "list_interactive",
+            "get_readable",
+            "get_markdown",
+            "navigate_and_wait_for",
+            "fill_form_and_submit",
+            "run_a11y_and_export_sarif",
             "record_start",
             "record_stop",
             "upload",
@@ -1364,6 +1402,30 @@
           "description": "Upload escalation timeout in ms",
           "type": "number"
         },
+        "fields": {
+          "description": "Form fields to fill (fill_form_and_submit)",
+          "items": {
+            "properties": {
+              "index": {
+                "description": "Element index from list_interactive (alternative to selector)",
+                "type": "number"
+              },
+              "selector": {
+                "description": "CSS selector for the field",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value to type into the field",
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "file_path": {
           "description": "Absolute file path for upload action",
           "type": "string"
@@ -1383,9 +1445,17 @@
             }
           ]
         },
+        "include_content": {
+          "description": "Return page content with navigate response (url, title, text_content, vitals)",
+          "type": "boolean"
+        },
         "include_url": {
           "description": "Restore URL with state",
           "type": "boolean"
+        },
+        "index": {
+          "description": "Element index from list_interactive results (alternative to selector)",
+          "type": "number"
         },
         "name": {
           "description": "Attribute or recording name",
@@ -1393,6 +1463,10 @@
         },
         "reason": {
           "description": "Action reason (shown as toast)",
+          "type": "string"
+        },
+        "save_to": {
+          "description": "File path to save output (run_a11y_and_export_sarif)",
           "type": "string"
         },
         "script": {
@@ -1414,6 +1488,14 @@
         "submit": {
           "description": "Submit form after upload",
           "type": "boolean"
+        },
+        "submit_index": {
+          "description": "Submit button index from list_interactive (fill_form_and_submit)",
+          "type": "number"
+        },
+        "submit_selector": {
+          "description": "Submit button selector (fill_form_and_submit)",
+          "type": "string"
         },
         "subtitle": {
           "description": "Narration text, composable with any action. Empty clears.",
@@ -1452,9 +1534,17 @@
           "description": "Value for select/set_attribute",
           "type": "string"
         },
+        "visible_only": {
+          "description": "Only return visible elements (list_interactive)",
+          "type": "boolean"
+        },
         "wait": {
           "description": "Alias for sync (default: true).",
           "type": "boolean"
+        },
+        "wait_for": {
+          "description": "CSS selector to wait for after navigation (navigate_and_wait_for)",
+          "type": "string"
         },
         "world": {
           "description": "JS world: auto (default), main (page globals), isolated (bypass CSP).",

--- a/cmd/dev-console/tools_configure_capabilities_test.go
+++ b/cmd/dev-console/tools_configure_capabilities_test.go
@@ -1,0 +1,113 @@
+// tools_configure_capabilities_test.go — Tests for describe_capabilities handler.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDescribeCapabilities_ResponseStructure(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	resp := h.handleDescribeCapabilities(req, json.RawMessage(`{}`))
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal MCPToolResult: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("expected non-error response")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content")
+	}
+
+	text := result.Content[0].Text
+
+	// Must contain the 5 core tools
+	for _, tool := range []string{"observe", "generate", "configure", "interact", "analyze"} {
+		if !strings.Contains(text, `"`+tool+`"`) {
+			t.Errorf("expected tool %q in capabilities", tool)
+		}
+	}
+
+	// Must contain version and protocol_version
+	if !strings.Contains(text, `"version"`) {
+		t.Error("expected version field")
+	}
+	if !strings.Contains(text, `"protocol_version"`) {
+		t.Error("expected protocol_version field")
+	}
+
+	// Parse deeper to check structure
+	idx := strings.Index(text, "{")
+	if idx < 0 {
+		t.Fatal("no JSON in response")
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(text[idx:]), &data); err != nil {
+		t.Fatalf("parse capabilities JSON: %v", err)
+	}
+
+	tools, ok := data["tools"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tools map")
+	}
+
+	// Each tool should have dispatch_param, modes, params, description
+	for name, toolData := range tools {
+		td, ok := toolData.(map[string]any)
+		if !ok {
+			t.Errorf("tool %s: expected map", name)
+			continue
+		}
+		if _, ok := td["dispatch_param"]; !ok {
+			t.Errorf("tool %s: missing dispatch_param", name)
+		}
+		if _, ok := td["description"]; !ok {
+			t.Errorf("tool %s: missing description", name)
+		}
+		if _, ok := td["params"]; !ok {
+			t.Errorf("tool %s: missing params", name)
+		}
+	}
+}
+
+func TestDescribeCapabilities_ToolsHaveModes(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	resp := h.handleDescribeCapabilities(req, json.RawMessage(`{}`))
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	text := result.Content[0].Text
+	idx := strings.Index(text, "{")
+	var data map[string]any
+	json.Unmarshal([]byte(text[idx:]), &data)
+	tools := data["tools"].(map[string]any)
+
+	// observe tool should have modes (what enum)
+	observeTool := tools["observe"].(map[string]any)
+	modes, ok := observeTool["modes"].([]any)
+	if !ok || len(modes) == 0 {
+		t.Error("observe tool should have non-empty modes list")
+	}
+
+	// Check that modes include known values
+	modeSet := make(map[string]bool)
+	for _, m := range modes {
+		modeSet[m.(string)] = true
+	}
+	if !modeSet["errors"] {
+		t.Error("observe modes should include 'errors'")
+	}
+	if !modeSet["logs"] {
+		t.Error("observe modes should include 'logs'")
+	}
+}

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -216,6 +216,11 @@ type ToolHandler struct {
 	// Cached interact dispatch map (initialized once via sync.Once)
 	interactOnce     sync.Once
 	interactHandlers map[string]interactHandler
+
+	// Element index store: maps index→selector from last list_interactive call.
+	// Protected by elementIndexMu; refreshed on each list_interactive.
+	elementIndexMu    sync.RWMutex
+	elementIndexStore map[int]string
 }
 
 // GetCapture returns the capture instance

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -217,8 +217,11 @@ type ToolHandler struct {
 	interactOnce     sync.Once
 	interactHandlers map[string]interactHandler
 
-	// Element index store: maps index→selector from last list_interactive call.
-	// Protected by elementIndexMu; refreshed on each list_interactive.
+	// Element index store: maps index→selector from the last list_interactive call.
+	// Protected by elementIndexMu; replaced on each list_interactive response.
+	// NOTE: This is a single shared store — concurrent clients calling list_interactive
+	// will overwrite each other's index. Acceptable for single-agent usage; scope by
+	// tab or client ID if multi-client support is needed.
 	elementIndexMu    sync.RWMutex
 	elementIndexStore map[int]string
 }

--- a/cmd/dev-console/tools_generate_validation_test.go
+++ b/cmd/dev-console/tools_generate_validation_test.go
@@ -1,0 +1,140 @@
+// tools_generate_validation_test.go — Tests for generate API strict parameter validation (#57).
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRejectsUnknownParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		args   map[string]any
+	}{
+		{
+			name:   "reproduction rejects bogus param",
+			format: "reproduction",
+			args:   map[string]any{"format": "reproduction", "bogus": true},
+		},
+		{
+			name:   "test rejects unknown scope param",
+			format: "test",
+			args:   map[string]any{"format": "test", "scope": "page"},
+		},
+		{
+			name:   "har rejects include_passes",
+			format: "har",
+			args:   map[string]any{"format": "har", "include_passes": true},
+		},
+		{
+			name:   "csp rejects resource_types",
+			format: "csp",
+			args:   map[string]any{"format": "csp", "resource_types": []string{"script"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsJSON, _ := json.Marshal(tt.args)
+			resp := validateGenerateParams(
+				JSONRPCRequest{ID: 1},
+				tt.format,
+				argsJSON,
+			)
+			if resp == nil {
+				t.Fatal("expected error response for unknown params, got nil")
+			}
+			var result MCPToolResult
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if !result.IsError {
+				t.Error("expected isError=true")
+			}
+			if !strings.Contains(result.Content[0].Text, "invalid_param") {
+				t.Errorf("expected invalid_param error code, got: %s", result.Content[0].Text)
+			}
+		})
+	}
+}
+
+func TestGenerateAcceptsValidParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		args   map[string]any
+	}{
+		{
+			name:   "reproduction with valid params",
+			format: "reproduction",
+			args:   map[string]any{"format": "reproduction", "error_message": "404", "last_n": 5},
+		},
+		{
+			name:   "test with telemetry_mode",
+			format: "test",
+			args:   map[string]any{"format": "test", "test_name": "login", "telemetry_mode": "auto"},
+		},
+		{
+			name:   "har with filters",
+			format: "har",
+			args:   map[string]any{"format": "har", "url": "/api", "method": "GET"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsJSON, _ := json.Marshal(tt.args)
+			resp := validateGenerateParams(
+				JSONRPCRequest{ID: 1},
+				tt.format,
+				argsJSON,
+			)
+			if resp != nil {
+				t.Fatalf("expected nil (no error) for valid params, got: %+v", resp)
+			}
+		})
+	}
+}
+
+func TestGenerateEmptyOutputIncludesReason(t *testing.T) {
+	h := newTestToolHandler()
+
+	// Call generate(test) with no actions captured → should include reason
+	args, _ := json.Marshal(map[string]any{"format": "test"})
+	resp := h.toolGenerate(JSONRPCRequest{ID: 1}, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, `"reason"`) {
+		t.Error("expected reason field in empty output")
+	}
+	if !strings.Contains(text, "no_actions_captured") {
+		t.Error("expected no_actions_captured reason")
+	}
+}
+
+func TestGeneratePRSummaryEmptyIncludesReason(t *testing.T) {
+	h := newTestToolHandler()
+
+	args, _ := json.Marshal(map[string]any{"format": "pr_summary"})
+	resp := h.toolGenerate(JSONRPCRequest{ID: 1}, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	text := result.Content[0].Text
+	if !strings.Contains(text, `"reason"`) {
+		t.Error("expected reason field in empty pr_summary output")
+	}
+	if !strings.Contains(text, "no_activity_captured") {
+		t.Error("expected no_activity_captured reason")
+	}
+}

--- a/cmd/dev-console/tools_interact_content.go
+++ b/cmd/dev-console/tools_interact_content.go
@@ -250,7 +250,7 @@ func (h *ToolHandler) handleGetMarkdown(req JSONRPCRequest, args json.RawMessage
 }
 
 // enrichNavigateResponse appends page content to a successful navigate response.
-// Runs a page_summary script to extract text content, headings, and metadata.
+// Runs a page_summary script (defined in tools_analyze.go) to extract text content, headings, and metadata.
 func (h *ToolHandler) enrichNavigateResponse(resp JSONRPCResponse, req JSONRPCRequest, tabID int) JSONRPCResponse {
 	// Only enrich successful (non-error) responses
 	var result MCPToolResult

--- a/cmd/dev-console/tools_interact_content.go
+++ b/cmd/dev-console/tools_interact_content.go
@@ -1,0 +1,316 @@
+// tools_interact_content.go — Content extraction handlers for interact tool.
+// Implements get_readable and get_markdown actions using embedded JS scripts
+// executed via the "execute" query type (no TypeScript changes needed).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/queries"
+)
+
+// getReadableScript is a self-contained IIFE that extracts clean article content.
+// Finds <article>/<main>/largest text block, strips nav/footer/ads, returns structured content.
+const getReadableScript = `(function() {
+  function cleanText(el) {
+    if (!el) return '';
+    var clone = el.cloneNode(true);
+    var removeTags = ['nav','header','footer','aside','script','style','noscript','svg',
+      '[role="navigation"]','[role="banner"]','[role="contentinfo"]','[aria-hidden="true"]',
+      '.ad,.ads,.advertisement,.social-share,.comments,.sidebar,.related-posts,.newsletter'];
+    removeTags.forEach(function(sel) {
+      var els = clone.querySelectorAll(sel);
+      for (var i = 0; i < els.length; i++) els[i].remove();
+    });
+    return (clone.innerText || clone.textContent || '').replace(/\s+/g,' ').trim();
+  }
+
+  function findMainContent() {
+    var candidates = ['article','main','[role="main"]','.post-content','.entry-content',
+      '.article-body','.article-content','.story-body','#content','.content'];
+    for (var i = 0; i < candidates.length; i++) {
+      var el = document.querySelector(candidates[i]);
+      if (el) {
+        var text = cleanText(el);
+        if (text.length > 100) return {el: el, text: text};
+      }
+    }
+    return {el: document.body, text: cleanText(document.body)};
+  }
+
+  function getByline() {
+    var selectors = ['.author','[rel="author"]','.byline','.post-author','meta[name="author"]'];
+    for (var i = 0; i < selectors.length; i++) {
+      var el = document.querySelector(selectors[i]);
+      if (el) {
+        var text = el.getAttribute('content') || el.innerText || '';
+        text = text.trim();
+        if (text.length > 0 && text.length < 200) return text;
+      }
+    }
+    return '';
+  }
+
+  var found = findMainContent();
+  var content = found.text;
+  var excerpt = content.slice(0, 300);
+  var words = content.split(/\s+/).filter(Boolean);
+
+  return {
+    title: document.title || '',
+    content: content,
+    excerpt: excerpt,
+    byline: getByline(),
+    word_count: words.length,
+    url: window.location.href
+  };
+})()`;
+
+// getMarkdownScript extracts content and converts to Markdown.
+const getMarkdownScript = `(function() {
+  function findMainContent() {
+    var candidates = ['article','main','[role="main"]','.post-content','.entry-content',
+      '.article-body','.article-content','.story-body','#content','.content'];
+    for (var i = 0; i < candidates.length; i++) {
+      var el = document.querySelector(candidates[i]);
+      if (el && (el.innerText||'').trim().length > 100) return el;
+    }
+    return document.body;
+  }
+
+  function nodeToMarkdown(node, depth) {
+    if (!node) return '';
+    if (depth > 20) return '';
+    if (node.nodeType === 3) return node.textContent || '';
+    if (node.nodeType !== 1) return '';
+    var el = node;
+    var tag = el.tagName.toLowerCase();
+
+    // Skip unwanted elements
+    if (['nav','header','footer','aside','script','style','noscript','svg'].indexOf(tag) >= 0) return '';
+    if (el.getAttribute('role') === 'navigation') return '';
+    if (el.getAttribute('aria-hidden') === 'true') return '';
+
+    var children = '';
+    for (var i = 0; i < el.childNodes.length; i++) {
+      children += nodeToMarkdown(el.childNodes[i], depth + 1);
+    }
+    children = children.replace(/\n{3,}/g, '\n\n');
+
+    switch(tag) {
+      case 'h1': return '\n# ' + children.trim() + '\n\n';
+      case 'h2': return '\n## ' + children.trim() + '\n\n';
+      case 'h3': return '\n### ' + children.trim() + '\n\n';
+      case 'h4': return '\n#### ' + children.trim() + '\n\n';
+      case 'h5': return '\n##### ' + children.trim() + '\n\n';
+      case 'h6': return '\n###### ' + children.trim() + '\n\n';
+      case 'p': return '\n' + children.trim() + '\n\n';
+      case 'br': return '\n';
+      case 'hr': return '\n---\n\n';
+      case 'strong': case 'b': return '**' + children.trim() + '**';
+      case 'em': case 'i': return '*' + children.trim() + '*';
+      case 'code': return '` + "`" + `' + children.trim() + '` + "`" + `';
+      case 'pre': return '\n` + "```" + `\n' + (el.innerText||'').trim() + '\n` + "```" + `\n\n';
+      case 'a':
+        var href = el.getAttribute('href') || '';
+        if (href && href !== '#' && !href.startsWith('javascript:')) {
+          try { href = new URL(href, window.location.href).href; } catch(e) {}
+          return '[' + children.trim() + '](' + href + ')';
+        }
+        return children;
+      case 'img':
+        var src = el.getAttribute('src') || '';
+        var alt = el.getAttribute('alt') || '';
+        if (src) {
+          try { src = new URL(src, window.location.href).href; } catch(e) {}
+          return '![' + alt + '](' + src + ')';
+        }
+        return '';
+      case 'ul': case 'ol': return '\n' + children + '\n';
+      case 'li':
+        var parent = el.parentElement;
+        if (parent && parent.tagName.toLowerCase() === 'ol') {
+          var idx = Array.from(parent.children).indexOf(el) + 1;
+          return idx + '. ' + children.trim() + '\n';
+        }
+        return '- ' + children.trim() + '\n';
+      case 'blockquote': return '\n> ' + children.trim().replace(/\n/g, '\n> ') + '\n\n';
+      case 'table': return '\n' + tableToMarkdown(el) + '\n\n';
+      case 'div': case 'section': case 'article': case 'main': return children;
+      default: return children;
+    }
+  }
+
+  function tableToMarkdown(table) {
+    var rows = table.querySelectorAll('tr');
+    if (rows.length === 0) return '';
+    var md = '';
+    for (var r = 0; r < rows.length; r++) {
+      var cells = rows[r].querySelectorAll('th,td');
+      var row = '|';
+      for (var c = 0; c < cells.length; c++) {
+        row += ' ' + (cells[c].innerText||'').trim().replace(/\|/g,'\\|').replace(/\n/g,' ') + ' |';
+      }
+      md += row + '\n';
+      if (r === 0 && rows[r].querySelector('th')) {
+        md += '|';
+        for (var c2 = 0; c2 < cells.length; c2++) md += ' --- |';
+        md += '\n';
+      }
+    }
+    return md;
+  }
+
+  var main = findMainContent();
+  var markdown = nodeToMarkdown(main, 0).trim();
+  var words = markdown.replace(/[#*\[\]()` + "`" + `|>-]/g,' ').split(/\s+/).filter(Boolean);
+
+  return {
+    title: document.title || '',
+    markdown: markdown,
+    word_count: words.length,
+    url: window.location.href
+  };
+})()`;
+
+func (h *ToolHandler) handleGetReadable(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		TabID     int    `json:"tab_id,omitempty"`
+		TimeoutMs int    `json:"timeout_ms,omitempty"`
+		World     string `json:"world,omitempty"`
+	}
+	lenientUnmarshal(args, &params)
+
+	if params.World == "" {
+		params.World = "isolated"
+	}
+	if !validWorldValues[params.World] {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'world' value: "+params.World, "Use 'isolated' (default), 'main', or 'auto'", withParam("world"))}
+	}
+	if params.TimeoutMs <= 0 {
+		params.TimeoutMs = 10_000
+	}
+
+	correlationID := fmt.Sprintf("readable_%d_%d", time.Now().UnixNano(), randomInt63())
+	execParams, _ := json.Marshal(map[string]any{
+		"script":     getReadableScript,
+		"timeout_ms": params.TimeoutMs,
+		"world":      params.World,
+		"reason":     "get_readable",
+	})
+
+	query := queries.PendingQuery{
+		Type:          "execute",
+		Params:        execParams,
+		TabID:         params.TabID,
+		CorrelationID: correlationID,
+	}
+	h.capture.CreatePendingQueryWithTimeout(query, queries.AsyncCommandTimeout, req.ClientID)
+
+	return h.maybeWaitForCommand(req, correlationID, args, "get_readable queued")
+}
+
+func (h *ToolHandler) handleGetMarkdown(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		TabID     int    `json:"tab_id,omitempty"`
+		TimeoutMs int    `json:"timeout_ms,omitempty"`
+		World     string `json:"world,omitempty"`
+	}
+	lenientUnmarshal(args, &params)
+
+	if params.World == "" {
+		params.World = "isolated"
+	}
+	if !validWorldValues[params.World] {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'world' value: "+params.World, "Use 'isolated' (default), 'main', or 'auto'", withParam("world"))}
+	}
+	if params.TimeoutMs <= 0 {
+		params.TimeoutMs = 10_000
+	}
+
+	correlationID := fmt.Sprintf("markdown_%d_%d", time.Now().UnixNano(), randomInt63())
+	execParams, _ := json.Marshal(map[string]any{
+		"script":     getMarkdownScript,
+		"timeout_ms": params.TimeoutMs,
+		"world":      params.World,
+		"reason":     "get_markdown",
+	})
+
+	query := queries.PendingQuery{
+		Type:          "execute",
+		Params:        execParams,
+		TabID:         params.TabID,
+		CorrelationID: correlationID,
+	}
+	h.capture.CreatePendingQueryWithTimeout(query, queries.AsyncCommandTimeout, req.ClientID)
+
+	return h.maybeWaitForCommand(req, correlationID, args, "get_markdown queued")
+}
+
+// enrichNavigateResponse appends page content to a successful navigate response.
+// Runs a page_summary script to extract text content, headings, and metadata.
+func (h *ToolHandler) enrichNavigateResponse(resp JSONRPCResponse, req JSONRPCRequest, tabID int) JSONRPCResponse {
+	// Only enrich successful (non-error) responses
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil || result.IsError {
+		return resp
+	}
+
+	// Get current page info from tracking state
+	_, _, tabURL := h.capture.GetTrackingStatus()
+	tabTitle := h.capture.GetTrackedTabTitle()
+
+	// Get performance vitals
+	vitals := h.capture.GetPerformanceSnapshots()
+
+	// Execute page summary script for text content
+	summaryCorrelationID := fmt.Sprintf("nav_content_%d_%d", time.Now().UnixNano(), randomInt63())
+	execParams, _ := json.Marshal(map[string]any{
+		"script":     pageSummaryScript,
+		"timeout_ms": 10000,
+		"world":      "isolated",
+		"reason":     "navigate_content_enrichment",
+	})
+	summaryQuery := queries.PendingQuery{
+		Type:          "execute",
+		Params:        execParams,
+		TabID:         tabID,
+		CorrelationID: summaryCorrelationID,
+	}
+	h.capture.CreatePendingQueryWithTimeout(summaryQuery, queries.AsyncCommandTimeout, req.ClientID)
+
+	// Wait for page summary (5s timeout — page should already be loaded)
+	var textContent string
+	cmd, found := h.capture.WaitForCommand(summaryCorrelationID, 5*time.Second)
+	if found && cmd.Status != "pending" && cmd.Result != nil {
+		var summaryResult map[string]any
+		if json.Unmarshal(cmd.Result, &summaryResult) == nil {
+			if preview, ok := summaryResult["main_content_preview"].(string); ok {
+				textContent = preview
+			}
+		}
+	}
+
+	// Parse existing result text and append enrichment data
+	if len(result.Content) > 0 {
+		enrichment := map[string]any{
+			"url":          tabURL,
+			"title":        tabTitle,
+			"text_content": textContent,
+		}
+		if len(vitals) > 0 {
+			enrichment["vitals"] = vitals[len(vitals)-1]
+		}
+		enrichJSON, _ := json.Marshal(enrichment)
+		result.Content = append(result.Content, MCPContentBlock{
+			Type: "text",
+			Text: "Page content:\n" + string(enrichJSON),
+		})
+	}
+
+	resultJSON, _ := json.Marshal(result)
+	resp.Result = json.RawMessage(resultJSON)
+	return resp
+}

--- a/cmd/dev-console/tools_interact_elements.go
+++ b/cmd/dev-console/tools_interact_elements.go
@@ -95,18 +95,13 @@ func extractElementList(data map[string]any) []any {
 	if elems, ok := data["elements"].([]any); ok {
 		return elems
 	}
-	// Nested in result field
+	// Nested in result field (json.Unmarshal into map[string]any always produces map[string]any)
 	if resultData, ok := data["result"].(map[string]any); ok {
 		if elems, ok := resultData["elements"].([]any); ok {
 			return elems
 		}
-	}
-	// Nested in result.result (command result wrapping)
-	if resultOuter, ok := data["result"].(json.RawMessage); ok {
-		var inner map[string]any
-		if json.Unmarshal(resultOuter, &inner) == nil {
-			return extractElementList(inner)
-		}
+		// Recurse into nested result (command result wrapping)
+		return extractElementList(resultData)
 	}
 	return nil
 }

--- a/cmd/dev-console/tools_interact_elements.go
+++ b/cmd/dev-console/tools_interact_elements.go
@@ -1,0 +1,120 @@
+// tools_interact_elements.go — Element indexing for interact tool.
+// Implements list_interactive with indexed element store and index→selector resolution.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/queries"
+)
+
+func (h *ToolHandler) handleListInteractive(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		TabID       int  `json:"tab_id,omitempty"`
+		VisibleOnly bool `json:"visible_only,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+
+	if !h.capture.IsPilotEnabled() {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrCodePilotDisabled, "AI Web Pilot is disabled", "Enable AI Web Pilot in the extension popup", h.diagnosticHint())}
+	}
+
+	correlationID := fmt.Sprintf("dom_list_%d_%d", time.Now().UnixNano(), randomInt63())
+
+	query := queries.PendingQuery{
+		Type:          "dom_action",
+		Params:        args,
+		TabID:         params.TabID,
+		CorrelationID: correlationID,
+	}
+	h.capture.CreatePendingQueryWithTimeout(query, queries.AsyncCommandTimeout, req.ClientID)
+
+	h.recordAIAction("dom_list_interactive", "", nil)
+
+	resp := h.maybeWaitForCommand(req, correlationID, args, "list_interactive queued")
+
+	// Post-process: extract elements from result and build index→selector store
+	h.buildElementIndexFromResponse(resp)
+
+	return resp
+}
+
+// buildElementIndexFromResponse parses list_interactive results and populates elementIndexStore.
+func (h *ToolHandler) buildElementIndexFromResponse(resp JSONRPCResponse) {
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil || result.IsError {
+		return
+	}
+
+	// Extract the result JSON from the command response
+	for _, block := range result.Content {
+		// Try to find JSON in the text content
+		idx := strings.Index(block.Text, "{")
+		if idx < 0 {
+			continue
+		}
+		jsonStr := block.Text[idx:]
+
+		var data map[string]any
+		if json.Unmarshal([]byte(jsonStr), &data) != nil {
+			continue
+		}
+
+		// Look for result.elements or result.result.elements
+		elements := extractElementList(data)
+		if elements == nil {
+			continue
+		}
+
+		h.elementIndexMu.Lock()
+		h.elementIndexStore = make(map[int]string, len(elements))
+		for _, elem := range elements {
+			elemMap, ok := elem.(map[string]any)
+			if !ok {
+				continue
+			}
+			indexVal, _ := elemMap["index"].(float64)
+			selector, _ := elemMap["selector"].(string)
+			if selector != "" {
+				h.elementIndexStore[int(indexVal)] = selector
+			}
+		}
+		h.elementIndexMu.Unlock()
+		return
+	}
+}
+
+// extractElementList walks nested result JSON to find the elements array.
+func extractElementList(data map[string]any) []any {
+	// Direct elements field
+	if elems, ok := data["elements"].([]any); ok {
+		return elems
+	}
+	// Nested in result field
+	if resultData, ok := data["result"].(map[string]any); ok {
+		if elems, ok := resultData["elements"].([]any); ok {
+			return elems
+		}
+	}
+	// Nested in result.result (command result wrapping)
+	if resultOuter, ok := data["result"].(json.RawMessage); ok {
+		var inner map[string]any
+		if json.Unmarshal(resultOuter, &inner) == nil {
+			return extractElementList(inner)
+		}
+	}
+	return nil
+}
+
+// resolveIndexToSelector looks up a selector from the element index store.
+func (h *ToolHandler) resolveIndexToSelector(index int) (string, bool) {
+	h.elementIndexMu.RLock()
+	defer h.elementIndexMu.RUnlock()
+	sel, ok := h.elementIndexStore[index]
+	return sel, ok
+}

--- a/cmd/dev-console/tools_interact_elements_test.go
+++ b/cmd/dev-console/tools_interact_elements_test.go
@@ -1,0 +1,171 @@
+// tools_interact_elements_test.go — Tests for element index store and resolution.
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResolveIndexToSelector_Empty(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	_, ok := h.resolveIndexToSelector(0)
+	if ok {
+		t.Error("expected not found on empty store")
+	}
+}
+
+func TestResolveIndexToSelector_AfterBuild(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+
+	// Manually populate the store
+	h.elementIndexMu.Lock()
+	h.elementIndexStore = map[int]string{
+		0: "#email",
+		1: "#password",
+		2: "button[type=submit]",
+	}
+	h.elementIndexMu.Unlock()
+
+	sel, ok := h.resolveIndexToSelector(1)
+	if !ok || sel != "#password" {
+		t.Errorf("expected #password, got %q (ok=%v)", sel, ok)
+	}
+
+	_, ok = h.resolveIndexToSelector(99)
+	if ok {
+		t.Error("expected not found for missing index")
+	}
+}
+
+func TestBuildElementIndexFromResponse_ValidElements(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+
+	// Simulate a list_interactive response with elements in the JSON
+	elemData := map[string]any{
+		"elements": []any{
+			map[string]any{"index": float64(0), "selector": "#name", "tag": "input"},
+			map[string]any{"index": float64(1), "selector": ".btn-submit", "tag": "button"},
+			map[string]any{"index": float64(2), "selector": "", "tag": "div"}, // empty selector, should be skipped
+		},
+	}
+	elemJSON, _ := json.Marshal(elemData)
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "list_interactive results\n" + string(elemJSON)}},
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	h.buildElementIndexFromResponse(resp)
+
+	sel, ok := h.resolveIndexToSelector(0)
+	if !ok || sel != "#name" {
+		t.Errorf("index 0: expected #name, got %q (ok=%v)", sel, ok)
+	}
+
+	sel, ok = h.resolveIndexToSelector(1)
+	if !ok || sel != ".btn-submit" {
+		t.Errorf("index 1: expected .btn-submit, got %q (ok=%v)", sel, ok)
+	}
+
+	// Index 2 had empty selector, should not be stored
+	_, ok = h.resolveIndexToSelector(2)
+	if ok {
+		t.Error("index 2 with empty selector should not be stored")
+	}
+}
+
+func TestBuildElementIndexFromResponse_NestedResult(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+
+	// Elements nested under result.result.elements
+	nestedData := map[string]any{
+		"result": map[string]any{
+			"result": map[string]any{
+				"elements": []any{
+					map[string]any{"index": float64(0), "selector": "a.link"},
+				},
+			},
+		},
+	}
+	nestedJSON, _ := json.Marshal(nestedData)
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: string(nestedJSON)}},
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	h.buildElementIndexFromResponse(resp)
+
+	sel, ok := h.resolveIndexToSelector(0)
+	if !ok || sel != "a.link" {
+		t.Errorf("expected a.link from nested result, got %q (ok=%v)", sel, ok)
+	}
+}
+
+func TestBuildElementIndexFromResponse_ErrorResponse(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+
+	// Pre-populate store
+	h.elementIndexMu.Lock()
+	h.elementIndexStore = map[int]string{0: "old"}
+	h.elementIndexMu.Unlock()
+
+	// Error response should not clear the store
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "error"}},
+		IsError: true,
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	h.buildElementIndexFromResponse(resp)
+
+	sel, ok := h.resolveIndexToSelector(0)
+	if !ok || sel != "old" {
+		t.Errorf("error response should not clear store, got %q (ok=%v)", sel, ok)
+	}
+}
+
+func TestExtractElementList_Direct(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{
+		"elements": []any{
+			map[string]any{"index": float64(0), "selector": "#a"},
+		},
+	}
+	elems := extractElementList(data)
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+}
+
+func TestExtractElementList_Nested(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{
+		"result": map[string]any{
+			"elements": []any{
+				map[string]any{"index": float64(0), "selector": "#b"},
+			},
+		},
+	}
+	elems := extractElementList(data)
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element from nested, got %d", len(elems))
+	}
+}
+
+func TestExtractElementList_NoElements(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{"foo": "bar"}
+	elems := extractElementList(data)
+	if elems != nil {
+		t.Error("expected nil for data without elements")
+	}
+}

--- a/cmd/dev-console/tools_interact_workflows.go
+++ b/cmd/dev-console/tools_interact_workflows.go
@@ -1,0 +1,307 @@
+// tools_interact_workflows.go — High-level workflow primitives for interact tool.
+// Implements compound actions that chain existing handlers to reduce agent call overhead.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// WorkflowStep records a single step's outcome within a workflow trace.
+type WorkflowStep struct {
+	Action        string `json:"action"`
+	CorrelationID string `json:"correlation_id,omitempty"`
+	Status        string `json:"status"` // "success", "error", "skipped"
+	TimingMs      int64  `json:"timing_ms"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+// handleNavigateAndWaitFor navigates to a URL, waits for a CSS selector to appear,
+// and optionally returns page content — all in one call.
+func (h *ToolHandler) handleNavigateAndWaitFor(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		URL            string `json:"url"`
+		WaitFor        string `json:"wait_for"`
+		TabID          int    `json:"tab_id,omitempty"`
+		TimeoutMs      int    `json:"timeout_ms,omitempty"`
+		IncludeContent bool   `json:"include_content,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+	if params.URL == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'url' is missing", "Add 'url' to navigate to", withParam("url"))}
+	}
+	if params.WaitFor == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'wait_for' is missing", "Add a CSS selector to wait for after navigation", withParam("wait_for"))}
+	}
+	if params.TimeoutMs <= 0 {
+		params.TimeoutMs = 15_000
+	}
+
+	trace := make([]WorkflowStep, 0, 3)
+	workflowStart := time.Now()
+
+	// Step 1: Navigate
+	navArgs, _ := json.Marshal(map[string]any{
+		"action": "navigate",
+		"url":    params.URL,
+		"tab_id": params.TabID,
+	})
+	stepStart := time.Now()
+	navResp := h.handleBrowserActionNavigate(req, navArgs)
+	trace = append(trace, WorkflowStep{
+		Action:   "navigate",
+		Status:   responseStatus(navResp),
+		TimingMs: time.Since(stepStart).Milliseconds(),
+		Detail:   params.URL,
+	})
+	if isErrorResponse(navResp) {
+		return workflowResult(req, "navigate_and_wait_for", trace, navResp, workflowStart)
+	}
+
+	// Step 2: Wait for selector
+	elapsed := time.Since(workflowStart).Milliseconds()
+	waitTimeout := params.TimeoutMs - int(elapsed)
+	if waitTimeout < 1000 {
+		waitTimeout = 1000
+	}
+	waitArgs, _ := json.Marshal(map[string]any{
+		"action":     "wait_for",
+		"selector":   params.WaitFor,
+		"timeout_ms": waitTimeout,
+		"tab_id":     params.TabID,
+	})
+	stepStart = time.Now()
+	waitResp := h.handleDOMPrimitive(req, waitArgs, "wait_for")
+	trace = append(trace, WorkflowStep{
+		Action:   "wait_for",
+		Status:   responseStatus(waitResp),
+		TimingMs: time.Since(stepStart).Milliseconds(),
+		Detail:   params.WaitFor,
+	})
+	if isErrorResponse(waitResp) {
+		return workflowResult(req, "navigate_and_wait_for", trace, waitResp, workflowStart)
+	}
+
+	// Step 3: Optional content enrichment
+	if params.IncludeContent {
+		stepStart = time.Now()
+		navResp = h.enrichNavigateResponse(navResp, req, params.TabID)
+		trace = append(trace, WorkflowStep{
+			Action:   "get_content",
+			Status:   "success",
+			TimingMs: time.Since(stepStart).Milliseconds(),
+		})
+	}
+
+	return workflowResult(req, "navigate_and_wait_for", trace, navResp, workflowStart)
+}
+
+// FormField represents a single field to fill in a form workflow.
+type FormField struct {
+	Selector string `json:"selector"`
+	Value    string `json:"value"`
+	Index    *int   `json:"index,omitempty"`
+}
+
+// handleFillFormAndSubmit fills multiple form fields and clicks a submit button.
+func (h *ToolHandler) handleFillFormAndSubmit(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Fields          []FormField `json:"fields"`
+		SubmitSelector  string      `json:"submit_selector"`
+		SubmitIndex     *int        `json:"submit_index,omitempty"`
+		TabID           int         `json:"tab_id,omitempty"`
+		TimeoutMs       int         `json:"timeout_ms,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+	if len(params.Fields) == 0 {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'fields' is empty", "Provide at least one {selector, value} field entry", withParam("fields"))}
+	}
+	if params.SubmitSelector == "" && params.SubmitIndex == nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'submit_selector' or 'submit_index' is missing", "Add the selector or index of the submit button", withParam("submit_selector"))}
+	}
+	if params.TimeoutMs <= 0 {
+		params.TimeoutMs = 15_000
+	}
+
+	trace := make([]WorkflowStep, 0, len(params.Fields)+1)
+	workflowStart := time.Now()
+
+	// Fill each field
+	for i, field := range params.Fields {
+		if field.Selector == "" && field.Index == nil {
+			trace = append(trace, WorkflowStep{
+				Action: fmt.Sprintf("type[%d]", i),
+				Status: "error",
+				Detail: "Missing selector and index",
+			})
+			return workflowResult(req, "fill_form_and_submit", trace,
+				JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+					ErrMissingParam,
+					fmt.Sprintf("Field %d missing 'selector' or 'index'", i),
+					"Each field needs a 'selector' or 'index'",
+					withParam("fields"),
+				)}, workflowStart)
+		}
+
+		typeArgs := map[string]any{
+			"action":   "type",
+			"text":     field.Value,
+			"clear":    true,
+			"tab_id":   params.TabID,
+		}
+		if field.Index != nil {
+			typeArgs["index"] = *field.Index
+		} else {
+			typeArgs["selector"] = field.Selector
+		}
+		argsJSON, _ := json.Marshal(typeArgs)
+
+		stepStart := time.Now()
+		typeResp := h.handleDOMPrimitive(req, argsJSON, "type")
+		selectorLabel := field.Selector
+		if field.Index != nil {
+			selectorLabel = fmt.Sprintf("index:%d", *field.Index)
+		}
+		trace = append(trace, WorkflowStep{
+			Action:   fmt.Sprintf("type[%d]", i),
+			Status:   responseStatus(typeResp),
+			TimingMs: time.Since(stepStart).Milliseconds(),
+			Detail:   selectorLabel,
+		})
+		if isErrorResponse(typeResp) {
+			return workflowResult(req, "fill_form_and_submit", trace, typeResp, workflowStart)
+		}
+	}
+
+	// Click submit
+	clickArgs := map[string]any{
+		"action": "click",
+		"tab_id": params.TabID,
+	}
+	if params.SubmitIndex != nil {
+		clickArgs["index"] = *params.SubmitIndex
+	} else {
+		clickArgs["selector"] = params.SubmitSelector
+	}
+	clickJSON, _ := json.Marshal(clickArgs)
+
+	stepStart := time.Now()
+	clickResp := h.handleDOMPrimitive(req, clickJSON, "click")
+	trace = append(trace, WorkflowStep{
+		Action:   "click_submit",
+		Status:   responseStatus(clickResp),
+		TimingMs: time.Since(stepStart).Milliseconds(),
+		Detail:   params.SubmitSelector,
+	})
+
+	return workflowResult(req, "fill_form_and_submit", trace, clickResp, workflowStart)
+}
+
+// handleRunA11yAndExportSARIF runs accessibility audit then exports SARIF in one call.
+func (h *ToolHandler) handleRunA11yAndExportSARIF(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Scope  string `json:"scope,omitempty"`
+		SaveTo string `json:"save_to,omitempty"`
+		TabID  int    `json:"tab_id,omitempty"`
+	}
+	lenientUnmarshal(args, &params)
+
+	trace := make([]WorkflowStep, 0, 2)
+	workflowStart := time.Now()
+
+	// Step 1: Run accessibility audit
+	a11yArgs, _ := json.Marshal(map[string]any{
+		"what":   "accessibility",
+		"scope":  params.Scope,
+		"tab_id": params.TabID,
+	})
+	stepStart := time.Now()
+	a11yResp := h.toolAnalyze(req, a11yArgs)
+	trace = append(trace, WorkflowStep{
+		Action:   "analyze_accessibility",
+		Status:   responseStatus(a11yResp),
+		TimingMs: time.Since(stepStart).Milliseconds(),
+	})
+	if isErrorResponse(a11yResp) {
+		return workflowResult(req, "run_a11y_and_export_sarif", trace, a11yResp, workflowStart)
+	}
+
+	// Step 2: Export as SARIF
+	sarifArgs, _ := json.Marshal(map[string]any{
+		"format":  "sarif",
+		"scope":   params.Scope,
+		"save_to": params.SaveTo,
+	})
+	stepStart = time.Now()
+	sarifResp := h.toolGenerate(req, sarifArgs)
+	trace = append(trace, WorkflowStep{
+		Action:   "generate_sarif",
+		Status:   responseStatus(sarifResp),
+		TimingMs: time.Since(stepStart).Milliseconds(),
+	})
+
+	return workflowResult(req, "run_a11y_and_export_sarif", trace, sarifResp, workflowStart)
+}
+
+// ---- Workflow helpers ----
+
+// isErrorResponse checks if a JSONRPCResponse represents an error.
+func isErrorResponse(resp JSONRPCResponse) bool {
+	if resp.Error != nil {
+		return true
+	}
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err == nil {
+		return result.IsError
+	}
+	return false
+}
+
+// responseStatus returns "success" or "error" based on the response.
+func responseStatus(resp JSONRPCResponse) string {
+	if isErrorResponse(resp) {
+		return "error"
+	}
+	return "success"
+}
+
+// workflowResult wraps the final step's response with workflow metadata (trace + timing).
+func workflowResult(req JSONRPCRequest, workflow string, trace []WorkflowStep, lastResp JSONRPCResponse, start time.Time) JSONRPCResponse {
+	totalMs := time.Since(start).Milliseconds()
+
+	// Count steps by status
+	successCount := 0
+	for _, s := range trace {
+		if s.Status == "success" {
+			successCount++
+		}
+	}
+	allSuccess := successCount == len(trace)
+
+	status := "success"
+	if !allSuccess {
+		status = "partial_failure"
+	}
+
+	summary := fmt.Sprintf("%s completed (%d/%d steps succeeded, %dms)", workflow, successCount, len(trace), totalMs)
+
+	// If the last response was an error, use it as the base but add workflow context
+	if isErrorResponse(lastResp) {
+		status = "failed"
+		summary = fmt.Sprintf("%s failed at step %d/%d (%dms)", workflow, len(trace), len(trace), totalMs)
+	}
+
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse(summary, map[string]any{
+		"workflow":   workflow,
+		"status":     status,
+		"trace":      trace,
+		"total_ms":   totalMs,
+		"steps":      len(trace),
+		"successful": successCount,
+	})}
+}

--- a/cmd/dev-console/tools_interact_workflows_test.go
+++ b/cmd/dev-console/tools_interact_workflows_test.go
@@ -1,0 +1,249 @@
+// tools_interact_workflows_test.go — Tests for high-level workflow primitives.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================
+// Helper response tests
+// ============================================
+
+func TestIsErrorResponse_NilError(t *testing.T) {
+	t.Parallel()
+	resp := JSONRPCResponse{JSONRPC: "2.0"}
+	// No error field, no result — should not panic
+	if isErrorResponse(resp) {
+		t.Error("expected non-error for empty response with no error field")
+	}
+}
+
+func TestIsErrorResponse_WithJSONRPCError(t *testing.T) {
+	t.Parallel()
+	resp := JSONRPCResponse{JSONRPC: "2.0", Error: &JSONRPCError{Code: -32600, Message: "bad"}}
+	if !isErrorResponse(resp) {
+		t.Error("expected error response when Error field is set")
+	}
+}
+
+func TestIsErrorResponse_WithMCPToolError(t *testing.T) {
+	t.Parallel()
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "fail"}},
+		IsError: true,
+	}
+	raw, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: raw}
+	if !isErrorResponse(resp) {
+		t.Error("expected error when isError=true in MCPToolResult")
+	}
+}
+
+func TestResponseStatus(t *testing.T) {
+	t.Parallel()
+	ok := JSONRPCResponse{JSONRPC: "2.0"}
+	if responseStatus(ok) != "success" {
+		t.Error("expected success for non-error response")
+	}
+
+	err := JSONRPCResponse{JSONRPC: "2.0", Error: &JSONRPCError{Code: -1, Message: "x"}}
+	if responseStatus(err) != "error" {
+		t.Error("expected error for error response")
+	}
+}
+
+// ============================================
+// navigate_and_wait_for validation tests
+// ============================================
+
+func TestNavigateAndWaitFor_MissingURL(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"wait_for": ".content",
+	})
+	resp := h.handleNavigateAndWaitFor(req, args)
+	assertIsError(t, resp, "url")
+}
+
+func TestNavigateAndWaitFor_MissingWaitFor(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"url": "https://example.com",
+	})
+	resp := h.handleNavigateAndWaitFor(req, args)
+	assertIsError(t, resp, "wait_for")
+}
+
+func TestNavigateAndWaitFor_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	resp := h.handleNavigateAndWaitFor(req, json.RawMessage(`{bad`))
+	assertIsError(t, resp, "JSON")
+}
+
+// ============================================
+// fill_form_and_submit validation tests
+// ============================================
+
+func TestFillFormAndSubmit_EmptyFields(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"fields":          []any{},
+		"submit_selector": "button[type=submit]",
+	})
+	resp := h.handleFillFormAndSubmit(req, args)
+	assertIsError(t, resp, "fields")
+}
+
+func TestFillFormAndSubmit_MissingSubmit(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"fields": []map[string]string{
+			{"selector": "#email", "value": "test@example.com"},
+		},
+	})
+	resp := h.handleFillFormAndSubmit(req, args)
+	assertIsError(t, resp, "submit_selector")
+}
+
+func TestFillFormAndSubmit_FieldMissingSelectorAndIndex(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"fields": []map[string]string{
+			{"value": "test@example.com"},
+		},
+		"submit_selector": "button",
+	})
+	resp := h.handleFillFormAndSubmit(req, args)
+	assertIsError(t, resp, "selector")
+}
+
+func TestFillFormAndSubmit_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	resp := h.handleFillFormAndSubmit(req, json.RawMessage(`{bad`))
+	assertIsError(t, resp, "JSON")
+}
+
+// ============================================
+// run_a11y_and_export_sarif tests
+// ============================================
+
+func TestRunA11yAndExportSARIF_ValidParams(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{
+		"scope": "page",
+	})
+	// This will fail due to no extension connected, but should not panic
+	// and should return a structured error/workflow result
+	resp := h.handleRunA11yAndExportSARIF(req, args)
+	if resp.JSONRPC != "2.0" {
+		t.Error("expected valid JSON-RPC response")
+	}
+	// The workflow should have a trace in the result
+	var result map[string]any
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+}
+
+// ============================================
+// workflowResult tests
+// ============================================
+
+func TestWorkflowResult_AllSuccess(t *testing.T) {
+	t.Parallel()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	trace := []WorkflowStep{
+		{Action: "step1", Status: "success", TimingMs: 10},
+		{Action: "step2", Status: "success", TimingMs: 20},
+	}
+	okResp := JSONRPCResponse{JSONRPC: "2.0"}
+	resp := workflowResult(req, "test_workflow", trace, okResp, time.Now())
+
+	// mcpJSONResponse puts data as JSON text in Content[0].Text
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal MCPToolResult: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("expected non-error result")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected content blocks")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, `"status":"success"`) {
+		t.Errorf("expected status=success in text, got: %s", text)
+	}
+	if !strings.Contains(text, `"successful":2`) {
+		t.Errorf("expected successful=2 in text, got: %s", text)
+	}
+	if !strings.Contains(text, "test_workflow completed") {
+		t.Errorf("expected summary line, got: %s", text)
+	}
+}
+
+func TestWorkflowResult_Failure(t *testing.T) {
+	t.Parallel()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	trace := []WorkflowStep{
+		{Action: "step1", Status: "success", TimingMs: 10},
+		{Action: "step2", Status: "error", TimingMs: 5},
+	}
+	errResp := JSONRPCResponse{JSONRPC: "2.0", Error: &JSONRPCError{Code: -1, Message: "fail"}}
+	resp := workflowResult(req, "test_workflow", trace, errResp, time.Now())
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, `"status":"failed"`) {
+		t.Errorf("expected status=failed, got: %s", text)
+	}
+	if !strings.Contains(text, `"successful":1`) {
+		t.Errorf("expected successful=1, got: %s", text)
+	}
+}
+
+// ============================================
+// Test helpers
+// ============================================
+
+func assertIsError(t *testing.T, resp JSONRPCResponse, contains string) {
+	t.Helper()
+	if !isErrorResponse(resp) {
+		var result MCPToolResult
+		if err := json.Unmarshal(resp.Result, &result); err == nil {
+			for _, c := range result.Content {
+				if strings.Contains(c.Text, contains) {
+					return
+				}
+			}
+		}
+		t.Errorf("expected error response containing %q", contains)
+		return
+	}
+	raw, _ := json.Marshal(resp)
+	if !strings.Contains(string(raw), contains) {
+		t.Errorf("error response doesn't contain %q: %s", contains, raw)
+	}
+}

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -209,6 +209,9 @@ func (h *ToolHandler) toolGetBrowserErrors(req JSONRPCRequest, args json.RawMess
 	if params.Scope == "" {
 		params.Scope = "current_page"
 	}
+	if params.Scope != "current_page" && params.Scope != "all" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid scope: "+params.Scope, "Use 'current_page' (default) or 'all'", withParam("scope"))}
+	}
 
 	// Get tracked tab ID for current_page filtering
 	_, trackedTabID, _ := h.capture.GetTrackingStatus()
@@ -291,6 +294,9 @@ func (h *ToolHandler) toolGetBrowserLogs(req JSONRPCRequest, args json.RawMessag
 	lenientUnmarshal(args, &params)
 	if params.Scope == "" {
 		params.Scope = "current_page"
+	}
+	if params.Scope != "current_page" && params.Scope != "all" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid scope: "+params.Scope, "Use 'current_page' (default) or 'all'", withParam("scope"))}
 	}
 
 	// Get tracked tab ID for current_page filtering

--- a/cmd/dev-console/tools_observe_scope_test.go
+++ b/cmd/dev-console/tools_observe_scope_test.go
@@ -1,0 +1,95 @@
+// tools_observe_scope_test.go — Tests for scope filtering in errors/logs observe handlers.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGetBrowserErrors_InvalidScope(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{"scope": "bogus"})
+	resp := h.toolGetBrowserErrors(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid scope")
+	}
+	if !strings.Contains(result.Content[0].Text, "invalid_param") {
+		t.Errorf("expected invalid_param error, got: %s", result.Content[0].Text)
+	}
+}
+
+func TestGetBrowserErrors_ValidScopes(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+
+	for _, scope := range []string{"current_page", "all", ""} {
+		args, _ := json.Marshal(map[string]any{"scope": scope})
+		resp := h.toolGetBrowserErrors(req, args)
+		var result MCPToolResult
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			t.Fatalf("scope=%q unmarshal: %v", scope, err)
+		}
+		if result.IsError {
+			t.Errorf("scope=%q should not error", scope)
+		}
+	}
+}
+
+func TestGetBrowserLogs_InvalidScope(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	args, _ := json.Marshal(map[string]any{"scope": "invalid"})
+	resp := h.toolGetBrowserLogs(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid scope")
+	}
+}
+
+func TestGetBrowserLogs_ValidScopes(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+
+	for _, scope := range []string{"current_page", "all", ""} {
+		args, _ := json.Marshal(map[string]any{"scope": scope})
+		resp := h.toolGetBrowserLogs(req, args)
+		var result MCPToolResult
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			t.Fatalf("scope=%q unmarshal: %v", scope, err)
+		}
+		if result.IsError {
+			t.Errorf("scope=%q should not error", scope)
+		}
+	}
+}
+
+func TestGetBrowserErrors_ScopeInResponse(t *testing.T) {
+	t.Parallel()
+	h := newTestToolHandler()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+
+	args, _ := json.Marshal(map[string]any{"scope": "all"})
+	resp := h.toolGetBrowserErrors(req, args)
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(result.Content[0].Text, `"scope":"all"`) {
+		t.Error("expected scope=all in response")
+	}
+}

--- a/cmd/dev-console/tools_schema.go
+++ b/cmd/dev-console/tools_schema.go
@@ -108,6 +108,11 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"type":        "string",
 						"description": "Recording ID (recording_actions, playback_results)",
 					},
+					"scope": map[string]any{
+						"type":        "string",
+						"description": "Filter scope: current_page (default) filters by tracked tab, all returns everything (errors, logs)",
+						"enum":        []string{"current_page", "all"},
+					},
 					"window_seconds": map[string]any{
 						"type":        "number",
 						"description": "error_bundles lookback seconds (default 3, max 10)",
@@ -119,6 +124,27 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					"replay_id": map[string]any{
 						"type":        "string",
 						"description": "Replay recording ID (log_diff_report)",
+					},
+					"format": map[string]any{
+						"type":        "string",
+						"description": "Screenshot format (screenshot)",
+						"enum":        []string{"png", "jpeg"},
+					},
+					"quality": map[string]any{
+						"type":        "number",
+						"description": "Screenshot JPEG quality 1-100 (screenshot)",
+					},
+					"full_page": map[string]any{
+						"type":        "boolean",
+						"description": "Capture full scrollable page (screenshot)",
+					},
+					"selector": map[string]any{
+						"type":        "string",
+						"description": "Capture specific element by CSS selector (screenshot)",
+					},
+					"wait_for_stable": map[string]any{
+						"type":        "boolean",
+						"description": "Wait for layout to stabilize before capture (screenshot)",
 					},
 				},
 				"required": []string{"what"},
@@ -440,7 +466,7 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 				"properties": map[string]any{
 					"action": map[string]any{
 						"type": "string",
-						"enum": []string{"store", "load", "noise_rule", "clear", "health", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "diff_sessions", "audit_log"},
+						"enum": []string{"store", "load", "noise_rule", "clear", "health", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log"},
 					},
 					"telemetry_mode": map[string]any{
 						"type":        "string",
@@ -812,6 +838,8 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"get_text", "get_value", "get_attribute",
 							"set_attribute", "focus", "scroll_to", "wait_for", "key_press", "paste",
 							"list_interactive",
+							"get_readable", "get_markdown",
+							"navigate_and_wait_for", "fill_form_and_submit", "run_a11y_and_export_sarif",
 							"record_start", "record_stop",
 							"upload", "draw_mode_start",
 						},
@@ -836,6 +864,14 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					"selector": map[string]any{
 						"type":        "string",
 						"description": "CSS or semantic selector for target element",
+					},
+					"index": map[string]any{
+						"type":        "number",
+						"description": "Element index from list_interactive results (alternative to selector)",
+					},
+					"visible_only": map[string]any{
+						"type":        "boolean",
+						"description": "Only return visible elements (list_interactive)",
 					},
 					"frame": map[string]any{
 						"description": "Target iframe: CSS selector, 0-based index, or \"all\"",
@@ -906,6 +942,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"type":        "string",
 						"description": "URL (navigate, new_tab)",
 					},
+					"include_content": map[string]any{
+						"type":        "boolean",
+						"description": "Return page content with navigate response (url, title, text_content, vitals)",
+					},
 					"tab_id": map[string]any{
 						"type":        "number",
 						"description": "Tab ID (default: active)",
@@ -941,6 +981,35 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					"escalation_timeout_ms": map[string]any{
 						"type":        "number",
 						"description": "Upload escalation timeout in ms",
+					},
+					"fields": map[string]any{
+						"type":        "array",
+						"description": "Form fields to fill (fill_form_and_submit)",
+						"items": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"selector": map[string]any{"type": "string", "description": "CSS selector for the field"},
+								"value":    map[string]any{"type": "string", "description": "Value to type into the field"},
+								"index":    map[string]any{"type": "number", "description": "Element index from list_interactive (alternative to selector)"},
+							},
+							"required": []string{"value"},
+						},
+					},
+					"submit_selector": map[string]any{
+						"type":        "string",
+						"description": "Submit button selector (fill_form_and_submit)",
+					},
+					"submit_index": map[string]any{
+						"type":        "number",
+						"description": "Submit button index from list_interactive (fill_form_and_submit)",
+					},
+					"wait_for": map[string]any{
+						"type":        "string",
+						"description": "CSS selector to wait for after navigation (navigate_and_wait_for)",
+					},
+					"save_to": map[string]any{
+						"type":        "string",
+						"description": "File path to save output (run_a11y_and_export_sarif)",
 					},
 				},
 				"required": []string{"action"},


### PR DESCRIPTION
## Summary

- **#57**: Generate API strict param validation — rejects unknown params per format, adds reason/hint to empty outputs
- **#67**: `observe(errors/logs)` scope filtering — `scope=current_page` (default) filters by tracked tab, `scope=all` for everything
- **#60**: `configure(describe_capabilities)` — machine-readable capabilities endpoint derived from tool schemas
- **#65**: Verified existing `page_summary` implementation matches spec (no changes needed)
- **#63**: Navigate `include_content` param — returns url, title, text_content, and vitals in one call
- **#66**: Screenshot improvements — `format`, `quality`, `full_page`, `selector`, `wait_for_stable` params with validation
- **#68**: Indexed `list_interactive` — element index store maps index→selector, `index` param on DOM primitives, `visible_only` filtering
- **#64**: `get_readable` and `get_markdown` content extraction — embedded JS IIFEs via execute query (no TS changes)
- **#58**: High-level workflow primitives — `navigate_and_wait_for`, `fill_form_and_submit`, `run_a11y_and_export_sarif` with workflow trace arrays

## Test plan

- [x] `go build ./cmd/dev-console/...` compiles cleanly
- [x] `go vet ./cmd/dev-console/...` passes
- [x] Golden files updated (`UPDATE_GOLDEN=1`)
- [x] All golden tests pass (TestGoldenToolsList, TestGoldenInitialize, etc.)
- [x] Generate validation tests pass (TestGenerateRejectsUnknownParams, TestGenerateAcceptsValidParams, TestGenerateEmptyOutputIncludesReason)
- [x] Workflow tests pass (TestNavigateAndWaitFor_*, TestFillFormAndSubmit_*, TestRunA11yAndExportSARIF_*, TestWorkflowResult_*)
- [x] Helper tests pass (TestIsErrorResponse_*, TestResponseStatus)
- [x] All internal package tests pass
- [ ] Manual end-to-end with connected extension (navigate + content, screenshot formats, list_interactive + click by index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)