### PR TITLE
fix: make ErrNoData retryable for extension disconnect resilience

### DIFF
--- a/cmd/dev-console/tools_async.go
+++ b/cmd/dev-console/tools_async.go
@@ -117,7 +117,8 @@ func (h *ToolHandler) MaybeWaitForCommand(req JSONRPCRequest, correlationID stri
 				"total_wait_ms":       totalWaitMs,
 				"extension_connected": h.capture.IsExtensionConnected(),
 			},
-			"message": "Action is taking longer than expected. Polling is now required. Use observe({what:'command_result', correlation_id:'" + correlationID + "'}) to check the result.",
+			"suggested_retry_ms": 2000,
+			"message":            "Action is taking longer than expected. Polling is now required. Use observe({what:'command_result', correlation_id:'" + correlationID + "'}) to check the result.",
 		}
 		if pos := h.capture.QueuePosition(correlationID); pos >= 0 {
 			stillProcessing["queue_position"] = pos

--- a/cmd/dev-console/tools_errors_test.go
+++ b/cmd/dev-console/tools_errors_test.go
@@ -94,7 +94,7 @@ func TestStructuredError_ErrorCodes_RetryableDefaults(t *testing.T) {
 		{ErrMissingParam, false, 0},
 		{ErrInternal, false, 0},
 		{ErrUnknownMode, false, 0},
-		{ErrNoData, false, 0},
+		{ErrNoData, true, 2000},
 	}
 
 	for _, tc := range testCases {

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -113,6 +113,8 @@ func RetryDefaultsForCode(code string) []func(*StructuredError) {
 		return []func(*StructuredError){WithRetryable(true), WithRetryAfterMs(1000)}
 	case ErrCursorExpired:
 		return []func(*StructuredError){WithRetryable(true), WithRetryAfterMs(500)}
+	case ErrNoData:
+		return []func(*StructuredError){WithRetryable(true), WithRetryAfterMs(2000)}
 	default:
 		return []func(*StructuredError){WithRetryable(false)}
 	}


### PR DESCRIPTION
## Summary
- Mark `no_data` error code as `retryable: true` with `retry_after_ms: 2000` — LLMs now retry after brief extension disconnects instead of giving up
- Add `suggested_retry_ms: 2000` to `still_processing` responses so LLMs know how long to wait before polling

Partial fix for #148 (transport resilience easy win).

## Test plan
- [x] `TestStructuredError_ErrorCodes_RetryableDefaults/no_data` — passes with `retryable=true, retry_after_ms=2000`
- [x] `go vet` + `go build` clean
- [ ] Manual: disconnect extension briefly, verify LLM retries the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)