### PR TITLE
feat: client registry for multi-client install (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Go tests with race detection
         run: go test -race -v ./cmd/dev-console/...
 
+      - name: Reliability soak gate (bridge fast-start)
+        run: |
+          STATE_DIR="$(mktemp -d)"
+          echo "Using state dir: ${STATE_DIR}"
+          GASOLINE_STATE_DIR="${STATE_DIR}" go test -race ./cmd/dev-console -run TestFastStart_ResourceWorkflowSoak -count=3 -timeout=12m
+          go run ./cmd/dev-console --check --state-dir "${STATE_DIR}" --fastpath-min-samples 100 --fastpath-max-failure-ratio 0.02
+
       - name: Go test coverage (70% minimum)
         run: |
           go test -coverprofile=coverage.out ./cmd/dev-console/...

--- a/cmd/dev-console/cli_test.go
+++ b/cmd/dev-console/cli_test.go
@@ -34,6 +34,8 @@ func TestIsCLIMode(t *testing.T) {
 		{"flag --force", []string{"--force"}, false},
 		{"flag --check", []string{"--check"}, false},
 		{"flag --doctor", []string{"--doctor"}, false},
+		{"flag --fastpath-min-samples", []string{"--fastpath-min-samples", "20"}, false},
+		{"flag --fastpath-max-failure-ratio", []string{"--fastpath-max-failure-ratio", "0.05"}, false},
 		{"flag --connect", []string{"--connect"}, false},
 		{"empty args", []string{}, false},
 		{"unknown word", []string{"foobar"}, false},

--- a/cmd/dev-console/noise_autorun.go
+++ b/cmd/dev-console/noise_autorun.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dev-console/dev-console/internal/ai"
+	"github.com/dev-console/dev-console/internal/util"
 )
 
 // noiseAutoDetectInterval is the minimum time between automatic noise detection runs.
@@ -61,7 +62,7 @@ func (r *noiseAutoRunner) schedule() {
 		// Enough time has passed — run immediately in background
 		r.pending = true
 		r.mu.Unlock()
-		go r.run()
+		util.SafeGo(r.run)
 		return
 	}
 
@@ -70,10 +71,10 @@ func (r *noiseAutoRunner) schedule() {
 	delay := r.interval - elapsed
 	r.mu.Unlock()
 
-	go func() {
+	util.SafeGo(func() {
 		time.Sleep(delay)
 		r.run()
-	}()
+	})
 }
 
 // run executes the function and resets the debounce state.

--- a/cmd/dev-console/tools_interact_audit_test.go
+++ b/cmd/dev-console/tools_interact_audit_test.go
@@ -48,11 +48,38 @@ func newInteractTestEnv(t *testing.T) *interactTestEnv {
 	return &interactTestEnv{handler: handler, server: server, capture: cap}
 }
 
+func normalizeInteractArgsForAsync(argsJSON string) json.RawMessage {
+	raw := json.RawMessage(argsJSON)
+
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return raw
+	}
+	if _, hasAction := params["action"]; !hasAction {
+		return raw
+	}
+	if _, hasBackground := params["background"]; hasBackground {
+		return raw
+	}
+	if _, hasSync := params["sync"]; hasSync {
+		return raw
+	}
+	if _, hasWait := params["wait"]; hasWait {
+		return raw
+	}
+
+	params["background"] = true
+	if normalized, err := json.Marshal(params); err == nil {
+		return json.RawMessage(normalized)
+	}
+	return raw
+}
+
 // callInteract invokes the interact tool and returns parsed result
 func (e *interactTestEnv) callInteract(t *testing.T, argsJSON string) (MCPToolResult, bool) {
 	t.Helper()
 
-	args := json.RawMessage(argsJSON)
+	args := normalizeInteractArgsForAsync(argsJSON)
 	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
 	resp := e.handler.toolInteract(req, args)
 

--- a/cmd/dev-console/tools_interact_helpers_test.go
+++ b/cmd/dev-console/tools_interact_helpers_test.go
@@ -149,6 +149,7 @@ func TestQueueStateNavigation_QueuesBrowserAction(t *testing.T) {
 	t.Parallel()
 	env := newInteractHelpersTestEnv(t)
 	env.enablePilot(t)
+	simulateExtensionConnection(t, env)
 
 	stateData := map[string]any{
 		"url":   "https://example.com/page",
@@ -275,6 +276,7 @@ func TestQueueStateNavigation_CorrelationIDHasNavPrefix(t *testing.T) {
 	t.Parallel()
 	env := newInteractHelpersTestEnv(t)
 	env.enablePilot(t)
+	simulateExtensionConnection(t, env)
 
 	stateData := map[string]any{
 		"url": "https://example.com",

--- a/cmd/dev-console/tools_observe_analysis.go
+++ b/cmd/dev-console/tools_observe_analysis.go
@@ -702,14 +702,16 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "expired":
 		responseData["final"] = true
-		responseData["error"] = fmt.Sprintf("Command %s expired before the extension could execute it. Error: %s", corrID, cmd.Error)
+		responseData["error"] = ErrExtTimeout
+		responseData["message"] = fmt.Sprintf("Command %s expired before the extension could execute it. Error: %s", corrID, cmd.Error)
 		responseData["retry"] = "The browser extension may be disconnected or the page is not active. Check observe with what='pilot' to verify extension status, then retry the command."
 		responseData["hint"] = h.diagnosticHintString()
 		summary := fmt.Sprintf("FAILED — Command %s expired: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "timeout":
 		responseData["final"] = true
-		responseData["error"] = fmt.Sprintf("Command %s timed out waiting for the extension to respond. Error: %s", corrID, cmd.Error)
+		responseData["error"] = ErrExtTimeout
+		responseData["message"] = fmt.Sprintf("Command %s timed out waiting for the extension to respond. Error: %s", corrID, cmd.Error)
 		responseData["retry"] = "The command took too long. The page may be unresponsive or the action is stuck. Try refreshing the page with interact action='refresh', then retry."
 		responseData["hint"] = h.diagnosticHintString()
 		summary := fmt.Sprintf("FAILED — Command %s timed out: %s", corrID, cmd.Error)

--- a/cmd/dev-console/tools_observe_analysis.go
+++ b/cmd/dev-console/tools_observe_analysis.go
@@ -652,14 +652,26 @@ func (h *ToolHandler) toolObserveCommandResult(req JSONRPCRequest, args json.Raw
 	if strings.HasPrefix(corrID, "ann_") {
 		cmd, found := h.capture.WaitForCommand(corrID, annotationCommandWaitTimeout)
 		if !found {
-			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrNoData, "Annotation command not found: "+corrID, "The command may have expired (10 min TTL). Start a new draw mode session.", h.diagnosticHint())}
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+				ErrNoData,
+				"Annotation command not found: "+corrID,
+				"The command may have expired (10 min TTL). Start a new draw mode session.",
+				withFinal(true),
+				h.diagnosticHint(),
+			)}
 		}
 		return h.formatCommandResult(req, *cmd, corrID)
 	}
 
 	cmd, found := h.capture.GetCommandResult(corrID)
 	if !found {
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrNoData, "Command not found: "+corrID, "The command may have already completed and been cleaned up (60s TTL), or the correlation_id is invalid. Use observe with what='pending_commands' to see active commands.", h.diagnosticHint())}
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+			ErrNoData,
+			"Command not found: "+corrID,
+			"The command may have already completed and been cleaned up (60s TTL), or the correlation_id is invalid. Use observe with what='pending_commands' to see active commands.",
+			withFinal(true),
+			h.diagnosticHint(),
+		)}
 	}
 
 	return h.formatCommandResult(req, *cmd, corrID)
@@ -669,6 +681,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 	responseData := map[string]any{
 		"correlation_id": cmd.CorrelationID,
 		"status":         cmd.Status,
+		"queued":         false,
 		"created_at":     cmd.CreatedAt.Format(time.RFC3339),
 	}
 
@@ -688,19 +701,19 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		summary := fmt.Sprintf("FAILED — Command %s error: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "expired":
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
-			ErrExtTimeout,
-			fmt.Sprintf("Command %s expired before the extension could execute it. Error: %s", corrID, cmd.Error),
-			"The browser extension may be disconnected or the page is not active. Check observe with what='pilot' to verify extension status, then retry the command.",
-			h.diagnosticHint(),
-		)}
+		responseData["final"] = true
+		responseData["error"] = fmt.Sprintf("Command %s expired before the extension could execute it. Error: %s", corrID, cmd.Error)
+		responseData["retry"] = "The browser extension may be disconnected or the page is not active. Check observe with what='pilot' to verify extension status, then retry the command."
+		responseData["hint"] = h.diagnosticHintString()
+		summary := fmt.Sprintf("FAILED — Command %s expired: %s", corrID, cmd.Error)
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "timeout":
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
-			ErrExtTimeout,
-			fmt.Sprintf("Command %s timed out waiting for the extension to respond. Error: %s", corrID, cmd.Error),
-			"The command took too long. The page may be unresponsive or the action is stuck. Try refreshing the page with interact action='refresh', then retry.",
-			h.diagnosticHint(),
-		)}
+		responseData["final"] = true
+		responseData["error"] = fmt.Sprintf("Command %s timed out waiting for the extension to respond. Error: %s", corrID, cmd.Error)
+		responseData["retry"] = "The command took too long. The page may be unresponsive or the action is stuck. Try refreshing the page with interact action='refresh', then retry."
+		responseData["hint"] = h.diagnosticHintString()
+		summary := fmt.Sprintf("FAILED — Command %s timed out: %s", corrID, cmd.Error)
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	default:
 		responseData["final"] = false
 		summary := fmt.Sprintf("Command %s: %s", corrID, cmd.Status)

--- a/docs/architecture/diagrams/c2-containers.md
+++ b/docs/architecture/diagrams/c2-containers.md
@@ -124,7 +124,7 @@ graph TB
 - **Port:** localhost:7890 (default, configurable)
 - **Components:**
   - **MCP Handler** - JSON-RPC 2.0 request routing
-  - **4 Tools** - observe, generate, interact, configure
+  - **5 Tools** - observe, generate, interact, configure, analyze
   - **Capture Manager** - Telemetry ring buffers, memory enforcement
   - **Session Manager** - Multi-client isolation, token verification
 - **Key Files:**

--- a/docs/core/comprehensive-uat-plan.md
+++ b/docs/core/comprehensive-uat-plan.md
@@ -35,14 +35,14 @@ These tests verify MCP JSON-RPC 2.0 correctness. Failures here mean no MCP clien
 | **Assert** | `response.result.capabilities.tools` exists, `response.result.serverInfo.name == "gasoline-mcp"`, `response.result.serverInfo.version` matches VERSION file |
 | **Trust because** | If capabilities are wrong, Claude/Cursor won't know what tools exist. Version mismatch means wrong binary is installed. |
 
-### 1.2 — tools/list returns exactly 4 tools
+### 1.2 — tools/list returns exactly 5 tools
 
 | Field | Value |
 |-------|-------|
 | **Type** | Contract |
 | **What** | Send `tools/list`, extract tool names |
-| **Assert** | Exactly `["observe", "generate", "configure", "interact"]` — no more, no less. Count == 4. |
-| **Trust because** | We shipped stub tools before (analyze, etc). This catches tool creep. Exact-match means no extras sneak in. |
+| **Assert** | Exactly `["observe", "generate", "configure", "interact", "analyze"]` — no more, no less. Count == 5. |
+| **Trust because** | Exact-match means no extras sneak in and no tools are missing. |
 
 ### 1.3 — tools/list schema shapes are valid
 
@@ -625,7 +625,7 @@ Each mode must return a valid response shape, even with no data.
 |-------|-------|
 | **Type** | Load |
 | **What** | Fork 10 processes, each sends `tools/list` simultaneously |
-| **Assert** | All 10 get valid responses with 4 tools each. Zero failures. |
+| **Assert** | All 10 get valid responses with 5 tools each. Zero failures. |
 | **Trust because** | Real usage has multiple MCP clients (Claude + Cursor + CI). Must handle concurrency. |
 
 ### 7.2 — Rapid sequential tool calls don't crash

--- a/docs/core/mcp-correctness.md
+++ b/docs/core/mcp-correctness.md
@@ -37,7 +37,7 @@ Gasoline MCP implements [Model Context Protocol](https://modelcontextprotocol.io
 ## Key Implementation Details
 
 **Capabilities declared:**
-- `tools` — 4 tools: observe, generate, configure, interact
+- `tools` — 5 tools: observe, generate, configure, interact, analyze
 - `resources` — 2 resources: `gasoline://guide`, `gasoline://quickstart`
 - `resourceTemplates` — 1 template: `gasoline://demo/{name}`
 

--- a/docs/features/cli-interface/tech-spec.md
+++ b/docs/features/cli-interface/tech-spec.md
@@ -31,7 +31,7 @@ gasoline-cmd (separate binary)
   └─ Returns JSON/human/CSV output
 
 gasoline-mcp (existing MCP server)
-  ├─ 4 tools: observe, generate, configure, interact
+  ├─ 5 tools: observe, generate, configure, interact, analyze
   ├─ Unchanged from MCP perspective
   └─ Serves both extension + CLI clients
 ```
@@ -679,7 +679,7 @@ shell.exec("gasoline-cmd interact upload --selector '#File' --file-path ./video.
 
 ## References
 
-- [CLAUDE.md](../../CLAUDE.md) — Core rules (TDD, no deps, 4 tools only)
+- [CLAUDE.md](../../CLAUDE.md) — Core rules (TDD, no deps, 5 tools only)
 - [upload/tech-spec.md](../file-upload/tech-spec.md) — Upload feature
 - Unix Philosophy: Do one thing, do it well
 - Exit codes: [POSIX Standard](https://en.wikipedia.org/wiki/Exit_status)

--- a/docs/features/feature/agentic-e2e-repair/qa-plan.md
+++ b/docs/features/feature/agentic-e2e-repair/qa-plan.md
@@ -232,7 +232,7 @@ Since Agentic E2E Repair is a workflow pattern (not new server code), unit tests
 ### Regression Checks
 - [ ] All individual MCP tools (observe, generate, configure, interact) work normally outside the repair workflow
 - [ ] Extension capture behavior unaffected by the repair workflow
-- [ ] No new MCP tools created (still exactly 4 tools — observe, generate, configure, interact)
+- [ ] No new MCP tools created (still exactly 5 tools — observe, generate, configure, interact, analyze)
 - [ ] Server performance unaffected by the multi-tool orchestration pattern
 - [ ] Existing test generation (`generate({type: "test"})`) still works for non-repair use cases
 

--- a/docs/features/feature/enhanced-cli-config/product-spec.md
+++ b/docs/features/feature/enhanced-cli-config/product-spec.md
@@ -14,7 +14,7 @@ last_reviewed: 2026-02-16
 ## Problem Statement
 
 Users installing Gasoline MCP (via NPM or PyPI) need to:
-1. Configure it across multiple AI assistant tools (Claude Desktop, VSCode, Cursor, Codeium)
+1. Configure it across multiple AI assistant clients (Claude Code, Claude Desktop, VS Code, Cursor, Windsurf)
 2. Verify the configuration is correct before committing changes
 3. Diagnose connection/installation issues when things go wrong
 4. Manage environment variables for different deployment scenarios
@@ -23,14 +23,14 @@ Users installing Gasoline MCP (via NPM or PyPI) need to:
 The current implementation (`--config`, `--install`) is functional but incomplete in both wrappers:
 - **No preview mode**: Users can't see what changes will be made before committing
 - **No diagnostics**: When installation fails, users have no way to troubleshoot
-- **Single-tool support**: Only first matching config file gets updated; other tools left out
+- **Single-client support**: Only first matching config file gets updated; other clients left out
 - **No verification**: No way to confirm the config is actually working
 - **No environment variables**: Can't inject custom env vars (e.g., API keys, server URLs) into MCP config
 - **Limited error recovery**: Confusing error messages when JSON is malformed or permissions denied
 
 ## Solution
 
-Enhance the gasoline-mcp CLI with five new features:
+Enhance the gasoline-mcp CLI with four new features:
 
 ### 1. **Dry-Run Mode** (`--dry-run`)
 Preview exactly what changes will be made without actually writing files. Shows:
@@ -41,23 +41,16 @@ Preview exactly what changes will be made without actually writing files. Shows:
 
 ### 2. **Doctor Command** (`--doctor`)
 Diagnostic tool that verifies local configuration:
-- Checks all 4 config file locations and their JSON validity
+- Checks all 5 client configs and their JSON validity
 - Verifies gasoline entry is present in each config
 - Confirms gasoline binary path resolves and is executable
 - Tests basic binary invocation (runs `gasoline --version`)
-- Reports which tools are configured, which aren't
+- Reports which clients are configured, which aren't
+- Detects legacy config paths and warns about orphaned configs
 - Provides actionable repair suggestions for fixable issues
-- **Note**: Cannot test actual MCP connection without AI agent running (VSCode, Claude, etc.)
+- **Note**: Cannot test actual MCP connection without AI agent running (VS Code, Claude, etc.)
 
-### 3. **Multi-Tool Install** (`--install --for-all`)
-Instead of stopping at first config, update ALL detected config files:
-- Find and update Claude Desktop config
-- Find and update VSCode config
-- Find and update Cursor config
-- Find and update Codeium config
-- Report which tools were updated
-
-### 4. **Environment Variables** (`--install --env KEY=VALUE`)
+### 3. **Environment Variables** (`--install --env KEY=VALUE`)
 Allow injecting environment variables into MCP config:
 - `--env GASOLINE_SERVER=http://localhost:7890`
 - `--env DEBUG=1`
@@ -65,12 +58,12 @@ Allow injecting environment variables into MCP config:
 - Saved in `env` object of MCP config
 - Useful for custom server URLs, debug modes, offline deployments
 
-### 5. **Uninstall Command** (`--uninstall`)
+### 4. **Uninstall Command** (`--uninstall`)
 Remove Gasoline from AI assistant configs:
-- Find gasoline entry in all config files
+- Find gasoline entry in all detected client configs
 - Remove it cleanly (preserve other MCP servers)
 - Confirm removal before writing
-- Report which tools were cleaned up
+- Report which clients were cleaned up
 
 ## Requirements
 
@@ -81,6 +74,7 @@ Remove Gasoline from AI assistant configs:
 5. **Composable**: `--dry-run` works with `--install`, `--uninstall`, `--doctor`
 6. **Verbose**: `--verbose` flag shows detailed operation logs
 7. **Recovery**: Commands provide next-step suggestions on failure
+8. **Multi-client**: `--install` targets all detected clients by default
 
 ## Out of Scope
 
@@ -94,7 +88,7 @@ Remove Gasoline from AI assistant configs:
 
 1. ✅ `--dry-run` shows exact changes without writing files
 2. ✅ `--doctor` diagnoses 90%+ of common config issues
-3. ✅ `--for-all` successfully updates all 4 tool configs in one run
+3. ✅ `--install` auto-detects and installs to all 5 supported clients
 4. ✅ `--env KEY=VALUE` properly saves env vars to config
 5. ✅ `--uninstall` cleanly removes gasoline from all configs
 6. ✅ All commands provide actionable error messages with recovery steps
@@ -106,30 +100,32 @@ Remove Gasoline from AI assistant configs:
 
 ### Workflow 1: Safe Installation
 ```
-User wants to try Gasoline on their VSCode but isn't sure what will change
+User wants to try Gasoline on their VS Code but isn't sure what will change
 
 1. User runs:   gasoline-mcp --config
-2. Sees:        Config template + 4 tool locations
+2. Sees:        Detected clients + config status for each
 3. User runs:   gasoline-mcp --install --dry-run
-4. Sees:        Exact JSON changes, which file would be modified
+4. Sees:        Exact JSON changes for each detected client
 5. User runs:   gasoline-mcp --install
-6. Sees:        ✅ Updated: ~/.claude/claude.mcp.json
+6. Sees:        ✅ Installed to all detected clients
 7. User runs:   gasoline-mcp --doctor
-8. Sees:        ✅ Gasoline configured in Claude Desktop
-                ❌ Not configured in VSCode, Cursor, Codeium
+8. Sees:        ✅ Gasoline configured in Claude Code, Cursor
+                ⚪ Claude Desktop not detected
+                ⚪ Windsurf not detected
 ```
 
-### Workflow 2: Multi-Tool Install
+### Workflow 2: Multi-Client Install
 ```
 User wants Gasoline available in all AI assistants
 
-1. User runs:   gasoline-mcp --install --for-all
-2. Sees:        ✅ Claude Desktop: Updated
-                ✅ VSCode: Updated
+1. User runs:   gasoline-mcp --install
+2. Sees:        ✅ Claude Code: Installed (via CLI)
+                ✅ Claude Desktop: Updated
                 ✅ Cursor: Updated
-                ✅ Codeium: Updated
+                ✅ Windsurf: Updated
+                ✅ VS Code: Updated
 3. User runs:   gasoline-mcp --doctor
-4. Sees:        ✅ All 4 tools configured and connected
+4. Sees:        ✅ All 5 clients configured
 ```
 
 ### Workflow 3: Environment Variables
@@ -137,7 +133,7 @@ User wants Gasoline available in all AI assistants
 User needs to point Gasoline at custom server URL
 
 1. User runs:   gasoline-mcp --install --env GASOLINE_SERVER=http://192.168.1.100:7890
-2. Sees:        ✅ Updated: ~/.claude/claude.mcp.json
+2. Sees:        ✅ Installed to all detected clients
 3. Config has:  "env": { "GASOLINE_SERVER": "http://192.168.1.100:7890" }
 ```
 
@@ -149,26 +145,26 @@ User says "It's not working, can you check?"
 2. Sees:
                 Gasoline MCP Diagnostic Report
 
-                ✅ Claude Desktop
-                   ~/.claude/claude.mcp.json - Configured and ready
-
-                ❌ VSCode
-                   ~/.vscode/claude.mcp.json - gasoline entry missing
-                   Fix: gasoline-mcp --install --for-all
+                ✅ Claude Code
+                   Configured via CLI
 
                 ✅ Cursor
                    ~/.cursor/mcp.json - Configured and ready
 
-                ⚠️  Codeium
-                   ~/.codeium/mcp.json - Invalid JSON at line 5
+                ⚠️  Windsurf
+                   ~/.codeium/windsurf/mcp_config.json - Invalid JSON at line 5
                    Fix: Manually edit or restore from backup
-                       code ~/.codeium/mcp.json
+
+                ⚪ Claude Desktop
+                   Not detected
+
+                ⚪ VS Code
+                   Not detected
 
                 ✅ Binary check
                    Gasoline binary found at /usr/local/bin/gasoline
-                   Version: v5.3.0
 
-                Summary: 2 tools ready, 1 needs repair, 1 not configured
+                Summary: 2 clients ready, 1 needs repair, 2 not detected
 
 3. User gets:   Actionable next steps for each issue
 ```
@@ -179,35 +175,31 @@ User wants to remove Gasoline from all configs
 
 1. User runs:   gasoline-mcp --uninstall --dry-run
 2. Sees:        Would remove gasoline from:
-                - ~/.claude/claude.mcp.json
-                - ~/.vscode/claude.mcp.json
+                - Claude Code (via CLI)
+                - ~/.cursor/mcp.json
 3. User runs:   gasoline-mcp --uninstall
-4. Sees:        ✅ Removed from 2 tools
-                ℹ️  Not configured in Cursor, Codeium
+4. Sees:        ✅ Removed from 2 clients
 ```
 
 ## Examples
 
 ### Basic Commands
 ```bash
-# Show current config template
+# Show detected clients and config status
 gasoline-mcp --config
 
-# Install to first matching config
+# Install to all detected clients
 gasoline-mcp --install
-# Output: ✅ Installed Gasoline to Claude Desktop at ~/.claude/claude.mcp.json
+# Output:
+# ✅ 5/5 clients installed:
+#    ✅ Claude Code (via CLI)
+#    ✅ Claude Desktop (at ~/Library/Application Support/Claude/claude_desktop_config.json)
+#    ✅ Cursor (at ~/.cursor/mcp.json)
+#    ✅ Windsurf (at ~/.codeium/windsurf/mcp_config.json)
+#    ✅ VS Code (at ~/Library/Application Support/Code/User/mcp.json)
 
 # Preview what --install would do (no files written)
 gasoline-mcp --install --dry-run
-
-# Install to ALL 4 detected tools
-gasoline-mcp --install --for-all
-# Output:
-# ✅ 4/4 tools updated:
-#    ✅ Claude Desktop (at ~/.claude/claude.mcp.json)
-#    ✅ VSCode (at ~/.vscode/claude.mcp.json)
-#    ✅ Cursor (at ~/.cursor/mcp.json)
-#    ✅ Codeium (at ~/.codeium/mcp.json)
 ```
 
 ### Environment Variables
@@ -256,17 +248,17 @@ gasoline-mcp --install --env BADFORMAT
 
 # Error: Permission denied
 gasoline-mcp --install
-# ❌ Error: Permission denied writing ~/.claude/claude.mcp.json
+# ❌ Error: Permission denied writing ~/.cursor/mcp.json
 #    Try: sudo gasoline-mcp --install
-#    Or: Check permissions with: ls -la ~/.claude/
+#    Or: Check permissions with: ls -la ~/.cursor/
 
 # Error: Invalid JSON in config
 gasoline-mcp --install
-# ❌ Error: Invalid JSON in ~/.vscode/claude.mcp.json at line 15
+# ❌ Error: Invalid JSON in ~/.cursor/mcp.json at line 15
 #    Unexpected token }
 #
 #    Fix options:
-#    1. Manually edit: code ~/.vscode/claude.mcp.json
+#    1. Manually edit: code ~/.cursor/mcp.json
 #    2. Restore from backup and try --install again
 #    3. Run: gasoline-mcp --doctor (for more info)
 ```
@@ -276,6 +268,6 @@ gasoline-mcp --install
 - **Distribution**: Both NPM (`npm/gasoline-mcp/`) and PyPI (`pypi/gasoline-mcp/`) wrappers must be updated with feature parity
 - **NPM Entry Point**: `npm/gasoline-mcp/bin/gasoline-mcp` (Node.js)
 - **PyPI Entry Point**: `pypi/gasoline-mcp/gasoline_mcp/__main__.py` (Python)
-- **Related**: `.claude/docs/architecture.md` (4-tool MCP constraint)
+- **Related**: `.claude/docs/architecture.md` (5-tool MCP constraint)
 - **Building on**: v5.2.0 CLI foundation (`--config`, `--install`)
 - **Test reference**: `tests/extension/` (use as model for new tests)

--- a/docs/features/feature/pr-preview-exploration/product-spec.md
+++ b/docs/features/feature/pr-preview-exploration/product-spec.md
@@ -41,7 +41,7 @@ The workflow proceeds in five phases:
 
 ### Architecture: Orchestration, Not a New Tool
 
-This feature strictly follows the Gasoline architecture: **4 tools, no more**. The agent uses existing modes across all four tools:
+This feature strictly follows the Gasoline architecture: **5 tools, no more**. The agent uses existing modes across all five tools:
 
 | Phase | Tool | Mode/Action | Purpose |
 |-------|------|-------------|---------|

--- a/docs/features/feature/self-healing-tests/qa-plan.md
+++ b/docs/features/feature/self-healing-tests/qa-plan.md
@@ -200,7 +200,7 @@ last_reviewed: 2026-02-16
 - [ ] Existing `generate({format: "test"})` still works normally
 - [ ] `configure({action: "query_dom"})` still works as a standalone action
 - [ ] `observe({what: "changes"})` still works independently
-- [ ] No new MCP tools created (still exactly 4 tools)
+- [ ] No new MCP tools created (still exactly 5 tools)
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,20 +39,20 @@ last_reviewed: 2026-02-16
 
 **Symptom**: You added `.mcp.json` to your project but Gasoline uses wrong settings (different port, old path, etc.)
 
-**Cause**: Claude Code has two config levels:
-- **User-level**: `~/.claude.json` → `mcpServers` section (applies globally)
+**Cause**: Claude Code has multiple config levels with a precedence order:
+- **User-level**: Managed via `claude mcp add --scope user` (applies globally)
 - **Project-level**: `.mcp.json` in project root (applies to that project)
 
 **User-level config takes precedence.** If both define `"gasoline"`, the user-level wins silently.
 
 **To diagnose**:
 ```bash
-# Check for user-level gasoline config
-grep -A5 '"gasoline"' ~/.claude.json
+# Check if gasoline is installed at user level
+claude mcp list
 ```
 
 **To fix**:
-1. Edit `~/.claude.json` and remove the `gasoline` entry from `mcpServers`
+1. Remove user-level gasoline: `claude mcp remove --scope user gasoline`
 2. Or update the user-level config to match your desired settings
 3. Restart Claude Code to pick up changes
 

--- a/npm/gasoline-mcp/lib/config.test.js
+++ b/npm/gasoline-mcp/lib/config.test.js
@@ -1,0 +1,195 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const {
+  CLIENT_DEFINITIONS,
+  getClientConfigPath,
+  isClientInstalled,
+  getDetectedClients,
+  commandExistsOnPath,
+  getConfigCandidates,
+  getToolNameFromPath,
+  getClientById,
+} = require('./config');
+
+// --- CLIENT_DEFINITIONS ---
+
+test('CLIENT_DEFINITIONS contains all 5 clients', () => {
+  const ids = CLIENT_DEFINITIONS.map(c => c.id);
+  assert.deepEqual(ids, ['claude-code', 'claude-desktop', 'cursor', 'windsurf', 'vscode']);
+});
+
+test('each client definition has required fields', () => {
+  for (const def of CLIENT_DEFINITIONS) {
+    assert.ok(def.id, `missing id`);
+    assert.ok(def.name, `missing name for ${def.id}`);
+    assert.ok(['cli', 'file'].includes(def.type), `invalid type for ${def.id}`);
+    if (def.type === 'cli') {
+      assert.ok(def.detectCommand, `missing detectCommand for ${def.id}`);
+      assert.ok(Array.isArray(def.installArgs), `missing installArgs for ${def.id}`);
+      assert.ok(Array.isArray(def.removeArgs), `missing removeArgs for ${def.id}`);
+    } else {
+      assert.ok(def.configPath, `missing configPath for ${def.id}`);
+      assert.ok(def.detectDir, `missing detectDir for ${def.id}`);
+    }
+  }
+});
+
+test('claude-code is CLI type with correct detect command', () => {
+  const cc = CLIENT_DEFINITIONS.find(c => c.id === 'claude-code');
+  assert.equal(cc.type, 'cli');
+  assert.equal(cc.detectCommand, 'claude');
+});
+
+test('cursor uses correct config path', () => {
+  const cursor = CLIENT_DEFINITIONS.find(c => c.id === 'cursor');
+  assert.equal(cursor.type, 'file');
+  assert.ok(cursor.configPath.all.includes('.cursor/mcp.json'));
+});
+
+test('windsurf uses correct config path (not .codeium/mcp.json)', () => {
+  const ws = CLIENT_DEFINITIONS.find(c => c.id === 'windsurf');
+  assert.ok(ws.configPath.all.includes('.codeium/windsurf/mcp_config.json'));
+});
+
+// --- getClientById ---
+
+test('getClientById returns definition by id', () => {
+  const cursor = getClientById('cursor');
+  assert.equal(cursor.name, 'Cursor');
+});
+
+test('getClientById returns undefined for unknown id', () => {
+  assert.equal(getClientById('nonexistent'), undefined);
+});
+
+// --- getClientConfigPath ---
+
+test('getClientConfigPath returns platform-specific path for claude-desktop on darwin', () => {
+  const def = CLIENT_DEFINITIONS.find(c => c.id === 'claude-desktop');
+  const result = getClientConfigPath(def, 'darwin');
+  assert.ok(result.includes('Library/Application Support/Claude/claude_desktop_config.json'));
+});
+
+test('getClientConfigPath returns platform-specific path for vscode on linux', () => {
+  const def = CLIENT_DEFINITIONS.find(c => c.id === 'vscode');
+  const result = getClientConfigPath(def, 'linux');
+  assert.ok(result.includes('.config/Code/User/mcp.json'));
+});
+
+test('getClientConfigPath returns "all" path for cursor', () => {
+  const def = CLIENT_DEFINITIONS.find(c => c.id === 'cursor');
+  const result = getClientConfigPath(def);
+  assert.ok(result.includes('.cursor/mcp.json'));
+});
+
+test('getClientConfigPath returns null for CLI type', () => {
+  const def = CLIENT_DEFINITIONS.find(c => c.id === 'claude-code');
+  const result = getClientConfigPath(def);
+  assert.equal(result, null);
+});
+
+test('getClientConfigPath returns null for unsupported platform', () => {
+  const def = CLIENT_DEFINITIONS.find(c => c.id === 'claude-desktop');
+  // claude-desktop only has darwin + win32
+  const result = getClientConfigPath(def, 'linux');
+  assert.equal(result, null);
+});
+
+// --- isClientInstalled ---
+
+test('isClientInstalled detects existing directory for file-type client', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-test-'));
+  const cursorDir = path.join(tmp, '.cursor');
+  fs.mkdirSync(cursorDir);
+
+  const def = {
+    id: 'test-cursor',
+    type: 'file',
+    detectDir: { all: path.join(tmp, '.cursor') },
+    configPath: { all: path.join(tmp, '.cursor', 'mcp.json') },
+  };
+
+  assert.equal(isClientInstalled(def), true);
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('isClientInstalled returns false when directory does not exist', () => {
+  const def = {
+    id: 'test-missing',
+    type: 'file',
+    detectDir: { all: '/tmp/nonexistent-gasoline-test-dir-12345' },
+    configPath: { all: '/tmp/nonexistent-gasoline-test-dir-12345/mcp.json' },
+  };
+
+  assert.equal(isClientInstalled(def), false);
+});
+
+test('isClientInstalled checks detectCommand for CLI type', () => {
+  // 'node' should be on PATH
+  const def = {
+    id: 'test-cli',
+    type: 'cli',
+    detectCommand: 'node',
+  };
+  assert.equal(isClientInstalled(def), true);
+});
+
+test('isClientInstalled returns false for missing CLI command', () => {
+  const def = {
+    id: 'test-cli-missing',
+    type: 'cli',
+    detectCommand: 'nonexistent-command-gasoline-test-12345',
+  };
+  assert.equal(isClientInstalled(def), false);
+});
+
+// --- commandExistsOnPath ---
+
+test('commandExistsOnPath finds node', () => {
+  assert.equal(commandExistsOnPath('node'), true);
+});
+
+test('commandExistsOnPath returns false for missing command', () => {
+  assert.equal(commandExistsOnPath('nonexistent-command-gasoline-test-12345'), false);
+});
+
+// --- getDetectedClients ---
+
+test('getDetectedClients returns only installed clients', () => {
+  const detected = getDetectedClients();
+  assert.ok(Array.isArray(detected));
+  // Each should have isDetected = true implicitly (they passed the filter)
+  for (const d of detected) {
+    assert.ok(d.id, 'each detected client should have an id');
+  }
+});
+
+// --- getConfigCandidates (backward compat) ---
+
+test('getConfigCandidates returns file paths for detected file-type clients', () => {
+  const candidates = getConfigCandidates();
+  assert.ok(Array.isArray(candidates));
+  // Should be strings (file paths), no CLI entries
+  for (const c of candidates) {
+    assert.equal(typeof c, 'string');
+  }
+});
+
+// --- getToolNameFromPath (backward compat) ---
+
+test('getToolNameFromPath maps cursor path correctly', () => {
+  const homeDir = os.homedir();
+  assert.equal(getToolNameFromPath(path.join(homeDir, '.cursor', 'mcp.json')), 'Cursor');
+});
+
+test('getToolNameFromPath maps windsurf path correctly', () => {
+  const homeDir = os.homedir();
+  assert.equal(getToolNameFromPath(path.join(homeDir, '.codeium', 'windsurf', 'mcp_config.json')), 'Windsurf');
+});
+
+test('getToolNameFromPath returns Unknown for unrecognized path', () => {
+  assert.equal(getToolNameFromPath('/some/random/path'), 'Unknown');
+});

--- a/npm/gasoline-mcp/lib/errors.js
+++ b/npm/gasoline-mcp/lib/errors.js
@@ -72,16 +72,6 @@ class EnvWithoutInstallError extends GasolineError {
   }
 }
 
-class ForAllWithoutInstallError extends GasolineError {
-  constructor() {
-    super(
-      '--for-all only works with --install',
-      'Usage: gasoline-mcp --install --for-all'
-    );
-    this.name = 'ForAllWithoutInstallError';
-  }
-}
-
 class ConfigValidationError extends GasolineError {
   constructor(errors) {
     super(
@@ -109,7 +99,6 @@ module.exports = {
   BinaryNotFoundError,
   InvalidEnvFormatError,
   EnvWithoutInstallError,
-  ForAllWithoutInstallError,
   ConfigValidationError,
   FileSizeError,
 };

--- a/npm/gasoline-mcp/lib/install.test.js
+++ b/npm/gasoline-mcp/lib/install.test.js
@@ -1,0 +1,210 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const {
+  generateDefaultConfig,
+  buildMcpEntry,
+  installToClient,
+  executeInstall,
+} = require('./install');
+
+// --- generateDefaultConfig ---
+
+test('generateDefaultConfig returns valid MCP config', () => {
+  const cfg = generateDefaultConfig();
+  assert.ok(cfg.mcpServers);
+  assert.ok(cfg.mcpServers.gasoline);
+  assert.equal(cfg.mcpServers.gasoline.command, 'gasoline-mcp');
+});
+
+// --- buildMcpEntry ---
+
+test('buildMcpEntry returns JSON string for MCP entry', () => {
+  const entry = buildMcpEntry();
+  const parsed = JSON.parse(entry);
+  assert.equal(parsed.command, 'gasoline-mcp');
+  assert.deepEqual(parsed.args, []);
+});
+
+test('buildMcpEntry includes env vars when provided', () => {
+  const entry = buildMcpEntry({ DEBUG: '1' });
+  const parsed = JSON.parse(entry);
+  assert.equal(parsed.env.DEBUG, '1');
+});
+
+// --- installToClient: file-type ---
+
+test('installToClient creates new config for file-type client', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = installToClient(def, { dryRun: false, envVars: {} });
+  assert.equal(result.success, true);
+  assert.equal(result.method, 'file');
+  assert.equal(result.isNew, true);
+
+  const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.ok(written.mcpServers.gasoline);
+  assert.equal(written.mcpServers.gasoline.command, 'gasoline-mcp');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('installToClient merges into existing file-type config', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  // Pre-existing config with another server
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    mcpServers: { other: { command: 'other-cmd', args: [] } },
+  }));
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = installToClient(def, { dryRun: false, envVars: {} });
+  assert.equal(result.success, true);
+  assert.equal(result.isNew, false);
+
+  const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.ok(written.mcpServers.gasoline);
+  assert.ok(written.mcpServers.other, 'should preserve existing server');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('installToClient dry-run does not write file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = installToClient(def, { dryRun: true, envVars: {} });
+  assert.equal(result.success, true);
+  assert.equal(fs.existsSync(cfgPath), false, 'should not create file in dry-run');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('installToClient adds env vars to file-type config', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  installToClient(def, { dryRun: false, envVars: { DEBUG: '1' } });
+  const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.equal(written.mcpServers.gasoline.env.DEBUG, '1');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// --- installToClient: CLI-type ---
+
+test('installToClient handles CLI type with dry-run', () => {
+  const def = {
+    id: 'claude-code',
+    name: 'Claude Code',
+    type: 'cli',
+    detectCommand: 'claude',
+    installArgs: ['mcp', 'add-json', '--scope', 'user', 'gasoline'],
+  };
+
+  const result = installToClient(def, { dryRun: true, envVars: {} });
+  assert.equal(result.success, true);
+  assert.equal(result.method, 'cli');
+  assert.ok(result.message.includes('claude'));
+});
+
+// --- executeInstall ---
+
+test('executeInstall installs to detected file-type clients', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cursorDir = path.join(tmp, '.cursor');
+  fs.mkdirSync(cursorDir);
+
+  // Override detected clients for test
+  const result = executeInstall({
+    dryRun: false,
+    envVars: {},
+    _clientOverrides: [
+      {
+        id: 'test-cursor',
+        name: 'Test Cursor',
+        type: 'file',
+        configPath: { all: path.join(cursorDir, 'mcp.json') },
+        detectDir: { all: cursorDir },
+      },
+    ],
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.installed.length, 1);
+  assert.equal(result.installed[0].name, 'Test Cursor');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('executeInstall reports when no clients detected', () => {
+  const result = executeInstall({
+    dryRun: false,
+    envVars: {},
+    _clientOverrides: [],
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.installed.length, 0);
+});
+
+test('executeInstall dry-run reports all detected clients without writing', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const cursorDir = path.join(tmp, '.cursor');
+  fs.mkdirSync(cursorDir);
+
+  const result = executeInstall({
+    dryRun: true,
+    envVars: {},
+    _clientOverrides: [
+      {
+        id: 'test-cursor',
+        name: 'Test Cursor',
+        type: 'file',
+        configPath: { all: path.join(cursorDir, 'mcp.json') },
+        detectDir: { all: cursorDir },
+      },
+    ],
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.installed.length, 1);
+  assert.equal(fs.existsSync(path.join(cursorDir, 'mcp.json')), false);
+
+  fs.rmSync(tmp, { recursive: true });
+});

--- a/npm/gasoline-mcp/lib/uninstall.js
+++ b/npm/gasoline-mcp/lib/uninstall.js
@@ -1,18 +1,171 @@
 /**
  * Uninstall logic for Gasoline MCP CLI
- * Removes gasoline from config files while preserving other MCP servers
+ * Removes gasoline from all detected AI assistant clients
  */
 
 const fs = require('fs');
-const { getConfigCandidates, getToolNameFromPath, readConfigFile, writeConfigFile } = require('./config');
+const { execFileSync } = require('child_process');
+const {
+  CLIENT_DEFINITIONS,
+  getClientConfigPath,
+  getDetectedClients,
+  readConfigFile,
+  writeConfigFile,
+} = require('./config');
 
 /**
- * Execute uninstall operation
- * @param {Object} options {dryRun: bool, verbose: bool}
- * @returns {Object} {success: bool, removed: [{name, path}], notConfigured: [names], errors: []}
+ * Uninstall from a CLI-type client (e.g. Claude Code via `claude mcp remove`)
+ * @param {Object} def Client definition
+ * @param {Object} options {dryRun, verbose}
+ * @returns {Object} {status, name, method, message}
+ */
+function uninstallViaCli(def, options) {
+  const { dryRun = false, verbose = false } = options;
+  const cmd = def.detectCommand;
+  const args = [...def.removeArgs];
+
+  if (dryRun) {
+    if (verbose) {
+      console.log(`[DEBUG] Would run: ${cmd} ${args.join(' ')}`);
+    }
+    return {
+      status: 'removed',
+      name: def.name,
+      id: def.id,
+      method: 'cli',
+      message: `Would run: ${cmd} ${args.join(' ')}`,
+    };
+  }
+
+  try {
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+
+    execFileSync(cmd, args, {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 15000,
+    });
+
+    return {
+      status: 'removed',
+      name: def.name,
+      id: def.id,
+      method: 'cli',
+      message: `Removed via ${cmd} CLI`,
+    };
+  } catch (err) {
+    // If the command fails because gasoline isn't configured, treat as notConfigured
+    const stderr = err.stderr ? err.stderr.toString() : '';
+    if (stderr.includes('not found') || stderr.includes('does not exist')) {
+      return {
+        status: 'notConfigured',
+        name: def.name,
+        id: def.id,
+        method: 'cli',
+      };
+    }
+    return {
+      status: 'error',
+      name: def.name,
+      id: def.id,
+      method: 'cli',
+      message: `CLI uninstall failed: ${err.message}`,
+    };
+  }
+}
+
+/**
+ * Uninstall from a file-type client
+ * @param {Object} def Client definition
+ * @param {Object} options {dryRun, verbose}
+ * @returns {Object} {status, name, method, path}
+ */
+function uninstallViaFile(def, options) {
+  const { dryRun = false, verbose = false } = options;
+  const cfgPath = getClientConfigPath(def);
+
+  if (!cfgPath) {
+    return { status: 'notConfigured', name: def.name, id: def.id };
+  }
+
+  if (!fs.existsSync(cfgPath)) {
+    return { status: 'notConfigured', name: def.name, id: def.id };
+  }
+
+  const readResult = readConfigFile(cfgPath);
+  if (!readResult.valid) {
+    return {
+      status: 'error',
+      name: def.name,
+      id: def.id,
+      message: `${def.name}: Invalid JSON, cannot uninstall`,
+    };
+  }
+
+  if (!readResult.data.mcpServers || !readResult.data.mcpServers.gasoline) {
+    return { status: 'notConfigured', name: def.name, id: def.id };
+  }
+
+  if (dryRun) {
+    if (verbose) {
+      console.log(`[DEBUG] Would remove gasoline from ${cfgPath}`);
+    }
+    return {
+      status: 'removed',
+      name: def.name,
+      id: def.id,
+      method: 'file',
+      path: cfgPath,
+    };
+  }
+
+  const modified = JSON.parse(JSON.stringify(readResult.data));
+  delete modified.mcpServers.gasoline;
+
+  if (Object.keys(modified.mcpServers).length > 0) {
+    writeConfigFile(cfgPath, modified, false);
+  } else {
+    fs.unlinkSync(cfgPath);
+  }
+
+  if (verbose) {
+    console.log(`[DEBUG] Removed gasoline from ${cfgPath}`);
+  }
+
+  return {
+    status: 'removed',
+    name: def.name,
+    id: def.id,
+    method: 'file',
+    path: cfgPath,
+  };
+}
+
+/**
+ * Uninstall from a single client (dispatches by type)
+ * @param {Object} def Client definition
+ * @param {Object} options {dryRun, verbose}
+ * @returns {Object} Result with status, name, method
+ */
+function uninstallFromClient(def, options) {
+  if (def.type === 'cli') {
+    return uninstallViaCli(def, options);
+  }
+  return uninstallViaFile(def, options);
+}
+
+/**
+ * Execute uninstall across all detected clients
+ * @param {Object} options {dryRun, verbose, _clientOverrides}
+ * @returns {Object} {success, removed, notConfigured, errors}
  */
 function executeUninstall(options = {}) {
   const { dryRun = false, verbose = false } = options;
+
+  const clients = options._clientOverrides !== undefined
+    ? options._clientOverrides
+    : getDetectedClients();
 
   const result = {
     success: false,
@@ -21,67 +174,21 @@ function executeUninstall(options = {}) {
     errors: [],
   };
 
-  const candidates = getConfigCandidates();
-
-  for (const candidatePath of candidates) {
-    const toolName = getToolNameFromPath(candidatePath);
-
+  for (const def of clients) {
     try {
-      // Check if file exists
-      if (!fs.existsSync(candidatePath)) {
-        result.notConfigured.push(toolName);
-        continue;
-      }
+      const r = uninstallFromClient(def, { dryRun, verbose });
 
-      // Read config
-      const readResult = readConfigFile(candidatePath);
-      if (!readResult.valid) {
-        result.errors.push(`${toolName}: Invalid JSON, cannot uninstall`);
-        continue;
-      }
-
-      // Check if gasoline is configured
-      if (!readResult.data.mcpServers || !readResult.data.mcpServers.gasoline) {
-        result.notConfigured.push(toolName);
-        continue;
-      }
-
-      if (dryRun) {
-        result.removed.push({
-          name: toolName,
-          path: candidatePath,
-        });
-        if (verbose) {
-          console.log(`[DEBUG] Would remove gasoline from ${candidatePath}`);
-        }
-        continue;
-      }
-
-      // Remove gasoline entry
-      const modified = JSON.parse(JSON.stringify(readResult.data)); // Deep copy
-      delete modified.mcpServers.gasoline;
-
-      // Write back (or delete if no other servers)
-      const hasOtherServers = Object.keys(modified.mcpServers).length > 0;
-      if (hasOtherServers) {
-        writeConfigFile(candidatePath, modified, false);
-      } else {
-        // No other servers, delete the file
-        fs.unlinkSync(candidatePath);
-      }
-
-      result.removed.push({
-        name: toolName,
-        path: candidatePath,
-      });
-
-      if (verbose) {
-        console.log(`[DEBUG] Removed gasoline from ${candidatePath}`);
+      if (r.status === 'removed') {
+        result.removed.push(r);
+      } else if (r.status === 'notConfigured') {
+        result.notConfigured.push(r.name);
+      } else if (r.status === 'error') {
+        result.errors.push(r.message || `${r.name}: unknown error`);
       }
     } catch (err) {
-      result.errors.push(`${toolName}: ${err.message}`);
+      result.errors.push(`${def.name}: ${err.message}`);
       if (verbose) {
-        console.log(`[DEBUG] Error uninstalling from ${toolName}: ${err.message}`);
+        console.log(`[DEBUG] Error uninstalling from ${def.name}: ${err.message}`);
       }
     }
   }
@@ -91,5 +198,6 @@ function executeUninstall(options = {}) {
 }
 
 module.exports = {
+  uninstallFromClient,
   executeUninstall,
 };

--- a/npm/gasoline-mcp/lib/uninstall.test.js
+++ b/npm/gasoline-mcp/lib/uninstall.test.js
@@ -1,0 +1,169 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const { uninstallFromClient, executeUninstall } = require('./uninstall');
+
+// --- uninstallFromClient: file-type ---
+
+test('uninstallFromClient removes gasoline from file-type config', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-uninstall-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    mcpServers: {
+      gasoline: { command: 'gasoline-mcp', args: [] },
+      other: { command: 'other-cmd', args: [] },
+    },
+  }));
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = uninstallFromClient(def, { dryRun: false });
+  assert.equal(result.status, 'removed');
+
+  const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.equal(written.mcpServers.gasoline, undefined);
+  assert.ok(written.mcpServers.other, 'should preserve other servers');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('uninstallFromClient deletes file when gasoline is only server', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-uninstall-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    mcpServers: { gasoline: { command: 'gasoline-mcp', args: [] } },
+  }));
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = uninstallFromClient(def, { dryRun: false });
+  assert.equal(result.status, 'removed');
+  assert.equal(fs.existsSync(cfgPath), false, 'should delete file');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('uninstallFromClient returns notConfigured when file does not exist', () => {
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: '/tmp/nonexistent-gasoline-test-12345/mcp.json' },
+    detectDir: { all: '/tmp/nonexistent-gasoline-test-12345' },
+  };
+
+  const result = uninstallFromClient(def, { dryRun: false });
+  assert.equal(result.status, 'notConfigured');
+});
+
+test('uninstallFromClient returns notConfigured when gasoline not in config', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-uninstall-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    mcpServers: { other: { command: 'other-cmd', args: [] } },
+  }));
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = uninstallFromClient(def, { dryRun: false });
+  assert.equal(result.status, 'notConfigured');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+test('uninstallFromClient dry-run does not modify file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-uninstall-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  const original = {
+    mcpServers: { gasoline: { command: 'gasoline-mcp', args: [] } },
+  };
+  fs.writeFileSync(cfgPath, JSON.stringify(original));
+
+  const def = {
+    id: 'test-cursor',
+    name: 'Test Cursor',
+    type: 'file',
+    configPath: { all: cfgPath },
+    detectDir: { all: tmp },
+  };
+
+  const result = uninstallFromClient(def, { dryRun: true });
+  assert.equal(result.status, 'removed');
+
+  const still = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.ok(still.mcpServers.gasoline, 'should not modify in dry-run');
+
+  fs.rmSync(tmp, { recursive: true });
+});
+
+// --- uninstallFromClient: CLI-type ---
+
+test('uninstallFromClient handles CLI type with dry-run', () => {
+  const def = {
+    id: 'claude-code',
+    name: 'Claude Code',
+    type: 'cli',
+    detectCommand: 'claude',
+    removeArgs: ['mcp', 'remove', '--scope', 'user', 'gasoline'],
+  };
+
+  const result = uninstallFromClient(def, { dryRun: true });
+  assert.equal(result.status, 'removed');
+  assert.equal(result.method, 'cli');
+});
+
+// --- executeUninstall ---
+
+test('executeUninstall removes from detected file-type clients', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-uninstall-'));
+  const cfgPath = path.join(tmp, 'mcp.json');
+
+  fs.writeFileSync(cfgPath, JSON.stringify({
+    mcpServers: {
+      gasoline: { command: 'gasoline-mcp', args: [] },
+      other: { command: 'other-cmd', args: [] },
+    },
+  }));
+
+  const result = executeUninstall({
+    dryRun: false,
+    _clientOverrides: [
+      {
+        id: 'test-cursor',
+        name: 'Test Cursor',
+        type: 'file',
+        configPath: { all: cfgPath },
+        detectDir: { all: tmp },
+      },
+    ],
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.removed.length, 1);
+
+  fs.rmSync(tmp, { recursive: true });
+});

--- a/pypi/gasoline-mcp/gasoline_mcp/doctor.py
+++ b/pypi/gasoline-mcp/gasoline_mcp/doctor.py
@@ -55,44 +55,118 @@ def test_binary(get_binary_path=None):
         }
 
 
-def _diagnose_candidate(candidate_path, verbose):
-    """Diagnose a single config candidate path.
+def _diagnose_file_client(definition, verbose):
+    """Diagnose a single file-type client."""
+    cfg_path = config.get_client_config_path(definition)
+    detected = config.is_client_installed(definition)
 
-    Returns:
-        dict: Tool diagnostic with name, path, status, issues, suggestions.
-    """
-    tool_name = config.get_tool_name_from_path(candidate_path)
     tool = {
-        "name": tool_name,
-        "path": candidate_path,
+        "name": definition["name"],
+        "id": definition["id"],
+        "type": "file",
+        "path": cfg_path,
+        "detected": detected,
         "status": "error",
         "issues": [],
         "suggestions": [],
     }
 
     if verbose:
-        print(f"[DEBUG] Checking {tool_name} at {candidate_path}")
+        print(f"[DEBUG] Checking {definition['name']} at {cfg_path}")
 
-    if not os.path.exists(candidate_path):
+    if not detected:
         tool["status"] = "info"
-        tool["issues"].append("Config file not found")
-        tool["suggestions"].append("Run: gasoline-mcp --install --for-all")
+        tool["issues"].append("Not installed on this system")
         return tool
 
-    read_result = config.read_config_file(candidate_path)
+    if not cfg_path:
+        tool["status"] = "info"
+        tool["issues"].append("No config path for this platform")
+        return tool
+
+    if not os.path.exists(cfg_path):
+        tool["status"] = "error"
+        tool["issues"].append("Config file not found")
+        tool["suggestions"].append("Run: gasoline-mcp --install")
+        return tool
+
+    read_result = config.read_config_file(cfg_path)
     if not read_result["valid"]:
         tool["issues"].append("Invalid JSON")
         tool["suggestions"].append("Fix the JSON syntax or run: gasoline-mcp --install")
         return tool
 
-    cfg = read_result["data"]
-    if not cfg.get("mcpServers", {}).get("gasoline"):
+    if not read_result["data"].get("mcpServers", {}).get("gasoline"):
         tool["issues"].append("gasoline entry missing from mcpServers")
-        tool["suggestions"].append("Run: gasoline-mcp --install --for-all")
+        tool["suggestions"].append("Run: gasoline-mcp --install")
         return tool
 
     tool["status"] = "ok"
     return tool
+
+
+def _diagnose_cli_client(definition, verbose):
+    """Diagnose a CLI-type client."""
+    detected = config.is_client_installed(definition)
+
+    tool = {
+        "name": definition["name"],
+        "id": definition["id"],
+        "type": "cli",
+        "detected": detected,
+        "status": "error",
+        "issues": [],
+        "suggestions": [],
+    }
+
+    if verbose:
+        print(f"[DEBUG] Checking {definition['name']} (CLI: {definition['detectCommand']})")
+
+    if not detected:
+        tool["status"] = "info"
+        tool["issues"].append(f"{definition['detectCommand']} CLI not found on PATH")
+        return tool
+
+    # Try to check if gasoline is configured via CLI
+    try:
+        env = dict(os.environ)
+        env.pop("CLAUDECODE", None)
+
+        subprocess.run(
+            [definition["detectCommand"], "mcp", "get", "gasoline"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+            env=env,
+        )
+        tool["status"] = "ok"
+    except (subprocess.SubprocessError, OSError):
+        tool["status"] = "error"
+        tool["issues"].append("gasoline not configured")
+        tool["suggestions"].append("Run: gasoline-mcp --install")
+
+    return tool
+
+
+def _check_legacy_paths():
+    """Check for legacy/orphaned config files at old paths."""
+    warnings = []
+    for legacy in config.LEGACY_PATHS:
+        expanded = config.expand_path(legacy["path"])
+        if os.path.exists(expanded):
+            try:
+                read_result = config.read_config_file(expanded)
+                if (read_result["valid"]
+                        and read_result["data"].get("mcpServers", {}).get("gasoline")):
+                    warnings.append({
+                        "path": expanded,
+                        "description": legacy["description"],
+                        "message": f"Orphaned gasoline config at old path: {expanded}",
+                    })
+            except Exception:  # pylint: disable=broad-except
+                pass
+    return warnings
 
 
 def _build_summary(tools):
@@ -101,16 +175,16 @@ def _build_summary(tools):
     error_count = sum(1 for t in tools if t["status"] == "error")
     info_count = sum(1 for t in tools if t["status"] == "info")
 
-    summary = f"Summary: {ok_count} tool{'s' if ok_count != 1 else ''} ready"
+    summary = f"Summary: {ok_count} client{'s' if ok_count != 1 else ''} ready"
     if error_count > 0:
         summary += f", {error_count} need{'s' if error_count == 1 else ''} repair"
     if info_count > 0:
-        summary += f", {info_count} not configured"
+        summary += f", {info_count} not detected"
     return summary
 
 
 def run_diagnostics(verbose=False, get_binary_path=None):
-    """Run full diagnostics on all config locations.
+    """Run full diagnostics on all client locations.
 
     Args:
         verbose: If True, log debug info
@@ -120,11 +194,18 @@ def run_diagnostics(verbose=False, get_binary_path=None):
     Returns:
         dict: Diagnostic report with tools array and summary
     """
-    candidates = config.get_config_candidates()
-    tools = [_diagnose_candidate(path, verbose) for path in candidates]
+    tools = []
+    for definition in config.CLIENT_DEFINITIONS:
+        if definition["type"] == "cli":
+            tools.append(_diagnose_cli_client(definition, verbose))
+        else:
+            tools.append(_diagnose_file_client(definition, verbose))
+
+    legacy_warnings = _check_legacy_paths()
 
     return {
         "tools": tools,
         "binary": test_binary(get_binary_path),
+        "legacyWarnings": legacy_warnings,
         "summary": _build_summary(tools),
     }

--- a/pypi/gasoline-mcp/gasoline_mcp/errors.py
+++ b/pypi/gasoline-mcp/gasoline_mcp/errors.py
@@ -89,16 +89,6 @@ class EnvWithoutInstallError(GasolineError):
         self.name = "EnvWithoutInstallError"
 
 
-class ForAllWithoutInstallError(GasolineError):
-    """Raised when --for-all is used without --install."""
-
-    def __init__(self):
-        msg = "--for-all only works with --install"
-        recovery = "Usage: gasoline-mcp --install --for-all"
-        super().__init__(msg, recovery)
-        self.name = "ForAllWithoutInstallError"
-
-
 class ConfigValidationError(GasolineError):
     """Raised when config validation fails."""
 

--- a/pypi/gasoline-mcp/gasoline_mcp/output.py
+++ b/pypi/gasoline-mcp/gasoline_mcp/output.py
@@ -46,11 +46,16 @@ def json_diff(before, after):
 def install_result(result):
     """Format install result."""
     output = ""
+    installed = result.get("installed", result.get("updated", []))
+    total = result.get("total", 5)
 
-    if result.get("updated", []):
-        output += f"✅ {len(result['updated'])}/{result['total']} tools updated:\n"
-        for tool in result["updated"]:
-            output += f"   ✅ {tool['name']} (at {tool['path']})\n"
+    if installed:
+        output += f"✅ {len(installed)}/{total} clients updated:\n"
+        for entry in installed:
+            if entry.get("method") == "cli":
+                output += f"   ✅ {entry['name']} (via CLI)\n"
+            else:
+                output += f"   ✅ {entry['name']} (at {entry['path']})\n"
 
     if result.get("errors", []):
         output += "\n❌ Errors:\n"
@@ -68,14 +73,26 @@ def install_result(result):
 
 def _format_tool_ok(tool):
     """Format a tool with 'ok' status."""
+    if tool.get("type") == "cli":
+        return f"✅ {tool['name']}\n   Configured via CLI - Ready\n\n"
     return f"✅ {tool['name']}\n   {tool['path']} - Configured and ready\n\n"
+
+
+def _format_tool_info(tool):
+    """Format a tool with 'info' status (not detected)."""
+    output = f"⚪ {tool['name']}\n"
+    for issue in tool.get("issues", []):
+        output += f"   {issue}\n"
+    return output + "\n"
 
 
 def _format_tool_problem(tool):
     """Format a tool with 'error' or 'warning' status."""
     icon = "❌" if tool["status"] == "error" else "⚠️ "
     fix_label = "Fix" if tool["status"] == "error" else "Suggestion"
-    output = f"{icon} {tool['name']}\n   {tool['path']}\n"
+    output = f"{icon} {tool['name']}\n"
+    if tool.get("path"):
+        output += f"   {tool['path']}\n"
     for issue in tool.get("issues", []):
         output += f"   Issue: {issue}\n"
     for suggestion in tool.get("suggestions", []):
@@ -100,11 +117,20 @@ def diagnostic_report(report):
     for tool in report.get("tools", []):
         if tool["status"] == "ok":
             output += _format_tool_ok(tool)
+        elif tool["status"] == "info":
+            output += _format_tool_info(tool)
         else:
             output += _format_tool_problem(tool)
 
     if report.get("binary"):
         output += _format_binary(report["binary"])
+
+    # Legacy path warnings
+    if report.get("legacyWarnings"):
+        output += "\n⚠️  Legacy Configs Found:\n"
+        for w in report["legacyWarnings"]:
+            output += f"   {w['description']}: {w['path']}\n"
+            output += "   This path is no longer used. You can safely remove the gasoline entry.\n"
 
     if report.get("summary"):
         output += f"\n{report['summary']}\n"
@@ -118,11 +144,14 @@ def uninstall_result(result):
 
     if result.get("removed", []):
         count = len(result["removed"])
-        output += f"✅ Removed from {count} tool{'s' if count != 1 else ''}:\n"
-        for tool in result["removed"]:
-            output += f"   ✅ {tool['name']} (removed from {tool['path']})\n"
+        output += f"✅ Removed from {count} client{'s' if count != 1 else ''}:\n"
+        for entry in result["removed"]:
+            if entry.get("method") == "cli":
+                output += f"   ✅ {entry['name']} (via CLI)\n"
+            else:
+                output += f"   ✅ {entry['name']} (removed from {entry['path']})\n"
     else:
-        output += "ℹ️  Gasoline not configured in any tools\n"
+        output += "ℹ️  Gasoline not configured in any clients\n"
 
     if result.get("notConfigured", []):
         output += f"\nℹ️  Not configured in: {', '.join(result['notConfigured'])}\n"

--- a/pypi/gasoline-mcp/tests/test_config.py
+++ b/pypi/gasoline-mcp/tests/test_config.py
@@ -1,0 +1,157 @@
+"""Tests for config module client registry."""
+
+import os
+import tempfile
+import shutil
+import unittest
+from gasoline_mcp.config import (
+    CLIENT_DEFINITIONS,
+    get_client_config_path,
+    get_client_detect_dir,
+    is_client_installed,
+    get_detected_clients,
+    command_exists_on_path,
+    get_config_candidates,
+    get_tool_name_from_path,
+    get_client_by_id,
+)
+
+
+class TestClientDefinitions(unittest.TestCase):
+    """Test CLIENT_DEFINITIONS registry."""
+
+    def test_contains_all_5_clients(self):
+        ids = [c["id"] for c in CLIENT_DEFINITIONS]
+        self.assertEqual(ids, ["claude-code", "claude-desktop", "cursor", "windsurf", "vscode"])
+
+    def test_each_has_required_fields(self):
+        for d in CLIENT_DEFINITIONS:
+            self.assertIn("id", d)
+            self.assertIn("name", d)
+            self.assertIn("type", d)
+            self.assertIn(d["type"], ["cli", "file"])
+            if d["type"] == "cli":
+                self.assertIn("detectCommand", d)
+                self.assertIsInstance(d["installArgs"], list)
+                self.assertIsInstance(d["removeArgs"], list)
+            else:
+                self.assertIn("configPath", d)
+                self.assertIn("detectDir", d)
+
+    def test_claude_code_is_cli_type(self):
+        cc = get_client_by_id("claude-code")
+        self.assertEqual(cc["type"], "cli")
+        self.assertEqual(cc["detectCommand"], "claude")
+
+    def test_cursor_uses_correct_path(self):
+        cursor = get_client_by_id("cursor")
+        self.assertIn(".cursor/mcp.json", cursor["configPath"]["all"])
+
+    def test_windsurf_uses_correct_path(self):
+        ws = get_client_by_id("windsurf")
+        self.assertIn(".codeium/windsurf/mcp_config.json", ws["configPath"]["all"])
+
+
+class TestGetClientById(unittest.TestCase):
+    def test_returns_definition(self):
+        cursor = get_client_by_id("cursor")
+        self.assertEqual(cursor["name"], "Cursor")
+
+    def test_returns_none_for_unknown(self):
+        self.assertIsNone(get_client_by_id("nonexistent"))
+
+
+class TestGetClientConfigPath(unittest.TestCase):
+    def test_darwin_claude_desktop(self):
+        d = get_client_by_id("claude-desktop")
+        result = get_client_config_path(d, "darwin")
+        self.assertIn("Library/Application Support/Claude/claude_desktop_config.json", result)
+
+    def test_linux_vscode(self):
+        d = get_client_by_id("vscode")
+        result = get_client_config_path(d, "linux")
+        self.assertIn(".config/Code/User/mcp.json", result)
+
+    def test_cursor_all_platform(self):
+        d = get_client_by_id("cursor")
+        result = get_client_config_path(d)
+        self.assertIn(".cursor/mcp.json", result)
+
+    def test_returns_none_for_cli(self):
+        d = get_client_by_id("claude-code")
+        self.assertIsNone(get_client_config_path(d))
+
+    def test_returns_none_for_unsupported_platform(self):
+        d = get_client_by_id("claude-desktop")
+        self.assertIsNone(get_client_config_path(d, "linux"))
+
+
+class TestIsClientInstalled(unittest.TestCase):
+    def test_detects_existing_dir(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            d = {
+                "id": "test", "type": "file",
+                "detectDir": {"all": tmp},
+                "configPath": {"all": os.path.join(tmp, "mcp.json")},
+            }
+            self.assertTrue(is_client_installed(d))
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_returns_false_for_missing_dir(self):
+        d = {
+            "id": "test", "type": "file",
+            "detectDir": {"all": "/tmp/nonexistent-gasoline-12345"},
+            "configPath": {"all": "/tmp/nonexistent-gasoline-12345/mcp.json"},
+        }
+        self.assertFalse(is_client_installed(d))
+
+    def test_cli_with_existing_command(self):
+        d = {"id": "test", "type": "cli", "detectCommand": "python3"}
+        self.assertTrue(is_client_installed(d))
+
+    def test_cli_with_missing_command(self):
+        d = {"id": "test", "type": "cli", "detectCommand": "nonexistent-cmd-12345"}
+        self.assertFalse(is_client_installed(d))
+
+
+class TestCommandExistsOnPath(unittest.TestCase):
+    def test_finds_python(self):
+        self.assertTrue(command_exists_on_path("python3"))
+
+    def test_missing_command(self):
+        self.assertFalse(command_exists_on_path("nonexistent-cmd-12345"))
+
+
+class TestGetDetectedClients(unittest.TestCase):
+    def test_returns_list(self):
+        result = get_detected_clients()
+        self.assertIsInstance(result, list)
+
+
+class TestGetConfigCandidates(unittest.TestCase):
+    def test_returns_file_paths(self):
+        result = get_config_candidates()
+        self.assertIsInstance(result, list)
+        for p in result:
+            self.assertIsInstance(p, str)
+
+
+class TestGetToolNameFromPath(unittest.TestCase):
+    def test_cursor_path(self):
+        home = os.path.expanduser("~")
+        result = get_tool_name_from_path(os.path.join(home, ".cursor", "mcp.json"))
+        self.assertEqual(result, "Cursor")
+
+    def test_windsurf_path(self):
+        home = os.path.expanduser("~")
+        result = get_tool_name_from_path(os.path.join(home, ".codeium", "windsurf", "mcp_config.json"))
+        self.assertEqual(result, "Windsurf")
+
+    def test_unknown_path(self):
+        self.assertEqual(get_tool_name_from_path("/some/random/path"), "Unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pypi/gasoline-mcp/tests/test_install.py
+++ b/pypi/gasoline-mcp/tests/test_install.py
@@ -1,0 +1,126 @@
+"""Tests for install module."""
+
+import json
+import os
+import tempfile
+import shutil
+import unittest
+from gasoline_mcp.install import (
+    generate_default_config,
+    build_mcp_entry,
+    install_to_client,
+    execute_install,
+)
+
+
+class TestGenerateDefaultConfig(unittest.TestCase):
+    def test_returns_valid_config(self):
+        cfg = generate_default_config()
+        self.assertIn("mcpServers", cfg)
+        self.assertIn("gasoline", cfg["mcpServers"])
+        self.assertEqual(cfg["mcpServers"]["gasoline"]["command"], "gasoline-mcp")
+
+
+class TestBuildMcpEntry(unittest.TestCase):
+    def test_returns_json_string(self):
+        entry = build_mcp_entry()
+        parsed = json.loads(entry)
+        self.assertEqual(parsed["command"], "gasoline-mcp")
+
+    def test_includes_env_vars(self):
+        entry = build_mcp_entry({"DEBUG": "1"})
+        parsed = json.loads(entry)
+        self.assertEqual(parsed["env"]["DEBUG"], "1")
+
+
+class TestInstallToClient(unittest.TestCase):
+    def test_creates_new_file_config(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = install_to_client(d, {"dryRun": False, "envVars": {}})
+            self.assertTrue(result["success"])
+            self.assertTrue(result["isNew"])
+
+            with open(cfg_path) as f:
+                written = json.load(f)
+            self.assertIn("gasoline", written["mcpServers"])
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_merges_existing_config(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            with open(cfg_path, "w") as f:
+                json.dump({"mcpServers": {"other": {"command": "other"}}}, f)
+
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = install_to_client(d, {"dryRun": False, "envVars": {}})
+            self.assertTrue(result["success"])
+            self.assertFalse(result["isNew"])
+
+            with open(cfg_path) as f:
+                written = json.load(f)
+            self.assertIn("gasoline", written["mcpServers"])
+            self.assertIn("other", written["mcpServers"])
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_dry_run_no_write(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = install_to_client(d, {"dryRun": True, "envVars": {}})
+            self.assertTrue(result["success"])
+            self.assertFalse(os.path.exists(cfg_path))
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_cli_dry_run(self):
+        d = {
+            "id": "claude-code", "name": "Claude Code", "type": "cli",
+            "detectCommand": "claude",
+            "installArgs": ["mcp", "add-json", "--scope", "user", "gasoline"],
+        }
+        result = install_to_client(d, {"dryRun": True, "envVars": {}})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["method"], "cli")
+
+
+class TestExecuteInstall(unittest.TestCase):
+    def test_installs_to_file_clients(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": os.path.join(tmp, "mcp.json")},
+                "detectDir": {"all": tmp},
+            }
+            result = execute_install({"dryRun": False, "envVars": {}, "_clientOverrides": [d]})
+            self.assertTrue(result["success"])
+            self.assertEqual(len(result["installed"]), 1)
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_no_clients_detected(self):
+        result = execute_install({"dryRun": False, "envVars": {}, "_clientOverrides": []})
+        self.assertFalse(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pypi/gasoline-mcp/tests/test_uninstall.py
+++ b/pypi/gasoline-mcp/tests/test_uninstall.py
@@ -1,0 +1,124 @@
+"""Tests for uninstall module."""
+
+import json
+import os
+import tempfile
+import shutil
+import unittest
+from gasoline_mcp.uninstall import uninstall_from_client, execute_uninstall
+
+
+class TestUninstallFromClient(unittest.TestCase):
+    def test_removes_gasoline_from_config(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            with open(cfg_path, "w") as f:
+                json.dump({
+                    "mcpServers": {
+                        "gasoline": {"command": "gasoline-mcp", "args": []},
+                        "other": {"command": "other", "args": []},
+                    }
+                }, f)
+
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = uninstall_from_client(d, {"dryRun": False})
+            self.assertEqual(result["status"], "removed")
+
+            with open(cfg_path) as f:
+                written = json.load(f)
+            self.assertNotIn("gasoline", written["mcpServers"])
+            self.assertIn("other", written["mcpServers"])
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_deletes_file_when_only_server(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            with open(cfg_path, "w") as f:
+                json.dump({"mcpServers": {"gasoline": {"command": "gasoline-mcp"}}}, f)
+
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = uninstall_from_client(d, {"dryRun": False})
+            self.assertEqual(result["status"], "removed")
+            self.assertFalse(os.path.exists(cfg_path))
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_not_configured_when_missing(self):
+        d = {
+            "id": "test", "name": "Test", "type": "file",
+            "configPath": {"all": "/tmp/nonexistent-12345/mcp.json"},
+            "detectDir": {"all": "/tmp/nonexistent-12345"},
+        }
+        result = uninstall_from_client(d, {"dryRun": False})
+        self.assertEqual(result["status"], "notConfigured")
+
+    def test_dry_run_no_modify(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            with open(cfg_path, "w") as f:
+                json.dump({"mcpServers": {"gasoline": {"command": "gasoline-mcp"}}}, f)
+
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = uninstall_from_client(d, {"dryRun": True})
+            self.assertEqual(result["status"], "removed")
+
+            with open(cfg_path) as f:
+                written = json.load(f)
+            self.assertIn("gasoline", written["mcpServers"])
+        finally:
+            shutil.rmtree(tmp)
+
+    def test_cli_dry_run(self):
+        d = {
+            "id": "claude-code", "name": "Claude Code", "type": "cli",
+            "detectCommand": "claude",
+            "removeArgs": ["mcp", "remove", "--scope", "user", "gasoline"],
+        }
+        result = uninstall_from_client(d, {"dryRun": True})
+        self.assertEqual(result["status"], "removed")
+        self.assertEqual(result["method"], "cli")
+
+
+class TestExecuteUninstall(unittest.TestCase):
+    def test_removes_from_file_clients(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            cfg_path = os.path.join(tmp, "mcp.json")
+            with open(cfg_path, "w") as f:
+                json.dump({
+                    "mcpServers": {
+                        "gasoline": {"command": "gasoline-mcp"},
+                        "other": {"command": "other"},
+                    }
+                }, f)
+
+            d = {
+                "id": "test", "name": "Test", "type": "file",
+                "configPath": {"all": cfg_path},
+                "detectDir": {"all": tmp},
+            }
+            result = execute_uninstall({"dryRun": False, "_clientOverrides": [d]})
+            self.assertTrue(result["success"])
+            self.assertEqual(len(result["removed"]), 1)
+        finally:
+            shutil.rmtree(tmp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cli/errors.test.cjs
+++ b/tests/cli/errors.test.cjs
@@ -12,7 +12,6 @@ const {
   BinaryNotFoundError,
   InvalidEnvFormatError,
   EnvWithoutInstallError,
-  ForAllWithoutInstallError,
   ConfigValidationError,
   FileSizeError
 } = require('../../npm/gasoline-mcp/lib/errors')
@@ -79,14 +78,6 @@ test('EnvWithoutInstallError has correct properties', () => {
   assert.ok(err.recovery, 'Should have recovery suggestion')
 })
 
-test('ForAllWithoutInstallError has correct properties', () => {
-  const err = new ForAllWithoutInstallError()
-
-  assert.strictEqual(err.name, 'ForAllWithoutInstallError')
-  assert.ok(err.message.includes('--for-all') || err.message.includes('--install'), 'Message should mention flags')
-  assert.ok(err.recovery, 'Should have recovery suggestion')
-})
-
 test('ConfigValidationError has correct properties', () => {
   const err = new ConfigValidationError(['mcpServers missing'])
 
@@ -111,7 +102,6 @@ test('All errors have recovery properties', () => {
     new BinaryNotFoundError('linux-x64'),
     new InvalidEnvFormatError('INVALID'),
     new EnvWithoutInstallError(),
-    new ForAllWithoutInstallError(),
     new ConfigValidationError(['error']),
     new FileSizeError('/path', 5000000)
   ]
@@ -129,7 +119,6 @@ test('All errors format() methods include emoji', () => {
     new BinaryNotFoundError('linux-x64'),
     new InvalidEnvFormatError('INVALID'),
     new EnvWithoutInstallError(),
-    new ForAllWithoutInstallError(),
     new ConfigValidationError(['error']),
     new FileSizeError('/path', 5000000)
   ]


### PR DESCRIPTION
## Summary

- Replace broken hardcoded 4-path config list with structured `CLIENT_DEFINITIONS` registry supporting 5 clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code)
- `--install` now auto-detects and targets all detected clients by default (removes `--for-all` flag)
- Claude Code installs via `claude mcp add-json` subprocess instead of file write
- Fix incorrect paths for Windsurf (`~/.codeium/windsurf/mcp_config.json`) and VS Code (platform-specific)
- Add Claude Desktop support (previously missing)
- 89 new tests across npm (41) and Python (43), plus Go QA fixes
- Update all docs: enhanced-cli-config specs, troubleshooting, and fix stale "4 tools" → "5 tools" MCP references across 7 doc files

## Test plan

- [x] 57 npm tests pass (config, install, uninstall, errors)
- [x] 43 Python tests pass (config, install, uninstall, platform_cleanup)
- [x] Go compiles clean
- [x] Merged next — no conflicts
- [ ] `gasoline-mcp --install --dry-run` shows correct paths for all detected clients
- [ ] `gasoline-mcp --doctor` reports correct status per client

🤖 Generated with [Claude Code](https://claude.com/claude-code)