### PR TITLE
feat(installer): add 4 new MCP clients and targeted install

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,20 +141,79 @@ curl http://localhost:7890/health
 - MCP client communicates via stdio
 - Both share the same browser telemetry state
 
-Works with **Claude Code**, **Cursor**, **Windsurf**, **Claude Desktop**, **Zed**, and any MCP-compatible tool.
+Works with **Claude Code**, **Cursor**, **Windsurf**, **Claude Desktop**, **Gemini CLI**, **OpenCode**, **Antigravity**, **Zed**, and any MCP-compatible tool.
 
-**[Full setup guide →](https://cookwithgasoline.com/getting-started/)**
+*Option D: Gemini CLI*
+
+Add to `~/.gemini/settings.json`:
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+*Option E: OpenCode*
+
+Add to `~/.config/opencode/opencode.json`:
+```json
+{
+  "mcp": {
+    "gasoline": {
+      "type": "local",
+      "command": ["gasoline-mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+*Option F: Antigravity*
+
+Add to `~/.gemini/antigravity/mcp_config.json`:
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+*Option G: Zed*
+
+Add to `~/.config/zed/settings.json`:
+```json
+{
+  "context_servers": {
+    "gasoline": {
+      "source": "custom",
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+**[Full setup guide →](https://cookwithgasoline.com/getting-started/)** | **[Per-tool install guide →](docs/mcp-install-guide.md)**
 
 **CLI options:**
 
 | Flag | Description |
 |------|-------------|
 | `--port <n>` | Port to listen on (default: 7890) |
-| `--server` | HTTP-only mode (no MCP) |
-| `--persist` | Keep running after MCP disconnect |
 | `--api-key <key>` | Require API key for HTTP requests |
 | `--connect` | Connect to existing server (multi-client) |
-| `--check` | Verify setup before running |
+| `--client-id <id>` | Override client ID (default: derived from CWD) |
+| `--check` | Verify setup and print status |
+| `--stop` | Stop the running server on the specified port |
+| `--version` | Show version |
 | `--help` | Show all options |
 
 ## Why You Cook With Gasoline MCP

--- a/docs/mcp-install-guide.md
+++ b/docs/mcp-install-guide.md
@@ -1,0 +1,211 @@
+# MCP Installation Guide
+
+Gasoline MCP supports 9 AI coding tools. Use the auto-installer or configure manually.
+
+## Auto-Install
+
+```bash
+# Install to all detected clients
+gasoline-mcp --install
+
+# Install to a specific tool
+gasoline-mcp --install gemini
+gasoline-mcp --install opencode
+gasoline-mcp --install cursor
+
+# Preview without writing
+gasoline-mcp --install --dry-run
+
+# Check what's configured
+gasoline-mcp --doctor
+```
+
+Valid tool names: `claude`, `claude-desktop`, `cursor`, `windsurf`, `vscode`, `gemini`, `opencode`, `antigravity`, `zed`
+
+## Per-Tool Reference
+
+### Claude Code
+
+| | |
+|---|---|
+| **Install method** | CLI (`claude mcp add-json`) |
+| **Auto-install** | `gasoline-mcp --install claude` |
+
+Claude Code is configured via its own CLI, not a config file. The installer runs `claude mcp add-json --scope user gasoline` automatically.
+
+### Claude Desktop
+
+| | |
+|---|---|
+| **Config path (macOS)** | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Config path (Windows)** | `%APPDATA%/Claude/claude_desktop_config.json` |
+| **Auto-install** | `gasoline-mcp --install claude-desktop` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Cursor
+
+| | |
+|---|---|
+| **Config path** | `~/.cursor/mcp.json` |
+| **Auto-install** | `gasoline-mcp --install cursor` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Windsurf
+
+| | |
+|---|---|
+| **Config path** | `~/.codeium/windsurf/mcp_config.json` |
+| **Auto-install** | `gasoline-mcp --install windsurf` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### VS Code
+
+| | |
+|---|---|
+| **Config path (macOS)** | `~/Library/Application Support/Code/User/mcp.json` |
+| **Config path (Windows)** | `%APPDATA%/Code/User/mcp.json` |
+| **Config path (Linux)** | `~/.config/Code/User/mcp.json` |
+| **Auto-install** | `gasoline-mcp --install vscode` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+| | |
+|---|---|
+| **Config path** | `~/.gemini/settings.json` |
+| **Auto-install** | `gasoline-mcp --install gemini` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### OpenCode
+
+| | |
+|---|---|
+| **Config path** | `~/.config/opencode/opencode.json` |
+| **Auto-install** | `gasoline-mcp --install opencode` |
+
+OpenCode uses a different config format (`mcp` key with array-style commands):
+
+```json
+{
+  "mcp": {
+    "gasoline": {
+      "type": "local",
+      "command": ["gasoline-mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+### Antigravity
+
+| | |
+|---|---|
+| **Config path** | `~/.gemini/antigravity/mcp_config.json` |
+| **Auto-install** | `gasoline-mcp --install antigravity` |
+
+```json
+{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+Note: Antigravity does not support `${workspaceFolder}` — use absolute paths only.
+
+### Zed
+
+| | |
+|---|---|
+| **Config path** | `~/.config/zed/settings.json` |
+| **Auto-install** | `gasoline-mcp --install zed` |
+
+Zed uses the `context_servers` key:
+
+```json
+{
+  "context_servers": {
+    "gasoline": {
+      "source": "custom",
+      "command": "gasoline-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+## Verification
+
+After installing, verify the setup:
+
+```bash
+# Check all client configurations
+gasoline-mcp --doctor
+
+# Test the server is reachable
+curl http://localhost:7890/health
+```
+
+## Uninstall
+
+```bash
+# Remove from all clients
+gasoline-mcp --uninstall
+
+# Preview removal
+gasoline-mcp --uninstall --dry-run
+```

--- a/npm/gasoline-mcp/lib/cli.js
+++ b/npm/gasoline-mcp/lib/cli.js
@@ -136,7 +136,7 @@ function showHelp() {
   console.log('Usage: gasoline-mcp [command] [options]\n');
   console.log('Commands:');
   console.log('  --config, -c          Show MCP configuration and detected clients');
-  console.log('  --install, -i         Auto-install to all detected AI clients');
+  console.log('  --install, -i [tool]  Auto-install to detected clients, or a specific tool');
   console.log('  --doctor              Run diagnostics on installed configs');
   console.log('  --uninstall           Remove Gasoline from all clients');
   console.log('  --help, -h            Show this help message\n');
@@ -145,7 +145,14 @@ function showHelp() {
   console.log('  Claude Desktop        config file');
   console.log('  Cursor                config file');
   console.log('  Windsurf              config file');
-  console.log('  VS Code               config file\n');
+  console.log('  VS Code               config file');
+  console.log('  Gemini CLI            config file');
+  console.log('  OpenCode              config file');
+  console.log('  Antigravity           config file');
+  console.log('  Zed                   config file\n');
+  console.log('Tool aliases for --install <tool>:');
+  console.log('  claude, claude-desktop, cursor, windsurf, vscode, gemini, opencode,');
+  console.log('  antigravity, zed\n');
   console.log('Options (with --install):');
   console.log('  --dry-run             Preview changes without writing');
   console.log('  --env KEY=VALUE       Add environment variables to config (multiple allowed)');
@@ -161,6 +168,8 @@ function showHelp() {
   console.log('  --verbose             Show detailed operation logs\n');
   console.log('Examples:');
   console.log('  gasoline-mcp --install                # Install to all detected clients');
+  console.log('  gasoline-mcp --install gemini          # Install to Gemini CLI only');
+  console.log('  gasoline-mcp --install opencode        # Install to OpenCode only');
   console.log('  gasoline-mcp --install --dry-run      # Preview without changes');
   console.log('  gasoline-mcp --install --env DEBUG=1  # Install with env vars');
   console.log('  gasoline-mcp --install --skills-repo brennhill/gasoline-skills');
@@ -204,6 +213,17 @@ async function main() {
 
   // Install command
   if (args.includes('--install') || args.includes('-i')) {
+    const installIdx = args.indexOf('--install') !== -1
+      ? args.indexOf('--install')
+      : args.indexOf('-i');
+
+    // Check for targeted tool name (positional arg after --install)
+    let targetTool = null;
+    const nextArg = args[installIdx + 1];
+    if (nextArg && !nextArg.startsWith('--')) {
+      targetTool = nextArg;
+    }
+
     const envVars = {};
     for (let i = 0; i < args.length; i++) {
       if (args[i] === '--env' && i + 1 < args.length) {
@@ -229,6 +249,7 @@ async function main() {
       dryRun,
       envVars,
       verbose,
+      targetTool,
       ...skillOptions,
     };
     await installCommand(options);

--- a/npm/gasoline-mcp/lib/doctor.js
+++ b/npm/gasoline-mcp/lib/doctor.js
@@ -203,8 +203,9 @@ function diagnoseFileClient(def, verbose) {
     return tool;
   }
 
-  if (!readResult.data.mcpServers || !readResult.data.mcpServers.gasoline) {
-    tool.issues.push('gasoline entry missing from mcpServers');
+  const configKey = def.configKey || 'mcpServers';
+  if (!readResult.data[configKey] || !readResult.data[configKey].gasoline) {
+    tool.issues.push(`gasoline entry missing from ${configKey}`);
     tool.suggestions.push('Run: gasoline-mcp --install');
     return tool;
   }

--- a/npm/gasoline-mcp/lib/uninstall.js
+++ b/npm/gasoline-mcp/lib/uninstall.js
@@ -103,7 +103,8 @@ function uninstallViaFile(def, options) {
     };
   }
 
-  if (!readResult.data.mcpServers || !readResult.data.mcpServers.gasoline) {
+  const configKey = def.configKey || 'mcpServers';
+  if (!readResult.data[configKey] || !readResult.data[configKey].gasoline) {
     return { status: 'notConfigured', name: def.name, id: def.id };
   }
 
@@ -121,10 +122,11 @@ function uninstallViaFile(def, options) {
   }
 
   const modified = JSON.parse(JSON.stringify(readResult.data));
-  delete modified.mcpServers.gasoline;
+  delete modified[configKey].gasoline;
 
-  if (Object.keys(modified.mcpServers).length > 0) {
-    writeConfigFile(cfgPath, modified, false);
+  if (Object.keys(modified[configKey]).length > 0) {
+    const skipValidation = configKey !== 'mcpServers';
+    writeConfigFile(cfgPath, modified, false, { skipValidation });
   } else {
     fs.unlinkSync(cfgPath);
   }


### PR DESCRIPTION
## Summary
- Add Gemini CLI, OpenCode, Antigravity, and Zed as install targets (9 total clients)
- Add targeted install via `--install <tool>` (e.g. `gasoline-mcp --install gemini`)
- Handle non-standard config formats: OpenCode (`mcp` key), Zed (`context_servers` key)
- New `docs/mcp-install-guide.md` with per-tool setup instructions

## Test plan
- [x] 59 tests pass (config, install, uninstall)
- [ ] `gasoline-mcp --install gemini` creates `~/.gemini/settings.json`
- [ ] `gasoline-mcp --install bogus` returns error with valid tool names
- [ ] `gasoline-mcp --doctor` includes all 9 clients
- [ ] `gasoline-mcp --uninstall` handles OpenCode/Zed config keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)