### PR TITLE
fix: always default upload dir to ~/gasoline-upload-dir

### DIFF
--- a/scripts/smoke-tests/upload-server.py
+++ b/scripts/smoke-tests/upload-server.py
@@ -284,22 +284,22 @@ document.getElementById('file-input').addEventListener('change', function(event)
         csrf_expected = csrf_tokens.get(session, "")
         csrf_ok = csrf_sent != "" and csrf_sent == csrf_expected
         if not csrf_ok:
-            self._send_html(403, "<h1>403 CSRF token expired</h1><p>CSRF token mismatch.</p>")
+            self._send_html(403, "<!DOCTYPE html><html><head><title>403 CSRF</title></head><body><h1>403 CSRF token expired</h1><p>CSRF token mismatch.</p></body></html>")
             return
 
         # Check file
         file_entry = files.get("Filedata")
         if not file_entry:
-            self._send_html(422, "<h1>422 No file uploaded</h1><p>The Filedata field is required.</p>")
+            self._send_html(422, "<!DOCTYPE html><html><head><title>422 No File</title></head><body><h1>422 No file uploaded</h1><p>The Filedata field is required.</p></body></html>")
             return
         if len(file_entry["data"]) == 0:
-            self._send_html(422, "<h1>422 Empty file</h1><p>File must not be empty.</p>")
+            self._send_html(422, "<!DOCTYPE html><html><head><title>422 Empty File</title></head><body><h1>422 Empty file</h1><p>File must not be empty.</p></body></html>")
             return
 
         # Check required field: title
         title = fields.get("title", "")
         if not title:
-            self._send_html(422, "<h1>422 Missing title</h1><p>The title field is required.</p>")
+            self._send_html(422, "<!DOCTYPE html><html><head><title>422 Missing Title</title></head><body><h1>422 Missing title</h1><p>The title field is required.</p></body></html>")
             return
 
         # Success


### PR DESCRIPTION
## Summary
- Always set default upload dir (`~/gasoline-upload-dir`) in `initUploadSecurity`, removing the `--enable-os-upload-automation` gate that caused Stage 4 to fail with "upload-dir required" when the flag wasn't set
- When `--enable-os-upload-automation` is NOT set and dir creation fails, falls back gracefully (non-fatal)
- Replace fixed `sleep 3` with poll loop in test 15.16 for form submission reliability
- Add `<title>` tags to upload-server error pages for better test diagnostics

Fixes #39, #40

## Test plan
- [x] `go vet ./cmd/dev-console/...` — clean
- [x] `go build ./cmd/dev-console` — compiles
- [x] `TestSmokeUpload*` — all pass
- [ ] Manual: start daemon without `--enable-os-upload-automation`, verify `~/gasoline-upload-dir` created and logged
- [ ] Smoke: `./scripts/test-all-tools-comprehensive.sh --only 15` with extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)