### PR TITLE
feat: audit/redaction wiring, save_state redaction (#132), MCP compliance (#125)

### DIFF
--- a/cmd/dev-console/bridge_fastpath_unit_test.go
+++ b/cmd/dev-console/bridge_fastpath_unit_test.go
@@ -161,8 +161,9 @@ func TestBridgeFastPathCoreMethods(t *testing.T) {
 	if err := json.Unmarshal(responses[1].Result, &initResult); err != nil {
 		t.Fatalf("initialize result unmarshal error = %v", err)
 	}
-	if initResult["protocolVersion"] != "2024-11-05" {
-		t.Fatalf("protocolVersion = %v, want 2024-11-05", initResult["protocolVersion"])
+	pv := initResult["protocolVersion"]
+	if pv != "2024-11-05" && pv != "2025-06-18" {
+		t.Fatalf("protocolVersion = %v, want supported version (2024-11-05 or 2025-06-18)", pv)
 	}
 
 	// tools/list fast path.

--- a/cmd/dev-console/bridge_runmode_unit_test.go
+++ b/cmd/dev-console/bridge_runmode_unit_test.go
@@ -33,7 +33,7 @@ func TestRunBridgeModeWithExistingServer(t *testing.T) {
 			runBridgeMode(port, "", 0)
 		})
 	})
-	if !strings.Contains(output, `"protocolVersion":"2024-11-05"`) {
-		t.Fatalf("runBridgeMode output missing initialize response: %q", output)
+	if !strings.Contains(output, `"protocolVersion":"2025-06-18"`) && !strings.Contains(output, `"protocolVersion":"2024-11-05"`) {
+		t.Fatalf("runBridgeMode output missing initialize response with supported protocolVersion: %q", output)
 	}
 }

--- a/cmd/dev-console/handler.go
+++ b/cmd/dev-console/handler.go
@@ -66,6 +66,7 @@ type RateLimiter interface {
 // RedactionEngine interface for response redaction
 type RedactionEngine interface {
 	RedactJSON(data json.RawMessage) json.RawMessage
+	RedactMapValues(data map[string]any) map[string]any
 }
 
 // NewMCPHandler creates a new MCP handler
@@ -157,12 +158,18 @@ func (h *MCPHandler) HandleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate Content-Type: must be application/json (or empty for lenient clients)
+	if ct := r.Header.Get("Content-Type"); ct != "" && !strings.Contains(ct, "application/json") {
+		h.writeJSONRPCError(w, nil, -32700, "Unsupported Content-Type: "+ct)
+		return
+	}
+
 	r.Body = http.MaxBytesReader(w, r.Body, maxPostBodySize)
 
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		h.logDebugEntry(ctx, "", http.StatusBadRequest, "", fmt.Sprintf("Could not read body: %v", err))
-		h.writeJSONRPCError(w, "error", -32700, "Read error: "+err.Error())
+		h.writeJSONRPCError(w, nil, -32700, "Read error: "+err.Error())
 		return
 	}
 
@@ -202,19 +209,6 @@ func (h *MCPHandler) writeJSONRPCError(w http.ResponseWriter, id any, code int, 
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// extractJSONRPCID attempts to extract the "id" field from JSON bytes.
-// Returns the extracted ID or "error" as fallback (never null - Cursor rejects it).
-func extractJSONRPCID(bodyBytes []byte) any {
-	var partial map[string]any
-	var errorID any = "error"
-	if json.Unmarshal(bodyBytes, &partial) == nil {
-		if id, ok := partial["id"]; ok && id != nil {
-			errorID = id
-		}
-	}
-	return errorID
-}
-
 // mcpMethodHandler is a function that handles a specific MCP method.
 type mcpMethodHandler func(h *MCPHandler, req JSONRPCRequest) JSONRPCResponse
 
@@ -238,9 +232,19 @@ var mcpStaticResponses = map[string]string{
 // HandleRequest processes an MCP request and returns a response.
 // Returns nil for notifications (which should not receive a response).
 func (h *MCPHandler) HandleRequest(req JSONRPCRequest) *JSONRPCResponse {
-	// CRITICAL: Notifications do NOT get responses per JSON-RPC 2.0 spec
-	if req.ID == nil || strings.HasPrefix(req.Method, "notifications/") {
+	// JSON-RPC 2.0: "A Notification is a Request object without an 'id' member."
+	// The notifications/ prefix is a naming convention, not a detection rule.
+	if req.ID == nil {
 		return nil
+	}
+
+	// JSON-RPC 2.0: All requests must include "jsonrpc": "2.0"
+	if req.JSONRPC != "2.0" {
+		return &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &JSONRPCError{Code: -32600, Message: `Invalid Request: jsonrpc must be "2.0"`},
+		}
 	}
 
 	if handler, ok := mcpMethodHandlers[req.Method]; ok {
@@ -262,7 +266,13 @@ func (h *MCPHandler) HandleRequest(req JSONRPCRequest) *JSONRPCResponse {
 }
 
 func (h *MCPHandler) handleInitialize(req JSONRPCRequest) JSONRPCResponse {
-	const supportedVersion = "2024-11-05"
+	const latestVersion = "2025-06-18"
+
+	// Supported protocol versions (newest first).
+	var supportedVersions = map[string]bool{
+		"2025-06-18": true,
+		"2024-11-05": true,
+	}
 
 	// Parse client's requested protocol version (best-effort; missing/empty is fine)
 	var initParams struct {
@@ -273,8 +283,8 @@ func (h *MCPHandler) handleInitialize(req JSONRPCRequest) JSONRPCResponse {
 	}
 
 	// Negotiate: echo client's version if supported, otherwise respond with our latest
-	negotiatedVersion := supportedVersion
-	if initParams.ProtocolVersion == supportedVersion {
+	negotiatedVersion := latestVersion
+	if supportedVersions[initParams.ProtocolVersion] {
 		negotiatedVersion = initParams.ProtocolVersion
 	}
 

--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -603,6 +603,14 @@
           "properties": {
             "action": {
               "const": "health"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -622,6 +630,14 @@
                 "actions",
                 "logs",
                 "all"
+              ],
+              "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
               ],
               "type": "string"
             }
@@ -654,6 +670,14 @@
                 "stats"
               ],
               "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -665,6 +689,14 @@
           "properties": {
             "action": {
               "const": "load"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -709,6 +741,14 @@
                 "type": "object"
               },
               "type": "array"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -751,6 +791,14 @@
                 "enable",
                 "disable",
                 "status"
+              ],
+              "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
               ],
               "type": "string"
             },
@@ -811,6 +859,14 @@
               ],
               "type": "string"
             },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
+            },
             "url": {
               "type": "string"
             }
@@ -842,6 +898,14 @@
             "since": {
               "type": "string"
             },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
+            },
             "tool_name": {
               "type": "string"
             }
@@ -859,6 +923,14 @@
             "label": {
               "type": "string"
             },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
+            },
             "test_id": {
               "type": "string"
             }
@@ -873,6 +945,14 @@
           "properties": {
             "action": {
               "const": "test_boundary_end"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             },
             "test_id": {
               "type": "string"
@@ -895,6 +975,14 @@
             "sensitive_data_enabled": {
               "type": "boolean"
             },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
+            },
             "url": {
               "type": "string"
             }
@@ -911,6 +999,14 @@
             },
             "recording_id": {
               "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -924,6 +1020,14 @@
               "const": "playback"
             },
             "recording_id": {
+              "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
               "type": "string"
             }
           },
@@ -941,6 +1045,14 @@
               "type": "string"
             },
             "replay_id": {
+              "type": "string"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
               "type": "string"
             }
           },

--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -597,6 +597,360 @@
     "name": "configure",
     "description": "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states).",
     "inputSchema": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "health"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "clear"
+            },
+            "buffer": {
+              "enum": [
+                "network",
+                "websocket",
+                "actions",
+                "logs",
+                "all"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "store"
+            },
+            "data": {
+              "type": "object"
+            },
+            "key": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "store_action": {
+              "enum": [
+                "save",
+                "load",
+                "list",
+                "delete",
+                "stats"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "load"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "noise_rule"
+            },
+            "category": {
+              "enum": [
+                "console",
+                "network",
+                "websocket"
+              ],
+              "type": "string"
+            },
+            "noise_action": {
+              "enum": [
+                "add",
+                "remove",
+                "list",
+                "reset",
+                "auto_detect"
+              ],
+              "type": "string"
+            },
+            "pattern": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "rule_id": {
+              "type": "string"
+            },
+            "rules": {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "streaming"
+            },
+            "events": {
+              "items": {
+                "enum": [
+                  "errors",
+                  "network_errors",
+                  "performance",
+                  "user_frustration",
+                  "security",
+                  "regression",
+                  "anomaly",
+                  "ci",
+                  "all"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "severity_min": {
+              "enum": [
+                "info",
+                "warning",
+                "error"
+              ],
+              "type": "string"
+            },
+            "streaming_action": {
+              "enum": [
+                "enable",
+                "disable",
+                "status"
+              ],
+              "type": "string"
+            },
+            "throttle_seconds": {
+              "maximum": 60,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "streaming_action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "telemetry"
+            },
+            "telemetry_mode": {
+              "enum": [
+                "off",
+                "auto",
+                "full"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "diff_sessions"
+            },
+            "compare_a": {
+              "type": "string"
+            },
+            "compare_b": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "session_action": {
+              "enum": [
+                "capture",
+                "compare",
+                "list",
+                "delete"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "audit_log"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "operation": {
+              "enum": [
+                "analyze",
+                "report",
+                "clear"
+              ],
+              "type": "string"
+            },
+            "session_id": {
+              "type": "string"
+            },
+            "since": {
+              "type": "string"
+            },
+            "tool_name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "test_boundary_start"
+            },
+            "label": {
+              "type": "string"
+            },
+            "test_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "test_id"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "test_boundary_end"
+            },
+            "test_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "test_id"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "recording_start"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sensitive_data_enabled": {
+              "type": "boolean"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "recording_stop"
+            },
+            "recording_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "playback"
+            },
+            "recording_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "const": "log_diff"
+            },
+            "original_id": {
+              "type": "string"
+            },
+            "replay_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "original_id",
+            "replay_id"
+          ]
+        }
+      ],
       "properties": {
         "action": {
           "enum": [
@@ -696,6 +1050,10 @@
           ],
           "type": "string"
         },
+        "operation": {
+          "description": "Action-specific operation key",
+          "type": "string"
+        },
         "original_id": {
           "description": "Original recording ID (log_diff)",
           "type": "string"
@@ -726,6 +1084,10 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "sensitive_data_enabled": {
+          "description": "Include sensitive data in recording capture",
+          "type": "boolean"
         },
         "session_action": {
           "enum": [
@@ -795,6 +1157,10 @@
         },
         "tool_name": {
           "description": "Filter by tool name",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL filter for snapshot capture (diff_sessions)",
           "type": "string"
         }
       },

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -540,6 +540,9 @@ func (h *ToolHandler) toolGetAuditLog(req JSONRPCRequest, args json.RawMessage) 
 	}
 	if operation == "clear" {
 		cleared := h.auditTrail.Clear()
+		h.auditMu.Lock()
+		h.auditSessions = make(map[string]string)
+		h.auditMu.Unlock()
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Audit log cleared", map[string]any{
 			"status":    "ok",
 			"operation": "clear",

--- a/cmd/dev-console/tools_configure_wave_abc_tdd_test.go
+++ b/cmd/dev-console/tools_configure_wave_abc_tdd_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/capture"
+)
+
+func configureSchemaPropertiesForTest(t *testing.T) map[string]any {
+	t.Helper()
+	server, err := NewServer(t.TempDir()+"/schema-wave-abc.jsonl", 10)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { server.Close() })
+	cap := capture.NewCapture()
+	tools := NewToolHandler(server, cap).toolHandler.ToolsList()
+	for _, tool := range tools {
+		if tool.Name != "configure" {
+			continue
+		}
+		props, ok := tool.InputSchema["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("configure tool schema missing properties")
+		}
+		return props
+	}
+	t.Fatal("configure tool not found in schema")
+	return nil
+}
+
+func callHandledTool(t *testing.T, h *ToolHandler, req JSONRPCRequest, name, argsJSON string) JSONRPCResponse {
+	t.Helper()
+	resp, handled := h.HandleToolCall(req, name, json.RawMessage(argsJSON))
+	if !handled {
+		t.Fatalf("tool %q was not handled", name)
+	}
+	return resp
+}
+
+func TestWaveA_ConfigureSchema_DiffSessionsURLPropertyPresent(t *testing.T) {
+	t.Parallel()
+
+	props := configureSchemaPropertiesForTest(t)
+	if _, ok := props["url"]; !ok {
+		t.Fatal("configure schema should include 'url' for diff_sessions capture filtering")
+	}
+}
+
+func TestWaveB_ConfigureSchema_AuditLogOperationPropertyPresent(t *testing.T) {
+	t.Parallel()
+
+	props := configureSchemaPropertiesForTest(t)
+	opRaw, ok := props["operation"].(map[string]any)
+	if !ok {
+		t.Fatal("configure schema should include 'operation' for audit_log operation routing")
+	}
+
+	enumVals, ok := opRaw["enum"].([]string)
+	if !ok {
+		t.Fatal("configure.operation enum should be []string")
+	}
+	got := strings.Join(enumVals, ",")
+	for _, want := range []string{"analyze", "report", "clear"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("configure.operation enum missing %q: %v", want, enumVals)
+		}
+	}
+}
+
+func TestWaveB_AuditLogOperationAnalyzeAndClear(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(t.TempDir()+"/audit-waveb.jsonl", 100)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { server.Close() })
+
+	cap := capture.NewCapture()
+	mcpHandler := NewToolHandler(server, cap)
+	h := mcpHandler.toolHandler.(*ToolHandler)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1, ClientID: "wave-b-test"}
+
+	callHandledTool(t, h, req, "configure", `{"action":"health"}`)
+	callHandledTool(t, h, req, "observe", `{"what":"logs"}`)
+
+	analyzeResp := callHandledTool(t, h, req, "configure", `{"action":"audit_log","operation":"analyze"}`)
+	analyzeResult := parseToolResult(t, analyzeResp)
+	if analyzeResult.IsError {
+		t.Fatalf("audit_log analyze should succeed, got: %s", analyzeResult.Content[0].Text)
+	}
+	analyzeData := extractResultJSON(t, analyzeResult)
+	if analyzeData["operation"] != "analyze" {
+		t.Fatalf("operation = %v, want analyze", analyzeData["operation"])
+	}
+	if _, ok := analyzeData["summary"]; !ok {
+		t.Fatal("audit_log analyze should include summary")
+	}
+
+	clearResp := callHandledTool(t, h, req, "configure", `{"action":"audit_log","operation":"clear"}`)
+	clearResult := parseToolResult(t, clearResp)
+	if clearResult.IsError {
+		t.Fatalf("audit_log clear should succeed, got: %s", clearResult.Content[0].Text)
+	}
+	clearData := extractResultJSON(t, clearResult)
+	if clearData["operation"] != "clear" {
+		t.Fatalf("operation = %v, want clear", clearData["operation"])
+	}
+	if _, ok := clearData["cleared"]; !ok {
+		t.Fatal("audit_log clear should report cleared count")
+	}
+}
+
+func TestWaveC_RedactionEngineIsWiredAndApplied(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(t.TempDir()+"/redaction-wavec.jsonl", 100)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { server.Close() })
+
+	cap := capture.NewCapture()
+	h := NewToolHandler(server, cap)
+	if h.toolHandler.GetRedactionEngine() == nil {
+		t.Fatal("tool handler should provide a redaction engine")
+	}
+
+	input := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      1,
+		Result:  json.RawMessage(`{"content":[{"type":"text","text":"Authorization: Bearer ghp_1234567890abcdef"}],"isError":false}`),
+	}
+	output := h.applyToolResponsePostProcessing(input, "wave-c-test", "configure", "")
+	result := parseToolResult(t, output)
+	if len(result.Content) == 0 {
+		t.Fatal("expected content in redacted response")
+	}
+	if !strings.Contains(result.Content[0].Text, "[REDACTED") {
+		t.Fatalf("expected redacted output, got: %q", result.Content[0].Text)
+	}
+}

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dev-console/dev-console/internal/analysis"
 	"github.com/dev-console/dev-console/internal/audit"
 	"github.com/dev-console/dev-console/internal/capture"
+	"github.com/dev-console/dev-console/internal/redaction"
 	"github.com/dev-console/dev-console/internal/security"
 	"github.com/dev-console/dev-console/internal/session"
 )
@@ -173,7 +174,7 @@ type ToolHandler struct {
 	healthMetrics *HealthMetrics
 
 	// Redaction engine for scrubbing sensitive data from tool responses
-	redactionEngine *RedactionEngine
+	redactionEngine RedactionEngine
 
 	// Rate limiter for MCP tool calls (sliding window)
 	toolCallLimiter *ToolCallLimiter
@@ -229,10 +230,7 @@ func (h *ToolHandler) GetToolCallLimiter() RateLimiter {
 
 // GetRedactionEngine returns the redaction engine
 func (h *ToolHandler) GetRedactionEngine() RedactionEngine {
-	if h.redactionEngine != nil {
-		return *h.redactionEngine
-	}
-	return nil
+	return h.redactionEngine
 }
 
 // NewToolHandler creates an MCP handler with composite tool capabilities
@@ -261,6 +259,7 @@ func NewToolHandler(server *Server, capture *capture.Capture) *MCPHandler {
 	} else {
 		handler.noiseConfig = ai.NewNoiseConfig()
 	}
+	handler.redactionEngine = redaction.NewRedactionEngine("")
 
 	// Use global annotation store for draw mode
 	handler.annotationStore = globalAnnotationStore

--- a/cmd/dev-console/tools_core_unit_test.go
+++ b/cmd/dev-console/tools_core_unit_test.go
@@ -44,7 +44,7 @@ func TestGetToolCallLimiter(t *testing.T) {
 	}
 }
 
-func TestGetRedactionEngine_Nil(t *testing.T) {
+func TestGetRedactionEngine_Configured(t *testing.T) {
 	t.Parallel()
 
 	cap := capture.NewCapture()
@@ -55,8 +55,7 @@ func TestGetRedactionEngine_Nil(t *testing.T) {
 	mcpHandler := NewToolHandler(server, cap)
 	h := mcpHandler.toolHandler.(*ToolHandler)
 
-	// By default, no redaction engine is configured
-	if h.GetRedactionEngine() != nil {
-		t.Fatal("GetRedactionEngine should return nil when no engine is set")
+	if h.GetRedactionEngine() == nil {
+		t.Fatal("GetRedactionEngine should return a configured engine")
 	}
 }

--- a/cmd/dev-console/tools_interact_state.go
+++ b/cmd/dev-console/tools_interact_state.go
@@ -359,6 +359,11 @@ func (h *ToolHandler) handlePilotManageStateSave(req JSONRPCRequest, args json.R
 		}
 	}
 
+	// Server-side redaction: scrub sensitive values before persisting to disk (#132)
+	if re := h.GetRedactionEngine(); re != nil {
+		stateData = re.RedactMapValues(stateData)
+	}
+
 	data, err := json.Marshal(stateData)
 	if err != nil {
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInternal, "Failed to serialize state: "+err.Error(), "Internal error — do not retry")}

--- a/cmd/dev-console/tools_schema.go
+++ b/cmd/dev-console/tools_schema.go
@@ -520,10 +520,13 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"type":        "string",
 						"description": "Recording ID (recording_stop, playback)",
 					},
+					"sensitive_data_enabled": map[string]any{
+						"type":        "boolean",
+						"description": "Include sensitive data in recording capture",
+					},
 					"operation": map[string]any{
 						"type":        "string",
-						"description": "Audit log operation",
-						"enum":        []string{"analyze", "report", "clear"},
+						"description": "Action-specific operation key",
 					},
 					"session_id": map[string]any{
 						"type":        "string",
@@ -578,6 +581,161 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					"replay_id": map[string]any{
 						"type":        "string",
 						"description": "Replay recording ID (log_diff)",
+					},
+				},
+				"oneOf": []map[string]any{
+					{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "health"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "clear"},
+							"buffer": map[string]any{"type": "string", "enum": []string{"network", "websocket", "actions", "logs", "all"}},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":       map[string]any{"const": "store"},
+							"store_action": map[string]any{"type": "string", "enum": []string{"save", "load", "list", "delete", "stats"}},
+							"namespace":    map[string]any{"type": "string"},
+							"key":          map[string]any{"type": "string"},
+							"data":         map[string]any{"type": "object"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "load"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":       map[string]any{"const": "noise_rule"},
+							"noise_action": map[string]any{"type": "string", "enum": []string{"add", "remove", "list", "reset", "auto_detect"}},
+							"rules":        map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
+							"rule_id":      map[string]any{"type": "string"},
+							"pattern":      map[string]any{"type": "string"},
+							"category":     map[string]any{"type": "string", "enum": []string{"console", "network", "websocket"}},
+							"reason":       map[string]any{"type": "string"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":           map[string]any{"const": "streaming"},
+							"streaming_action": map[string]any{"type": "string", "enum": []string{"enable", "disable", "status"}},
+							"events": map[string]any{
+								"type": "array",
+								"items": map[string]any{
+									"type": "string",
+									"enum": []string{"errors", "network_errors", "performance", "user_frustration", "security", "regression", "anomaly", "ci", "all"},
+								},
+							},
+							"throttle_seconds": map[string]any{"type": "integer", "minimum": 1, "maximum": 60},
+							"severity_min":     map[string]any{"type": "string", "enum": []string{"info", "warning", "error"}},
+							"url":              map[string]any{"type": "string"},
+						},
+						"required":             []string{"action", "streaming_action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "telemetry"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":         map[string]any{"const": "diff_sessions"},
+							"session_action": map[string]any{"type": "string", "enum": []string{"capture", "compare", "list", "delete"}},
+							"name":           map[string]any{"type": "string"},
+							"compare_a":      map[string]any{"type": "string"},
+							"compare_b":      map[string]any{"type": "string"},
+							"url":            map[string]any{"type": "string"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":     map[string]any{"const": "audit_log"},
+							"operation":  map[string]any{"type": "string", "enum": []string{"analyze", "report", "clear"}},
+							"session_id": map[string]any{"type": "string"},
+							"tool_name":  map[string]any{"type": "string"},
+							"since":      map[string]any{"type": "string"},
+							"limit":      map[string]any{"type": "number"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":  map[string]any{"const": "test_boundary_start"},
+							"test_id": map[string]any{"type": "string"},
+							"label":   map[string]any{"type": "string"},
+						},
+						"required":             []string{"action", "test_id"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":  map[string]any{"const": "test_boundary_end"},
+							"test_id": map[string]any{"type": "string"},
+						},
+						"required":             []string{"action", "test_id"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "recording_start"},
+							"name":   map[string]any{"type": "string"},
+							"url":    map[string]any{"type": "string"},
+							"sensitive_data_enabled": map[string]any{
+								"type": "boolean",
+							},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":       map[string]any{"const": "recording_stop"},
+							"recording_id": map[string]any{"type": "string"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":       map[string]any{"const": "playback"},
+							"recording_id": map[string]any{"type": "string"},
+						},
+						"required":             []string{"action"},
+						"additionalProperties": false,
+					},
+					{
+						"properties": map[string]any{
+							"action":      map[string]any{"const": "log_diff"},
+							"original_id": map[string]any{"type": "string"},
+							"replay_id":   map[string]any{"type": "string"},
+						},
+						"required":             []string{"action", "original_id", "replay_id"},
+						"additionalProperties": false,
 					},
 				},
 				"required": []string{"action"},

--- a/cmd/dev-console/tools_schema.go
+++ b/cmd/dev-console/tools_schema.go
@@ -587,6 +587,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					{
 						"properties": map[string]any{
 							"action": map[string]any{"const": "health"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -595,6 +599,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"properties": map[string]any{
 							"action": map[string]any{"const": "clear"},
 							"buffer": map[string]any{"type": "string", "enum": []string{"network", "websocket", "actions", "logs", "all"}},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -606,6 +614,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"namespace":    map[string]any{"type": "string"},
 							"key":          map[string]any{"type": "string"},
 							"data":         map[string]any{"type": "object"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -613,6 +625,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 					{
 						"properties": map[string]any{
 							"action": map[string]any{"const": "load"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -626,6 +642,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"pattern":      map[string]any{"type": "string"},
 							"category":     map[string]any{"type": "string", "enum": []string{"console", "network", "websocket"}},
 							"reason":       map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -644,6 +664,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"throttle_seconds": map[string]any{"type": "integer", "minimum": 1, "maximum": 60},
 							"severity_min":     map[string]any{"type": "string", "enum": []string{"info", "warning", "error"}},
 							"url":              map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action", "streaming_action"},
 						"additionalProperties": false,
@@ -667,6 +691,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"compare_a":      map[string]any{"type": "string"},
 							"compare_b":      map[string]any{"type": "string"},
 							"url":            map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -679,6 +707,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"tool_name":  map[string]any{"type": "string"},
 							"since":      map[string]any{"type": "string"},
 							"limit":      map[string]any{"type": "number"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -688,6 +720,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"action":  map[string]any{"const": "test_boundary_start"},
 							"test_id": map[string]any{"type": "string"},
 							"label":   map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action", "test_id"},
 						"additionalProperties": false,
@@ -696,6 +732,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"properties": map[string]any{
 							"action":  map[string]any{"const": "test_boundary_end"},
 							"test_id": map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action", "test_id"},
 						"additionalProperties": false,
@@ -708,6 +748,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"sensitive_data_enabled": map[string]any{
 								"type": "boolean",
 							},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -716,6 +760,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"properties": map[string]any{
 							"action":       map[string]any{"const": "recording_stop"},
 							"recording_id": map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -724,6 +772,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"properties": map[string]any{
 							"action":       map[string]any{"const": "playback"},
 							"recording_id": map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action"},
 						"additionalProperties": false,
@@ -733,6 +785,10 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 							"action":      map[string]any{"const": "log_diff"},
 							"original_id": map[string]any{"type": "string"},
 							"replay_id":   map[string]any{"type": "string"},
+							"telemetry_mode": map[string]any{
+								"type": "string",
+								"enum": []string{"off", "auto", "full"},
+							},
 						},
 						"required":             []string{"action", "original_id", "replay_id"},
 						"additionalProperties": false,

--- a/cmd/dev-console/tools_schema.go
+++ b/cmd/dev-console/tools_schema.go
@@ -512,9 +512,18 @@ func (h *ToolHandler) ToolsList() []MCPTool {
 						"type":        "string",
 						"description": "Second snapshot to compare",
 					},
+					"url": map[string]any{
+						"type":        "string",
+						"description": "URL filter for snapshot capture (diff_sessions)",
+					},
 					"recording_id": map[string]any{
 						"type":        "string",
 						"description": "Recording ID (recording_stop, playback)",
+					},
+					"operation": map[string]any{
+						"type":        "string",
+						"description": "Audit log operation",
+						"enum":        []string{"analyze", "report", "clear"},
 					},
 					"session_id": map[string]any{
 						"type":        "string",

--- a/docs/audits/api-reference.md
+++ b/docs/audits/api-reference.md
@@ -615,6 +615,7 @@ Classify test type.
 **Purpose**: Session settings and utilities.
 
 **Required parameter**: `action` (string)
+**Schema model**: `configure` is an action-discriminated union (`oneOf`). Each `action` allows only its action-specific keys.
 
 #### Configure Actions
 
@@ -713,16 +714,42 @@ Stop a flow recording.
 
 Replay a recording.
 
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| recording_id | string | no | -- | Recording to replay |
+
 ##### configure({action: "log_diff"})
 
 Compare error states over time.
 
-#### Configure actions registered in handler map but NOT in schema enum
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| original_id | string | yes | -- | Original recording ID |
+| replay_id | string | yes | -- | Replay recording ID |
 
-| Action | Status |
-|--------|--------|
-| `diff_sessions` | Registered in handler, NOT in schema enum |
-| `audit_log` | Registered in handler, NOT in schema enum |
+##### configure({action: "diff_sessions"})
+
+Capture/list/compare/delete session snapshots.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| session_action | string | no | "list" | capture, compare, list, delete |
+| name | string | no | -- | Snapshot name |
+| compare_a | string | no | -- | First snapshot to compare |
+| compare_b | string | no | -- | Second snapshot to compare |
+| url | string | no | -- | URL filter for capture |
+
+##### configure({action: "audit_log"})
+
+Query, summarize, or clear tool invocation history.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| operation | string | no | "report" | analyze, report, clear |
+| session_id | string | no | -- | Filter by session |
+| tool_name | string | no | -- | Filter by tool |
+| since | string | no | -- | RFC3339 lower bound |
+| limit | number | no | 100 | Max entries |
 
 ---
 

--- a/docs/audits/api-reference.md
+++ b/docs/audits/api-reference.md
@@ -615,7 +615,7 @@ Classify test type.
 **Purpose**: Session settings and utilities.
 
 **Required parameter**: `action` (string)
-**Schema model**: `configure` is an action-discriminated union (`oneOf`). Each `action` allows only its action-specific keys.
+**Schema model**: `configure` is an action-discriminated union (`oneOf`). Each `action` allows only its action-specific keys, plus optional cross-cutting `telemetry_mode`.
 
 #### Configure Actions
 

--- a/docs/core/mcp-command-option-matrix.md
+++ b/docs/core/mcp-command-option-matrix.md
@@ -134,7 +134,20 @@ canonical: true
 
 ### `configure` options
 - Dispatch key: `action`
-- Action family keys: `store_action`, `namespace`, `key`, `data`, `noise_action`, `rules`, `rule_id`, `pattern`, `category`, `reason`, `buffer`, `tab_id`, `session_action`, `name`, `compare_a`, `compare_b`, `recording_id`, `session_id`, `tool_name`, `since`, `limit`, `streaming_action`, `events`, `throttle_seconds`, `severity_min`, `test_id`, `label`, `original_id`, `replay_id`
+- Schema shape: discriminated union (`oneOf`) by `action` with action-specific keys only
+- `store`: `store_action`, `namespace`, `key`, `data`
+- `noise_rule`: `noise_action`, `rules`, `rule_id`, `pattern`, `category`, `reason`
+- `clear`: `buffer`
+- `streaming`: `streaming_action`, `events`, `throttle_seconds`, `severity_min`, `url`
+- `telemetry`: `telemetry_mode`
+- `diff_sessions`: `session_action`, `name`, `compare_a`, `compare_b`, `url`
+- `audit_log`: `operation`, `session_id`, `tool_name`, `since`, `limit`
+- `test_boundary_start`: `test_id`, `label`
+- `test_boundary_end`: `test_id`
+- `recording_start`: `name`, `url`, `sensitive_data_enabled`
+- `recording_stop`: `recording_id`
+- `playback`: `recording_id`
+- `log_diff`: `original_id`, `replay_id`
 - Cross-cutting key: `telemetry_mode`
 
 ### `interact` options

--- a/internal/audit/audit_trail.go
+++ b/internal/audit/audit_trail.go
@@ -40,12 +40,12 @@ type AuditEntry struct {
 
 // AuditTrail is an append-only, bounded, concurrent-safe audit log.
 type AuditTrail struct {
-	mu              sync.RWMutex
-	entries         []AuditEntry
-	maxSize         int
-	sessions        map[string]*SessionInfo
-	config          AuditConfig
-	redactions      []RedactionEvent
+	mu                sync.RWMutex
+	entries           []AuditEntry
+	maxSize           int
+	sessions          map[string]*SessionInfo
+	config            AuditConfig
+	redactions        []RedactionEvent
 	redactionPatterns []*redactionPattern
 }
 
@@ -119,10 +119,10 @@ func NewAuditTrail(config AuditConfig) *AuditTrail {
 	}
 
 	trail := &AuditTrail{
-		entries:  make([]AuditEntry, 0, config.MaxEntries),
-		maxSize:  config.MaxEntries,
-		sessions: make(map[string]*SessionInfo),
-		config:   config,
+		entries:    make([]AuditEntry, 0, config.MaxEntries),
+		maxSize:    config.MaxEntries,
+		sessions:   make(map[string]*SessionInfo),
+		config:     config,
 		redactions: make([]RedactionEvent, 0),
 	}
 
@@ -225,6 +225,18 @@ func (at *AuditTrail) Query(filter AuditFilter) []AuditEntry {
 	}
 
 	return results
+}
+
+// Clear removes all audit entries and redaction events and returns the number
+// of entries removed.
+func (at *AuditTrail) Clear() int {
+	at.mu.Lock()
+	defer at.mu.Unlock()
+
+	cleared := len(at.entries)
+	at.entries = at.entries[:0]
+	at.redactions = at.redactions[:0]
+	return cleared
 }
 
 // QueryRedactions returns redaction events matching the given filter.

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -15,17 +15,20 @@ import (
 )
 
 // MCPContentBlock represents a single content block in an MCP tool response.
-// This is duplicated from cmd/dev-console/tools.go to avoid circular imports.
+// This is duplicated from cmd/dev-console/tools_core.go to avoid circular imports.
+// IMPORTANT: Must stay in sync with the main package's MCPContentBlock.
 type MCPContentBlock struct {
 	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Text string `json:"text"`
 }
 
 // MCPToolResult represents the result of an MCP tool call.
-// This is duplicated from cmd/dev-console/tools.go to avoid circular imports.
+// This is duplicated from cmd/dev-console/tools_core.go to avoid circular imports.
+// IMPORTANT: Must stay in sync with the main package's MCPToolResult.
 type MCPToolResult struct {
-	Content []MCPContentBlock `json:"content"`
-	IsError bool              `json:"isError,omitempty"` // SPEC:MCP
+	Content  []MCPContentBlock `json:"content"`
+	IsError  bool              `json:"isError,omitempty"` // SPEC:MCP
+	Metadata map[string]any    `json:"metadata,omitempty"`
 }
 
 // RedactionPattern represents a single redaction rule.

--- a/internal/redaction/redaction_unit_test.go
+++ b/internal/redaction/redaction_unit_test.go
@@ -49,6 +49,138 @@ func TestRedact_CreditCardLuhnValidation(t *testing.T) {
 	}
 }
 
+func TestRedactMapValues_RedactsSensitiveKeyNames(t *testing.T) {
+	t.Parallel()
+	engine := NewRedactionEngine("")
+
+	input := map[string]any{
+		"username":    "alice",
+		"password":    "s3cret",
+		"token":       "abc123",
+		"secret":      "mysecret",
+		"ssn":         "123-45-6789",
+		"credit_card": "4111111111111111",
+		"cvv":         "123",
+		"auth":        "bearer xyz",
+		"normal_key":  "normal_value",
+	}
+	result := engine.RedactMapValues(input)
+
+	// Sensitive keys should be redacted
+	for _, key := range []string{"password", "token", "secret", "ssn", "credit_card", "cvv", "auth"} {
+		v, ok := result[key].(string)
+		if !ok {
+			t.Fatalf("expected string value for key %q, got %T", key, result[key])
+		}
+		if !strings.Contains(v, "[REDACTED") {
+			t.Errorf("key %q should be redacted, got %q", key, v)
+		}
+	}
+
+	// Non-sensitive keys should pass through
+	if result["username"] != "alice" {
+		t.Errorf("username should be preserved, got %q", result["username"])
+	}
+	if result["normal_key"] != "normal_value" {
+		t.Errorf("normal_key should be preserved, got %q", result["normal_key"])
+	}
+}
+
+func TestRedactMapValues_RedactsPatternMatches(t *testing.T) {
+	t.Parallel()
+	engine := NewRedactionEngine("")
+
+	input := map[string]any{
+		"header":    "Bearer abc123def456",
+		"note":      "Key is AKIAIOSFODNN7EXAMPLE",
+		"safe_data": "nothing special here",
+	}
+	result := engine.RedactMapValues(input)
+
+	if v := result["header"].(string); !strings.Contains(v, "[REDACTED:bearer-token]") {
+		t.Errorf("bearer token pattern should be redacted, got %q", v)
+	}
+	if v := result["note"].(string); !strings.Contains(v, "[REDACTED:aws-key]") {
+		t.Errorf("AWS key pattern should be redacted, got %q", v)
+	}
+	if result["safe_data"] != "nothing special here" {
+		t.Errorf("safe_data should be preserved, got %q", result["safe_data"])
+	}
+}
+
+func TestRedactMapValues_RecursesNestedMaps(t *testing.T) {
+	t.Parallel()
+	engine := NewRedactionEngine("")
+
+	input := map[string]any{
+		"user": map[string]any{
+			"name":     "alice",
+			"password": "s3cret",
+			"prefs": map[string]any{
+				"theme":  "dark",
+				"secret": "hidden",
+			},
+		},
+		"top_level": "safe",
+	}
+	result := engine.RedactMapValues(input)
+
+	user, ok := result["user"].(map[string]any)
+	if !ok {
+		t.Fatal("expected nested map for 'user'")
+	}
+	if user["name"] != "alice" {
+		t.Errorf("nested name should be preserved, got %q", user["name"])
+	}
+	if v := user["password"].(string); !strings.Contains(v, "[REDACTED") {
+		t.Errorf("nested password should be redacted, got %q", v)
+	}
+
+	prefs, ok := user["prefs"].(map[string]any)
+	if !ok {
+		t.Fatal("expected nested map for 'prefs'")
+	}
+	if prefs["theme"] != "dark" {
+		t.Errorf("deeply nested theme should be preserved, got %q", prefs["theme"])
+	}
+	if v := prefs["secret"].(string); !strings.Contains(v, "[REDACTED") {
+		t.Errorf("deeply nested secret should be redacted, got %q", v)
+	}
+}
+
+func TestRedactMapValues_PreservesNonSensitiveData(t *testing.T) {
+	t.Parallel()
+	engine := NewRedactionEngine("")
+
+	input := map[string]any{
+		"url":        "https://example.com",
+		"title":      "My Page",
+		"tab_id":     float64(42),
+		"is_active":  true,
+		"saved_at":   "2024-01-01T00:00:00Z",
+		"nil_value":  nil,
+		"int_value":  float64(100),
+		"bool_value": false,
+	}
+	result := engine.RedactMapValues(input)
+
+	if result["url"] != "https://example.com" {
+		t.Errorf("url should be preserved, got %v", result["url"])
+	}
+	if result["title"] != "My Page" {
+		t.Errorf("title should be preserved, got %v", result["title"])
+	}
+	if result["tab_id"] != float64(42) {
+		t.Errorf("tab_id should be preserved, got %v", result["tab_id"])
+	}
+	if result["is_active"] != true {
+		t.Errorf("is_active should be preserved, got %v", result["is_active"])
+	}
+	if result["nil_value"] != nil {
+		t.Errorf("nil_value should be preserved, got %v", result["nil_value"])
+	}
+}
+
 func TestRedactJSON_StructuredBlocksOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

### Audit & Redaction Wiring (original)
- **Audit log operations**: Added `operation` parameter to `audit_log` action with `analyze`, `report`, and `clear` modes
- **Redaction engine wiring**: Changed from nil pointer to always-initialized engine with 10 built-in patterns
- **Schema additions**: Added `url` property for `diff_sessions` and `operation` enum for audit log routing
- **Bug fixes (B1-B5)**: Redaction struct divergence, omitempty on empty text, Clear() sessions reset, header docs

### Issue #132 — Server-Side Redaction for save_state
- Added `RedactMapValues(map[string]any)` to `RedactionEngine` — walks maps recursively, redacts sensitive key names (password, token, secret, ssn, credit_card, cvv, auth) and pattern-matched values (bearer tokens, JWTs, AWS keys, etc.)
- Wired into `handlePilotManageStateSave` before `json.Marshal` so captured form values, cookies, localStorage are scrubbed before persisting to disk

### Issue #125 — MCP Compliance Hardening
- **G1**: Read-error uses `null` ID instead of `"error"` string (JSON-RPC 2.0 §5)
- **G2**: Removed dead `extractJSONRPCID` function
- **G7**: Unified notification detection to `req.ID == nil` only (spec: "A Notification is a Request without an id member")
- **G4**: Protocol version negotiation supports `2024-11-05` + `2025-06-18`, defaults to latest
- **G5**: Content-Type validation rejects non-JSON with `-32700`
- **G8**: Validates `jsonrpc: "2.0"` field, rejects with `-32600`

## Test plan

- [x] TDD: All new tests written before implementation
- [x] `TestRedactMapValues_RedactsSensitiveKeyNames` — sensitive keys replaced
- [x] `TestRedactMapValues_RedactsPatternMatches` — bearer/AWS patterns caught
- [x] `TestRedactMapValues_RecursesNestedMaps` — deep map walking
- [x] `TestRedactMapValues_PreservesNonSensitiveData` — non-sensitive passthrough
- [x] `TestHandleRequest_RejectsInvalidJSONRPCVersion` — G8 validation
- [x] `TestHandleHTTP_RejectsNonJSONContentType` — G5 validation
- [x] `TestHandleInitialize_NegotiatesProtocolVersion` — G4 negotiation
- [x] `TestHandleRequest_NotificationDetection` — G7 spec compliance
- [x] Read-error null ID assertion added to existing `TestMCPHandlerHandleHTTP`
- [x] Full test suite passes: `cmd/dev-console/` + all `internal/...` packages
- [x] `go vet` + `go build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)