### PR TITLE
feat(bridge): fast-path MCP resources + telemetry diagnostics

### DIFF
--- a/cmd/dev-console/bridge_faststart_test.go
+++ b/cmd/dev-console/bridge_faststart_test.go
@@ -12,6 +12,41 @@ import (
 	"time"
 )
 
+func readJSONRPCLine(t *testing.T, reader *bufio.Reader, timeout time.Duration) JSONRPCResponse {
+	t.Helper()
+	lineCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			errCh <- err
+			return
+		}
+		lineCh <- line
+	}()
+
+	select {
+	case line := <-lineCh:
+		var resp JSONRPCResponse
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			t.Fatalf("failed to parse JSON-RPC response: %v", err)
+		}
+		return resp
+	case err := <-errCh:
+		t.Fatalf("failed to read response: %v", err)
+	case <-time.After(timeout):
+		t.Fatalf("timeout waiting for response after %v", timeout)
+	}
+	return JSONRPCResponse{}
+}
+
+func writeJSONRPCLine(t *testing.T, w io.Writer, raw string) {
+	t.Helper()
+	if _, err := w.Write([]byte(raw + "\n")); err != nil {
+		t.Fatalf("failed to write request: %v", err)
+	}
+}
+
 // TestFastStart_InitializeRespondsImmediately verifies that initialize returns
 // within 100ms even when no daemon is running. This is critical for MCP client UX.
 func TestFastStart_InitializeRespondsImmediately(t *testing.T) {
@@ -382,6 +417,229 @@ func TestFastStart_OtherMethodsReturnQuickly(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFastStart_ResourceWorkflowBeforeDaemonReady verifies the recommended startup
+// sequence works without waiting for daemon readiness.
+func TestFastStart_ResourceWorkflowBeforeDaemonReady(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skips server spawn in short mode")
+	}
+
+	binary := buildTestBinary(t)
+	port := findFreePort(t)
+	cmd := startServerCmd(binary, "--bridge", "--port", fmt.Sprintf("%d", port))
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("Failed to get stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("Failed to get stdout pipe: %v", err)
+	}
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start command: %v", err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	reader := bufio.NewReader(stdout)
+
+	start := time.Now()
+	writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"workflow-test","version":"1.0"}}}`)
+	initResp := readJSONRPCLine(t, reader, 5*time.Second)
+	if initResp.Error != nil {
+		t.Fatalf("initialize error: %+v", initResp.Error)
+	}
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
+		t.Fatalf("initialize elapsed = %v, want < 4s", elapsed)
+	}
+
+	start = time.Now()
+	writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"gasoline://capabilities"}}`)
+	capResp := readJSONRPCLine(t, reader, 1*time.Second)
+	if capResp.Error != nil {
+		t.Fatalf("resources/read capabilities error: %+v", capResp.Error)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("resources/read capabilities elapsed = %v, want < 500ms", elapsed)
+	}
+
+	var capResult MCPResourcesReadResult
+	if err := json.Unmarshal(capResp.Result, &capResult); err != nil {
+		t.Fatalf("capabilities result parse error: %v", err)
+	}
+	if len(capResult.Contents) != 1 || capResult.Contents[0].URI != "gasoline://capabilities" {
+		t.Fatalf("capabilities result = %+v, want one capabilities content", capResult)
+	}
+
+	start = time.Now()
+	writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"gasoline://playbook/security"}}`)
+	playbookResp := readJSONRPCLine(t, reader, 1*time.Second)
+	if playbookResp.Error != nil {
+		t.Fatalf("resources/read playbook error: %+v", playbookResp.Error)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("resources/read playbook elapsed = %v, want < 500ms", elapsed)
+	}
+	var playbookResult MCPResourcesReadResult
+	if err := json.Unmarshal(playbookResp.Result, &playbookResult); err != nil {
+		t.Fatalf("playbook result parse error: %v", err)
+	}
+	if len(playbookResult.Contents) != 1 || playbookResult.Contents[0].URI != "gasoline://playbook/security/quick" {
+		t.Fatalf("playbook result = %+v, want canonical security/quick content", playbookResult)
+	}
+
+	// tools/call may return either real data or startup retry text, but must not be protocol error.
+	writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"observe","arguments":{"what":"errors"}}}`)
+	toolResp := readJSONRPCLine(t, reader, 1*time.Second)
+	if toolResp.Error != nil {
+		t.Fatalf("tools/call returned protocol error: %+v", toolResp.Error)
+	}
+}
+
+// TestFastStart_ClientCompatibilityMatrix validates immediate resources/read behavior
+// for multiple MCP clients right after initialize.
+func TestFastStart_ClientCompatibilityMatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skips server spawn in short mode")
+	}
+
+	binary := buildTestBinary(t)
+	clients := []struct {
+		name        string
+		clientName  string
+		clientVer   string
+		playbookURI string
+	}{
+		{name: "claude_code", clientName: "claude-code", clientVer: "1.0", playbookURI: "gasoline://playbook/performance"},
+		{name: "cursor", clientName: "cursor", clientVer: "1.0", playbookURI: "gasoline://playbook/performance_analysis/quick"},
+		{name: "windsurf", clientName: "windsurf", clientVer: "1.0", playbookURI: "gasoline://playbook/accessibility_audit/quick"},
+		{name: "continue", clientName: "continue", clientVer: "1.0", playbookURI: "gasoline://playbook/security_audit/quick"},
+	}
+
+	for _, tc := range clients {
+		t.Run(tc.name, func(t *testing.T) {
+			port := findFreePort(t)
+			cmd := startServerCmd(binary, "--bridge", "--port", fmt.Sprintf("%d", port))
+
+			stdin, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatalf("Failed to get stdin pipe: %v", err)
+			}
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Fatalf("Failed to get stdout pipe: %v", err)
+			}
+			cmd.Stderr = nil
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("Failed to start command: %v", err)
+			}
+			defer func() {
+				_ = stdin.Close()
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}()
+
+			reader := bufio.NewReader(stdout)
+			initReq := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"%s","version":"%s"}}}`, tc.clientName, tc.clientVer)
+			writeJSONRPCLine(t, stdin, initReq)
+			initResp := readJSONRPCLine(t, reader, 5*time.Second)
+			if initResp.Error != nil {
+				t.Fatalf("initialize error: %+v", initResp.Error)
+			}
+
+			start := time.Now()
+			writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"gasoline://capabilities"}}`)
+			capResp := readJSONRPCLine(t, reader, 1*time.Second)
+			if capResp.Error != nil {
+				t.Fatalf("resources/read capabilities error: %+v", capResp.Error)
+			}
+			if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+				t.Fatalf("resources/read capabilities elapsed = %v, want < 500ms", elapsed)
+			}
+
+			playbookReq := fmt.Sprintf(`{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"%s"}}`, tc.playbookURI)
+			writeJSONRPCLine(t, stdin, playbookReq)
+			playbookResp := readJSONRPCLine(t, reader, 1*time.Second)
+			if playbookResp.Error != nil {
+				t.Fatalf("resources/read playbook error: %+v", playbookResp.Error)
+			}
+		})
+	}
+}
+
+// TestFastStart_ResourceWorkflowSoak repeatedly exercises the recommended startup
+// resource workflow to catch timing/race regressions under sustained use.
+func TestFastStart_ResourceWorkflowSoak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skips server spawn in short mode")
+	}
+
+	binary := buildTestBinary(t)
+	port := findFreePort(t)
+	cmd := startServerCmd(binary, "--bridge", "--port", fmt.Sprintf("%d", port))
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("Failed to get stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("Failed to get stdout pipe: %v", err)
+	}
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start command: %v", err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	reader := bufio.NewReader(stdout)
+	writeJSONRPCLine(t, stdin, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"soak-test","version":"1.0"}}}`)
+	initResp := readJSONRPCLine(t, reader, 5*time.Second)
+	if initResp.Error != nil {
+		t.Fatalf("initialize error: %+v", initResp.Error)
+	}
+
+	const iterations = 40
+	start := time.Now()
+	for i := 0; i < iterations; i++ {
+		baseID := 100 + (i * 10)
+		writeJSONRPCLine(t, stdin, fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"resources/read","params":{"uri":"gasoline://capabilities"}}`, baseID))
+		capResp := readJSONRPCLine(t, reader, 1*time.Second)
+		if capResp.Error != nil {
+			t.Fatalf("iteration %d capabilities error: %+v", i, capResp.Error)
+		}
+
+		writeJSONRPCLine(t, stdin, fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"resources/read","params":{"uri":"gasoline://playbook/security_audit/quick"}}`, baseID+1))
+		playbookResp := readJSONRPCLine(t, reader, 1*time.Second)
+		if playbookResp.Error != nil {
+			t.Fatalf("iteration %d playbook error: %+v", i, playbookResp.Error)
+		}
+
+		// Include tool calls intermittently to verify mixed workflow stability.
+		if i%4 == 0 {
+			writeJSONRPCLine(t, stdin, fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"observe","arguments":{"what":"errors"}}}`, baseID+2))
+			toolResp := readJSONRPCLine(t, reader, 1*time.Second)
+			if toolResp.Error != nil {
+				t.Fatalf("iteration %d tools/call protocol error: %+v", i, toolResp.Error)
+			}
+		}
+	}
+	elapsed := time.Since(start)
+	if elapsed > 20*time.Second {
+		t.Fatalf("soak loop elapsed = %v, want <= 20s", elapsed)
+	}
+	t.Logf("soak completed: %d iterations in %v", iterations, elapsed.Round(time.Millisecond))
 }
 
 // TestFastStart_ToolsCallReturnsRetryWhenBooting verifies that tools/call

--- a/cmd/dev-console/cli_test.go
+++ b/cmd/dev-console/cli_test.go
@@ -33,6 +33,7 @@ func TestIsCLIMode(t *testing.T) {
 		{"flag --stop", []string{"--stop"}, false},
 		{"flag --force", []string{"--force"}, false},
 		{"flag --check", []string{"--check"}, false},
+		{"flag --doctor", []string{"--doctor"}, false},
 		{"flag --connect", []string{"--connect"}, false},
 		{"empty args", []string{}, false},
 		{"unknown word", []string{"foobar"}, false},
@@ -468,13 +469,13 @@ func TestParseCLIArgsDispatch(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		tool     string
-		action   string
-		args     []string
-		wantKey  string
-		wantVal  any
-		wantErr  bool
+		name    string
+		tool    string
+		action  string
+		args    []string
+		wantKey string
+		wantVal any
+		wantErr bool
 	}{
 		{"observe errors", "observe", "errors", nil, "what", "errors", false},
 		{"generate har", "generate", "har", nil, "format", "har", false},

--- a/cmd/dev-console/handler_unit_test.go
+++ b/cmd/dev-console/handler_unit_test.go
@@ -316,14 +316,18 @@ func TestMCPHandlerResourceAndToolMethods(t *testing.T) {
 		t.Fatalf("resources/read security playbook result = %+v, want security playbook content entry", readSecurityPlaybookData)
 	}
 
-	readInvalidPlaybook := h.HandleRequest(JSONRPCRequest{
+	readAliasedPlaybook := h.HandleRequest(JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      63,
 		Method:  "resources/read",
-		Params:  json.RawMessage(`{"uri":"gasoline://playbook/nonexistent/quick"}`),
+		Params:  json.RawMessage(`{"uri":"gasoline://playbook/security_audit/quick"}`),
 	})
-	if readInvalidPlaybook == nil || readInvalidPlaybook.Error == nil || readInvalidPlaybook.Error.Code != -32002 {
-		t.Fatalf("resources/read invalid playbook response = %+v, want -32002 error", readInvalidPlaybook)
+	if readAliasedPlaybook == nil || readAliasedPlaybook.Error != nil {
+		t.Fatalf("resources/read aliased playbook response = %+v, want success", readAliasedPlaybook)
+	}
+	readAliasedPlaybookData := mustDecodeJSON[MCPResourcesReadResult](t, readAliasedPlaybook.Result)
+	if len(readAliasedPlaybookData.Contents) != 1 || readAliasedPlaybookData.Contents[0].URI != "gasoline://playbook/security/quick" {
+		t.Fatalf("resources/read aliased playbook result = %+v, want canonical security/quick content entry", readAliasedPlaybookData)
 	}
 
 	readBareCapability := h.HandleRequest(JSONRPCRequest{
@@ -332,13 +336,27 @@ func TestMCPHandlerResourceAndToolMethods(t *testing.T) {
 		Method:  "resources/read",
 		Params:  json.RawMessage(`{"uri":"gasoline://playbook/security"}`),
 	})
-	if readBareCapability == nil || readBareCapability.Error == nil || readBareCapability.Error.Code != -32002 {
-		t.Fatalf("resources/read bare capability response = %+v, want -32002 error (level required)", readBareCapability)
+	if readBareCapability == nil || readBareCapability.Error != nil {
+		t.Fatalf("resources/read bare capability response = %+v, want success defaulting to quick", readBareCapability)
+	}
+	readBareCapabilityData := mustDecodeJSON[MCPResourcesReadResult](t, readBareCapability.Result)
+	if len(readBareCapabilityData.Contents) != 1 || readBareCapabilityData.Contents[0].URI != "gasoline://playbook/security/quick" {
+		t.Fatalf("resources/read bare capability result = %+v, want canonical security/quick content entry", readBareCapabilityData)
+	}
+
+	readInvalidPlaybook := h.HandleRequest(JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      65,
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"gasoline://playbook/nonexistent/quick"}`),
+	})
+	if readInvalidPlaybook == nil || readInvalidPlaybook.Error == nil || readInvalidPlaybook.Error.Code != -32002 {
+		t.Fatalf("resources/read invalid playbook response = %+v, want -32002 error", readInvalidPlaybook)
 	}
 
 	readInvalidDemo := h.HandleRequest(JSONRPCRequest{
 		JSONRPC: "2.0",
-		ID:      65,
+		ID:      66,
 		Method:  "resources/read",
 		Params:  json.RawMessage(`{"uri":"gasoline://demo/nonexistent"}`),
 	})

--- a/cmd/dev-console/mcp_resources.go
+++ b/cmd/dev-console/mcp_resources.go
@@ -1,0 +1,42 @@
+// mcp_resources.go — Shared MCP resource and template catalogs for handler and bridge fast path.
+package main
+
+func mcpResources() []MCPResource {
+	return []MCPResource{
+		{
+			URI:         "gasoline://capabilities",
+			Name:        "Gasoline Capability Index",
+			Description: "Compact capability index with task-to-playbook routing hints",
+			MimeType:    "text/markdown",
+		},
+		{
+			URI:         "gasoline://guide",
+			Name:        "Gasoline Usage Guide",
+			Description: "How to use Gasoline MCP tools for browser debugging",
+			MimeType:    "text/markdown",
+		},
+		{
+			URI:         "gasoline://quickstart",
+			Name:        "Gasoline MCP Quickstart",
+			Description: "Short, canonical MCP call examples and workflows",
+			MimeType:    "text/markdown",
+		},
+	}
+}
+
+func mcpResourceTemplates() []any {
+	return []any{
+		map[string]any{
+			"uriTemplate": "gasoline://playbook/{capability}/{level}",
+			"name":        "Gasoline Capability Playbook",
+			"description": "On-demand, token-efficient playbooks. Start with quick; use full for deep workflows.",
+			"mimeType":    "text/markdown",
+		},
+		map[string]any{
+			"uriTemplate": "gasoline://demo/{name}",
+			"name":        "Gasoline Demo Script",
+			"description": "Demo scripts for websockets, annotations, recording, and dependency vetting",
+			"mimeType":    "text/markdown",
+		},
+	}
+}

--- a/cmd/dev-console/server_routes.go
+++ b/cmd/dev-console/server_routes.go
@@ -395,6 +395,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request, cap *captu
 			"dropped_count": s.getLogDropCount(),
 		},
 	}
+	successReads, failedReads := snapshotFastPathResourceReadCounters()
+	resp["bridge_fastpath"] = map[string]any{
+		"resources_read_success": successReads,
+		"resources_read_failure": failedReads,
+	}
 	if availVer != "" {
 		resp["available_version"] = availVer
 	}

--- a/cmd/dev-console/server_routes_health_fastpath_test.go
+++ b/cmd/dev-console/server_routes_health_fastpath_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	statecfg "github.com/dev-console/dev-console/internal/state"
+)
+
+func TestHandleHealthIncludesBridgeFastPathCounters(t *testing.T) {
+	t.Setenv(statecfg.StateDirEnv, t.TempDir())
+	resetFastPathResourceReadCounters()
+	recordFastPathResourceRead("gasoline://capabilities", true, 0)
+	recordFastPathResourceRead("gasoline://playbook/nonexistent/quick", false, -32002)
+
+	s := &Server{
+		maxEntries: 100,
+		logFile:    filepath.Join(t.TempDir(), "gasoline.jsonl"),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	s.handleHealth(rr, req, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handleHealth status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json.Unmarshal(health) error = %v", err)
+	}
+	fastPath, ok := body["bridge_fastpath"].(map[string]any)
+	if !ok {
+		t.Fatalf("bridge_fastpath missing or wrong type: %#v", body["bridge_fastpath"])
+	}
+	if got, _ := fastPath["resources_read_success"].(float64); int(got) != 1 {
+		t.Fatalf("resources_read_success = %v, want 1", fastPath["resources_read_success"])
+	}
+	if got, _ := fastPath["resources_read_failure"].(float64); int(got) != 1 {
+		t.Fatalf("resources_read_failure = %v, want 1", fastPath["resources_read_failure"])
+	}
+}


### PR DESCRIPTION
## Summary
- Serve resources/list, resources/templates/list, and resources/read from bridge fast-path during startup.
- Centralize MCP resources/templates in a shared catalog (mcp_resources.go) so bridge and handler stay in sync.
- Canonicalize playbook aliases (security_audit, performance_analysis, etc.) and default bare capability URIs to /quick.
- Add bridge fast-path resources/read telemetry counters and JSONL logging.
- Expose fast-path counters in /health and include telemetry summary in --check/--doctor.

## Tests
- GOCACHE=/tmp/gocache go test ./cmd/dev-console -run "TestBridgeFastPathCoreMethods|TestBridgeFastPathResourcesReadCanonicalizesPlaybookAliases|TestBridgeFastPathResourcesReadFailureTelemetry|TestBridgeFastPathResourcesReadTelemetryPersistsToStateLogs|TestFastStart_ResourceWorkflowBeforeDaemonReady|TestFastStart_ClientCompatibilityMatrix|TestHandleHealthIncludesBridgeFastPathCounters|TestRunSetupCheckIncludesFastPathTelemetrySummary|TestMCPHandlerResourceAndToolMethods" -count=1