### PR TITLE
feat: log aggregation via observe(what="summarized_logs") (#89)

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -77,6 +77,10 @@
           "description": "HTTP method filter",
           "type": "string"
         },
+        "min_group_size": {
+          "description": "Minimum occurrences to form a group (summarized_logs, default 2)",
+          "type": "number"
+        },
         "min_level": {
           "description": "Min log level (logs)",
           "enum": [
@@ -177,7 +181,8 @@
             "recordings",
             "recording_actions",
             "playback_results",
-            "log_diff_report"
+            "log_diff_report",
+            "summarized_logs"
           ],
           "type": "string"
         },

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -69,6 +69,9 @@ var observeHandlers = map[string]ObserveHandler{
 	"storage": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return observe.GetStorage(h, req, args)
 	},
+	"summarized_logs": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return observe.GetSummarizedLogs(h, req, args)
+	},
 	// Local handlers — depend on async/recording subsystems
 	"command_result": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return h.toolObserveCommandResult(req, args)

--- a/docs/features/log-aggregation/log-aggregation-spec.md
+++ b/docs/features/log-aggregation/log-aggregation-spec.md
@@ -1,0 +1,481 @@
+---
+doc_type: product_spec
+feature_id: feature-log-aggregation
+status: proposed
+issue: "#89"
+tool: observe
+mode: summarized_logs
+last_reviewed: 2026-02-20
+---
+
+# LLM-Native Log Aggregation --- Product Spec
+
+## Problem
+
+A typical browser session produces hundreds of console log entries. The majority are repetitive noise: WebSocket heartbeat acknowledgments, polling status checks, framework lifecycle messages, analytics callbacks, and timer-driven telemetry pings. When an LLM agent calls `observe(what="logs")`, it receives every individual entry. This has three compounding costs:
+
+1. **Token waste.** A session with 200 log entries where 150 are heartbeat variants burns ~3,000 tokens on messages the agent will never act on. Over a multi-turn debugging session this compounds to tens of thousands of wasted tokens.
+
+2. **Signal burial.** The 5 entries that actually matter (a warning about a failed API retry, a deprecation notice, an unexpected state transition) are buried in pages of identical noise. The agent must scan the entire list to find them, and may miss them entirely.
+
+3. **Redundant tool calls.** To manage the volume, agents paginate through logs across multiple calls, adding latency and further token cost for each round-trip.
+
+Existing mitigations are insufficient:
+
+- `configure(action="noise_rule")` suppresses entries entirely. This is useful for entries that are never relevant (extension noise, favicon 404s), but destructive for entries that matter in aggregate. "200 heartbeats in 30 seconds" is useful context; "0 heartbeats" is misleading.
+- `observe(what="logs", level="error")` filters by level, but repetitive noise spans all levels.
+- `observe(what="error_bundles")` solves a different problem (assembling context around errors, not summarizing volume).
+
+## Solution
+
+Add `observe(what="summarized_logs")` --- a new observe mode that returns **aggregated log groups** instead of individual entries. The server performs single-pass grouping of log entries by normalized message fingerprint, then returns one entry per group with count, time range, and level breakdown. Anomalies (entries that do not belong to any high-frequency group) are surfaced prominently.
+
+This is the log equivalent of what `error_clusters` does for errors: collapse volume into structure.
+
+## User Experience
+
+### Before (raw logs)
+
+```
+observe({what: "logs", limit: 100})
+```
+
+Returns 100 entries. 82 are WebSocket heartbeats. 11 are polling status messages. 3 are React re-render traces. 4 are actual signal: a retry warning, a deprecation notice, a state assertion, and an unexpected null.
+
+The agent must read all 100 to find the 4 that matter. Cost: ~2,000 tokens.
+
+### After (summarized logs)
+
+```
+observe({what: "summarized_logs"})
+```
+
+Returns:
+
+```json
+{
+  "groups": [
+    {
+      "fingerprint": "ws_heartbeat_ack",
+      "sample_message": "WebSocket heartbeat acknowledged: connection_id=abc123",
+      "count": 82,
+      "level_breakdown": {"log": 82},
+      "first_seen": "2026-02-20T10:00:01Z",
+      "last_seen": "2026-02-20T10:04:58Z",
+      "is_periodic": true,
+      "period_seconds": 3.6,
+      "source": "ws-client.js"
+    },
+    {
+      "fingerprint": "poll_status_ok",
+      "sample_message": "Poll status: {\"ready\":true,\"queue\":0}",
+      "count": 11,
+      "level_breakdown": {"info": 11},
+      "first_seen": "2026-02-20T10:00:05Z",
+      "last_seen": "2026-02-20T10:04:55Z",
+      "is_periodic": true,
+      "period_seconds": 27.2,
+      "source": "poller.js"
+    },
+    {
+      "fingerprint": "react_rerender",
+      "sample_message": "Re-rendering Dashboard component (props changed)",
+      "count": 3,
+      "level_breakdown": {"debug": 3},
+      "first_seen": "2026-02-20T10:01:12Z",
+      "last_seen": "2026-02-20T10:03:44Z",
+      "is_periodic": false,
+      "source": "react-dom.js"
+    }
+  ],
+  "anomalies": [
+    {
+      "level": "warn",
+      "message": "API retry attempt 3/3 for /users/profile: timeout after 5000ms",
+      "source": "api-client.js",
+      "timestamp": "2026-02-20T10:02:33Z"
+    },
+    {
+      "level": "warn",
+      "message": "navigator.geolocation is deprecated in insecure contexts",
+      "source": "location.js",
+      "timestamp": "2026-02-20T10:01:05Z"
+    },
+    {
+      "level": "log",
+      "message": "State assertion failed: expected user.role to be 'admin', got 'viewer'",
+      "source": "auth-guard.js",
+      "timestamp": "2026-02-20T10:03:01Z"
+    },
+    {
+      "level": "warn",
+      "message": "Unexpected null in response.data.preferences, using defaults",
+      "source": "settings.js",
+      "timestamp": "2026-02-20T10:03:55Z"
+    }
+  ],
+  "summary": {
+    "total_entries": 100,
+    "groups": 3,
+    "anomalies": 4,
+    "compression_ratio": 0.93,
+    "time_range": {
+      "start": "2026-02-20T10:00:01Z",
+      "end": "2026-02-20T10:04:58Z"
+    }
+  },
+  "metadata": { }
+}
+```
+
+The agent reads 3 groups + 4 anomalies = 7 items instead of 100. Cost: ~300 tokens. The 4 signal entries are immediately visible in `anomalies`. The 3 groups give aggregate context without listing every instance.
+
+---
+
+## API Design
+
+### Invocation
+
+```json
+{"tool": "observe", "arguments": {"what": "summarized_logs"}}
+```
+
+### Parameters
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `what` | string | (required) | `"summarized_logs"` |
+| `limit` | int | 100 | Max number of **source entries** to consider for aggregation (from the tail of the buffer). Max 1000. |
+| `min_level` | string | `""` | Minimum log level to include: debug, log, info, warn, error. Empty means all levels. |
+| `level` | string | `""` | Exact log level filter. Only entries at this level are considered. |
+| `source` | string | `""` | Only aggregate entries from this source. |
+| `url` | string | `""` | Only aggregate entries matching this URL substring. |
+| `scope` | string | `"current_page"` | `"current_page"` (tracked tab only) or `"all"`. |
+| `min_group_size` | int | 2 | Minimum occurrences for an entry to form a group. Entries below this threshold appear in `anomalies`. |
+| `since_cursor` | string | `""` | Only aggregate entries newer than this cursor. |
+| `after_cursor` | string | `""` | Backward pagination cursor. |
+| `restart_on_eviction` | bool | false | Auto-restart if cursor expired. |
+
+### Response Format
+
+```json
+{
+  "groups": [
+    {
+      "fingerprint": "string",
+      "sample_message": "string",
+      "count": 82,
+      "level_breakdown": {"log": 80, "info": 2},
+      "first_seen": "2026-02-20T10:00:01Z",
+      "last_seen": "2026-02-20T10:04:58Z",
+      "is_periodic": true,
+      "period_seconds": 3.6,
+      "source": "ws-client.js",
+      "sources": ["ws-client.js", "ws-fallback.js"],
+      "noise_rule_match": "builtin_ws_heartbeat"
+    }
+  ],
+  "anomalies": [
+    {
+      "level": "warn",
+      "message": "Actual error or interesting event",
+      "source": "app.js",
+      "url": "https://example.com",
+      "line": 42,
+      "column": 15,
+      "timestamp": "2026-02-20T10:02:33Z",
+      "tab_id": 12345
+    }
+  ],
+  "summary": {
+    "total_entries": 100,
+    "groups": 3,
+    "anomalies": 4,
+    "noise_suppressed": 12,
+    "compression_ratio": 0.93,
+    "time_range": {
+      "start": "2026-02-20T10:00:01Z",
+      "end": "2026-02-20T10:04:58Z"
+    }
+  },
+  "metadata": {
+    "extension_connected": true,
+    "tracked_tab": 12345,
+    "scope": "current_page",
+    "pagination": {}
+  }
+}
+```
+
+### Response Fields
+
+**groups[]**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fingerprint` | string | Stable identifier for the group, derived from the normalized message template. Human-readable slug format (e.g., `ws_heartbeat_ack`, `poll_status_ok`). |
+| `sample_message` | string | One representative raw message from the group (the most recent instance). |
+| `count` | int | Number of entries in this group. |
+| `level_breakdown` | object | Map of log level to count within this group (e.g., `{"log": 80, "warn": 2}`). |
+| `first_seen` | string | RFC3339 timestamp of the earliest entry in the group. |
+| `last_seen` | string | RFC3339 timestamp of the most recent entry in the group. |
+| `is_periodic` | bool | Whether the entries arrive at regular intervals (standard deviation of inter-arrival times < 20% of mean, with 3+ observations). |
+| `period_seconds` | float | Mean interval between entries in seconds. Only present when `is_periodic` is true. |
+| `source` | string | Primary source file for the group (the most common source across entries). |
+| `sources` | []string | All unique source files that produced entries in this group. Only present when more than one source exists. |
+| `noise_rule_match` | string | If entries in this group match an existing noise rule, the rule ID is included. Omitted when no rule matches. This helps the agent understand that the group is already known noise. |
+
+**anomalies[]**:
+
+Anomalies use the same schema as `observe(what="logs")` individual entries. These are entries that appeared fewer than `min_group_size` times (default: fewer than 2 times, i.e., unique entries). They represent the signal --- the entries that are most likely to be actionable.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `level` | string | Log level (debug, log, info, warn, error). |
+| `message` | string | Raw message text. |
+| `source` | string | Source file. |
+| `url` | string | Page URL. |
+| `line` | int | Line number. |
+| `column` | int | Column number. |
+| `timestamp` | string | RFC3339 timestamp. |
+| `tab_id` | int | Browser tab ID. |
+
+**summary**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_entries` | int | Total number of log entries considered (before grouping). |
+| `groups` | int | Number of groups formed. |
+| `anomalies` | int | Number of anomaly entries (ungrouped). |
+| `noise_suppressed` | int | Number of entries suppressed by existing noise rules (not included in groups or anomalies). |
+| `compression_ratio` | float | `1 - (groups + anomalies) / total_entries`. Higher means more repetition was collapsed. 0.93 means the response is 93% smaller than raw. |
+| `time_range.start` | string | Earliest timestamp across all considered entries. |
+| `time_range.end` | string | Latest timestamp across all considered entries. |
+
+---
+
+## Aggregation Algorithm
+
+### Overview
+
+The algorithm runs in a single pass over the log buffer (newest to oldest), building groups incrementally. It is designed for the Go backend with zero allocations on the hot path beyond the group map itself.
+
+### Step 1: Message Fingerprinting
+
+Each log message is normalized into a fingerprint by replacing variable content with placeholders. This is the same normalization strategy used by error clustering, extended for general log messages.
+
+**Normalization rules** (applied in order):
+
+1. Strip ANSI color codes
+2. Replace UUIDs (`[0-9a-f]{8}-[0-9a-f]{4}-...`) with `{uuid}`
+3. Replace hex hashes (8+ hex chars) with `{hash}`
+4. Replace numeric sequences (3+ digits) with `{n}`
+5. Replace quoted strings longer than 20 chars with `{string}`
+6. Replace URL-like patterns (`https?://...`) with `{url}`
+7. Replace ISO 8601 timestamps with `{timestamp}`
+8. Replace file paths (`/foo/bar/baz.js`) with `{path}`
+9. Collapse whitespace
+
+**Example:**
+
+```
+"WebSocket heartbeat acknowledged: connection_id=abc12345-def6-7890-abcd-ef1234567890 at 2026-02-20T10:00:01Z"
+  -> "WebSocket heartbeat acknowledged: connection_id={uuid} at {timestamp}"
+  -> fingerprint: "ws_heartbeat_acknowledged_connection_id"
+```
+
+The fingerprint is then slugified: lowercased, non-alphanumeric replaced with `_`, consecutive underscores collapsed, truncated to 64 chars.
+
+### Step 2: Grouping
+
+Iterate the buffer tail-to-head (newest first), up to `limit` entries:
+
+1. Apply existing filters (scope, level, min_level, source, url, noise rules)
+2. Entries matching a noise rule are counted in `noise_suppressed` and skipped
+3. Compute the fingerprint for the entry's message
+4. If a group with this fingerprint exists: increment count, update `first_seen`, append level to breakdown, add source to sources set
+5. If no group exists and the entry is the first with this fingerprint: create a tentative entry (held in a "pending singles" map)
+6. If a second entry with the same fingerprint arrives: promote the pending single to a full group
+
+After the scan completes:
+
+- Groups with `count >= min_group_size` go into `groups[]`
+- Entries that remained in the pending singles map (count < min_group_size) go into `anomalies[]`
+
+### Step 3: Periodicity Detection
+
+For each group with 3+ entries:
+
+1. Compute inter-arrival times between consecutive entries (sorted by timestamp)
+2. Compute mean and standard deviation of intervals
+3. If `stddev / mean < 0.20` (less than 20% jitter), mark `is_periodic = true` and set `period_seconds = mean`
+
+This reuses the same periodicity heuristic from `configure(action="noise_rule", noise_action="auto_detect")` but applies it per-group rather than per-URL.
+
+### Step 4: Sorting
+
+- `groups[]` sorted by `count` descending (highest-frequency groups first)
+- `anomalies[]` sorted by timestamp descending (newest first), with error/warn levels promoted above log/info/debug
+
+### Complexity
+
+- Time: O(n) where n = number of entries scanned. Single pass with O(1) map lookups per entry.
+- Space: O(g + a) where g = number of unique fingerprints (groups) and a = number of anomalies. In practice, g is small (10-50 unique fingerprints in a typical session).
+
+---
+
+## Interaction with Existing Features
+
+### Noise Rules (`configure(action="noise_rule")`)
+
+Noise rules and log aggregation are **complementary, not competing**:
+
+- **Noise rules suppress entries entirely** --- they disappear from all observe responses. Use for entries that are never useful (extension warnings, favicon 404s).
+- **Log aggregation groups entries** --- they still appear, but collapsed. Use when the aggregate count/pattern matters but individual instances do not.
+
+In `summarized_logs`, entries matching existing noise rules are excluded from both groups and anomalies. Their count is reported in `summary.noise_suppressed`. If a group of entries all match a noise rule, the group does not appear.
+
+If only some entries in a would-be group match a noise rule, the non-matching entries form the group normally. This can happen when a noise rule has a narrow regex that catches most but not all variants.
+
+The `noise_rule_match` field on groups tells the agent "this group also matches noise rule X". The agent can then decide whether to suppress the group via noise rules in future calls, or keep it visible in summarized form.
+
+### Error Bundles (`observe(what="error_bundles")`)
+
+Error bundles assemble context **around** individual errors. Summarized logs aggregate **across** the log stream. They solve different problems and do not overlap:
+
+- Use `error_bundles` when investigating a specific error ("what happened around this crash?")
+- Use `summarized_logs` when surveying the session ("what's going on? what should I investigate?")
+
+### Error Clustering (`analyze(what="error_clusters")`)
+
+Error clustering groups related **errors** by stack frame and message similarity. Summarized logs groups **all log levels** by message fingerprint. There is some conceptual overlap for error-level entries, but:
+
+- Error clusters use stack trace analysis --- summarized logs do not (console logs rarely have stacks)
+- Error clusters infer root causes --- summarized logs just count
+- Summarized logs include debug/info/warn levels that error clusters ignore
+
+### Pagination
+
+`summarized_logs` supports `since_cursor` and `after_cursor` for incremental use. The cursor points into the underlying log buffer (same cursor system as `observe(what="logs")`). The aggregation runs over the slice of the buffer selected by the cursor range.
+
+This allows the agent to call `summarized_logs` once to get the baseline, then call it again with `since_cursor` to get only new entries aggregated. New entries that match existing group fingerprints will form new groups in the incremental response --- the server does not maintain cross-call group state.
+
+---
+
+## Anomaly Detection
+
+The primary anomaly signal is **uniqueness**: entries that appear only once (or fewer than `min_group_size` times) in the observation window are anomalies. This is a deliberately simple heuristic:
+
+- It requires no ML, no training data, no statistical models
+- It naturally surfaces errors, warnings, and unusual events because those tend to be unique
+- It automatically filters out repetitive noise because noise repeats
+
+Additional anomaly signals (applied as annotations, not filtering):
+
+1. **Level escalation**: A group that historically contained only `log`-level entries suddenly includes a `warn` or `error` entry. The anomaly entry is pulled out of the group and placed in `anomalies[]`.
+2. **Frequency spike**: A group's rate in the last 10 seconds is 3x higher than its overall rate. Annotated on the group with `"frequency_spike": true`.
+3. **New fingerprint**: A fingerprint that has never been seen in previous calls to `summarized_logs` in this session. Annotated on the group or anomaly with `"new": true` (requires session-scoped fingerprint tracking in the daemon).
+
+These secondary signals are optional enhancements for v2. The initial implementation relies solely on uniqueness (the `min_group_size` threshold).
+
+---
+
+## Privacy Considerations
+
+- All aggregation happens locally in the Go daemon. No data leaves the machine.
+- Fingerprints are derived from message content but strip identifying information (UUIDs, IDs, URLs) as part of normalization.
+- The `sample_message` field contains one raw message per group. If the agent needs to avoid passing sensitive message content to a cloud LLM, it should use the `fingerprint` and `count` fields instead.
+- No persistent storage. Groups are computed per-call and discarded. The daemon holds no aggregation state between calls (stateless aggregation).
+
+---
+
+## Performance Constraints
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| Aggregation of 1000 entries | < 5ms | Must feel instant. Single-pass O(n). |
+| Fingerprinting per message | < 0.05ms | 7 regex replacements, pre-compiled. |
+| Memory for 100 groups | < 50KB | Each group is ~500 bytes (fingerprint + sample + counters + timestamps). |
+| Response size vs raw logs | > 80% reduction | Typical sessions have 10-20 unique fingerprints from 100+ entries. |
+
+All regex patterns used for fingerprinting are pre-compiled at daemon startup, not per-call. The fingerprinting function is a pure function with no allocations beyond the output string.
+
+---
+
+## Edge Cases
+
+| Edge Case | Resolution |
+|-----------|------------|
+| Empty log buffer | Return `{groups: [], anomalies: [], summary: {total_entries: 0, groups: 0, anomalies: 0}}` |
+| All entries are unique (no repetition) | All entries appear in `anomalies[]`, `groups[]` is empty, `compression_ratio` is 0 |
+| All entries are identical | Single group with count = total, `anomalies[]` is empty, `compression_ratio` approaches 1 |
+| Mixed structured/unstructured messages | Fingerprinting operates on the string representation. JSON messages are fingerprinted as strings. |
+| Very long messages (>1000 chars) | Truncate to 1000 chars before fingerprinting. `sample_message` is also truncated. |
+| High cardinality (every message slightly different) | Fingerprinting strips variable content, so `"User 123 logged in"` and `"User 456 logged in"` share the fingerprint `"User {n} logged in"`. If normalization cannot collapse messages, they become anomalies. |
+| Entries from multiple tabs (scope="all") | Groups span tabs. The `sources` field may contain entries from different tab contexts. |
+| Cursor-based incremental call | Aggregation runs on the buffer slice selected by the cursor. Groups are computed fresh each call. A group may have count=1 in an incremental call if only one new entry arrived. |
+| min_group_size=1 | Every entry forms a group, `anomalies[]` is empty. This is valid but defeats the purpose. |
+| Entries with missing timestamps | Entries without timestamps are assigned the current time for grouping purposes. They sort last in anomalies. |
+| Entries already suppressed by noise rules | Counted in `noise_suppressed`, excluded from groups and anomalies. |
+| Rapid log spam (1000+ entries in 1 second) | The `limit` parameter caps processing. Default 100. Agent can increase to 1000. Grouping handles this in O(n). |
+
+---
+
+## Success Criteria
+
+1. An LLM agent calling `observe(what="summarized_logs")` on a session with 100 log entries (80% repetitive) receives fewer than 15 items total (groups + anomalies).
+2. Actual errors and warnings that appear only once are always present in `anomalies[]`.
+3. Response latency is under 10ms for 1000 entries.
+4. The feature works without any extension changes (pure Go daemon logic).
+5. Existing `observe(what="logs")` is unaffected --- agents can still get raw logs.
+6. Noise rules continue to work. Entries suppressed by noise rules do not appear in summarized output.
+
+---
+
+## Implementation Approach
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/tools/observe/summarized_logs.go` | **NEW.** Handler for `summarized_logs` mode. Fingerprinting, grouping, periodicity detection, response assembly. ~250 lines. |
+| `internal/tools/observe/summarized_logs_test.go` | **NEW.** Unit tests. ~300 lines. |
+| `internal/tools/observe/handlers.go` | Add `"summarized_logs": GetSummarizedLogs` to `Handlers` map. ~1 line. |
+| `internal/tools/observe/schema.go` | Add `"summarized_logs"` to the `what` enum. ~1 line. |
+| `cmd/dev-console/tools_observe.go` | Add `"summarized_logs"` to `observeHandlers` map, delegating to `observe.GetSummarizedLogs`. ~3 lines. |
+| `cmd/dev-console/tools_schema.go` | Add `"summarized_logs"` to tool description. ~1 line. |
+| `cmd/dev-console/testdata/mcp-tools-list.golden.json` | Regenerate (includes new enum value). |
+
+### No Extension Changes
+
+This is a pure Go-side feature. The extension already sends console log entries to the daemon via the existing sync protocol. The daemon ring buffer already holds all the data. Summarized logs is a new read path over existing data.
+
+### No Protocol Changes
+
+No new MCP methods, no new wire types, no new HTTP endpoints. This is a new `what` value for the existing `observe` tool.
+
+---
+
+## Effort Estimate
+
+2-3 days. One new Go file (~250 lines) for the handler and fingerprinting logic. One new test file (~300 lines). Five existing files changed by 1-3 lines each.
+
+---
+
+## Future Enhancements (Not in Scope)
+
+- **Cross-call group persistence**: Track fingerprints across calls to annotate new vs. recurring groups.
+- **Frequency spike detection**: Alert when a group's rate suddenly increases.
+- **Level escalation detection**: Alert when a normally-quiet group starts producing warnings/errors.
+- **Auto-promote to noise rule**: Suggest converting high-count periodic groups into permanent noise rules.
+- **Structured log parsing**: Parse JSON log messages and group by structured fields rather than string fingerprint.
+- **WebSocket message aggregation**: Apply the same grouping to `websocket_events`.
+
+---
+
+## See Also
+
+- [Noise Filtering Tech Spec](../feature/noise-filtering/tech-spec.md)
+- [Error Clustering Tech Spec](../feature/error-clustering/tech-spec.md)
+- [Error Bundling Tech Spec](../feature/error-bundling/tech-spec.md)
+- [Pagination Tech Spec](../feature/pagination/tech-spec.md)

--- a/docs/features/log-aggregation/log-aggregation-test-plan.md
+++ b/docs/features/log-aggregation/log-aggregation-test-plan.md
@@ -1,0 +1,331 @@
+---
+doc_type: test_plan
+feature_id: feature-log-aggregation
+status: proposed
+issue: "#89"
+last_reviewed: 2026-02-20
+---
+
+# LLM-Native Log Aggregation --- Test Plan
+
+**Status:** [x] Product Tests Defined | [x] Tech Tests Designed | [ ] Tests Generated | [ ] All Tests Passing
+
+---
+
+## Product Tests
+
+### Valid State Tests
+
+- **Test:** Basic aggregation of repetitive logs
+  - **Given:** Log buffer contains 50 entries: 40 identical heartbeat messages, 5 identical polling messages, 5 unique messages
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Response has 2 groups (heartbeat count=40, polling count=5) and 5 anomalies. `compression_ratio` is > 0.9.
+
+- **Test:** All entries are unique (no repetition)
+  - **Given:** Log buffer contains 20 entries, each with a completely unique message
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Response has 0 groups and 20 anomalies. `compression_ratio` is 0.
+
+- **Test:** All entries are identical
+  - **Given:** Log buffer contains 30 copies of the same message
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Response has 1 group with count=30 and 0 anomalies. `compression_ratio` approaches 1.
+
+- **Test:** Variable content is collapsed into same fingerprint
+  - **Given:** Log buffer contains 10 messages like "User 123 logged in", "User 456 logged in", "User 789 logged in" (different IDs each time)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** All 10 entries form a single group with fingerprint containing `user_{n}_logged_in`. `sample_message` is one raw message.
+
+- **Test:** Anomalies preserve full entry detail
+  - **Given:** Log buffer contains 20 repetitive entries and 1 unique warning
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** The unique warning appears in `anomalies[]` with `level`, `message`, `source`, `url`, `line`, `column`, `timestamp`, and `tab_id` fields.
+
+- **Test:** Level breakdown tracks per-group levels
+  - **Given:** A group of 10 messages where 8 are level "log" and 2 are level "warn"
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** The group's `level_breakdown` is `{"log": 8, "warn": 2}`.
+
+- **Test:** Periodicity detection for regular intervals
+  - **Given:** 10 heartbeat messages arriving every 3 seconds (timestamps: T, T+3, T+6, ..., T+27)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** The heartbeat group has `is_periodic: true` and `period_seconds` close to 3.0.
+
+- **Test:** Non-periodic irregular entries
+  - **Given:** 5 messages with the same fingerprint at irregular intervals (1s, 15s, 2s, 30s)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** The group has `is_periodic: false` and no `period_seconds` field.
+
+- **Test:** Scope filtering (current_page)
+  - **Given:** Log buffer has entries from tab 100 and tab 200. Tab 100 is tracked.
+  - **When:** Agent calls `observe(what="summarized_logs", scope="current_page")`
+  - **Then:** Only entries from tab 100 are aggregated.
+
+- **Test:** Scope filtering (all)
+  - **Given:** Log buffer has entries from tab 100 and tab 200
+  - **When:** Agent calls `observe(what="summarized_logs", scope="all")`
+  - **Then:** Entries from both tabs are aggregated together.
+
+- **Test:** Level filter (min_level)
+  - **Given:** Log buffer has 10 debug, 10 info, 10 warn, 10 error entries
+  - **When:** Agent calls `observe(what="summarized_logs", min_level="warn")`
+  - **Then:** Only warn and error entries (20 total) are considered for aggregation.
+
+- **Test:** Exact level filter
+  - **Given:** Log buffer has entries at multiple levels
+  - **When:** Agent calls `observe(what="summarized_logs", level="error")`
+  - **Then:** Only error-level entries are considered.
+
+- **Test:** Source filter
+  - **Given:** Log buffer has entries from "app.js" and "vendor.js"
+  - **When:** Agent calls `observe(what="summarized_logs", source="app.js")`
+  - **Then:** Only entries from "app.js" are aggregated.
+
+- **Test:** URL filter
+  - **Given:** Log buffer has entries with URLs containing "example.com" and "other.com"
+  - **When:** Agent calls `observe(what="summarized_logs", url="example.com")`
+  - **Then:** Only entries with "example.com" in the URL are aggregated.
+
+- **Test:** Limit parameter caps input entries
+  - **Given:** Log buffer has 500 entries
+  - **When:** Agent calls `observe(what="summarized_logs", limit=50)`
+  - **Then:** Only the 50 most recent entries are aggregated. `summary.total_entries` is 50.
+
+- **Test:** Custom min_group_size threshold
+  - **Given:** Log buffer has 3 messages appearing 2 times each, and 5 messages appearing once
+  - **When:** Agent calls `observe(what="summarized_logs", min_group_size=3)`
+  - **Then:** All 3 two-count messages appear in `anomalies[]` (below threshold), and `groups[]` is empty.
+
+- **Test:** Groups sorted by count descending
+  - **Given:** Log buffer has group A (count=5), group B (count=20), group C (count=10)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Groups are ordered: B (20), C (10), A (5).
+
+- **Test:** Anomalies sorted by timestamp descending with level promotion
+  - **Given:** 3 anomalies: warn at T+1, log at T+3, error at T+2
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Anomalies are ordered with error/warn first (error T+2, warn T+1), then log (T+3).
+
+- **Test:** Multiple sources tracked per group
+  - **Given:** 10 messages with the same fingerprint from "ws-client.js" (8 entries) and "ws-fallback.js" (2 entries)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Group has `source: "ws-client.js"` (most common) and `sources: ["ws-client.js", "ws-fallback.js"]`.
+
+### Edge Case Tests (Negative)
+
+- **Test:** Empty log buffer
+  - **Given:** No log entries in the buffer
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Returns `{groups: [], anomalies: [], summary: {total_entries: 0, groups: 0, anomalies: 0, compression_ratio: 0}}`.
+
+- **Test:** Invalid scope parameter
+  - **Given:** Agent provides an invalid scope
+  - **When:** Agent calls `observe(what="summarized_logs", scope="invalid")`
+  - **Then:** Returns structured error with param="scope" and hint about valid values.
+
+- **Test:** Very long messages truncated for fingerprinting
+  - **Given:** Two log messages that are identical in the first 1000 chars but differ after
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Both entries are fingerprinted on the first 1000 chars and grouped together. `sample_message` is truncated.
+
+- **Test:** Messages with only variable content
+  - **Given:** Messages like "12345", "67890", "11111" (pure numbers)
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** All normalize to `{n}` and form a single group.
+
+- **Test:** Entries with missing timestamps
+  - **Given:** Log entries where some have no `ts` field
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Entries without timestamps are still grouped by fingerprint. They sort last in anomalies.
+
+- **Test:** Entries with missing messages
+  - **Given:** A log entry with an empty or missing `message` field
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Empty-message entries form their own group (fingerprint is empty string). They appear in anomalies if unique.
+
+- **Test:** min_group_size=1 (every entry becomes a group)
+  - **Given:** 10 entries, each unique
+  - **When:** Agent calls `observe(what="summarized_logs", min_group_size=1)`
+  - **Then:** 10 groups, 0 anomalies. All entries are grouped (each as count=1).
+
+- **Test:** Limit exceeds buffer size
+  - **Given:** Log buffer has 30 entries
+  - **When:** Agent calls `observe(what="summarized_logs", limit=500)`
+  - **Then:** All 30 entries are aggregated. `summary.total_entries` is 30.
+
+- **Test:** Limit clamped to max (1000)
+  - **Given:** Agent requests limit=5000
+  - **When:** Agent calls `observe(what="summarized_logs", limit=5000)`
+  - **Then:** Limit is clamped to 1000.
+
+### Noise Rule Interaction Tests
+
+- **Test:** Entries matching noise rules are excluded
+  - **Given:** Log buffer has 10 entries matching a noise rule and 5 entries not matching
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Only the 5 non-matching entries are considered. `summary.noise_suppressed` is 10.
+
+- **Test:** noise_rule_match field populated on groups
+  - **Given:** A group of 5 entries where the fingerprint overlaps with noise rule "builtin_hmr"
+  - **When:** Noise rule does NOT match these specific entries (different pattern), but the group message is similar
+  - **Then:** `noise_rule_match` is omitted (only set when entries actually match a rule).
+
+- **Test:** Partial noise rule overlap
+  - **Given:** 10 messages share a fingerprint. 7 match noise rule "user_123". 3 do not.
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** The 7 matching entries are suppressed. The 3 non-matching entries form a group with count=3.
+
+- **Test:** Lifecycle/tracking/extension entries excluded
+  - **Given:** Log buffer contains entries with type "lifecycle", "tracking", and "extension"
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** These entries are excluded (same as `observe(what="logs")` behavior).
+
+### Concurrent/Race Condition Tests
+
+- **Test:** Concurrent summarized_logs calls
+  - **Given:** Log buffer is being written to while two agents call `summarized_logs` simultaneously
+  - **When:** Both calls execute concurrently
+  - **Then:** Both return valid responses. No panics, no data races. Results may differ slightly due to buffer changes between calls.
+
+- **Test:** Buffer eviction during aggregation
+  - **Given:** Ring buffer is full. New entries are evicting old ones during the aggregation scan
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Returns a consistent snapshot (read lock prevents eviction during scan). No partial or corrupted entries.
+
+### Cursor / Pagination Tests
+
+- **Test:** since_cursor returns only new entries aggregated
+  - **Given:** Agent calls `summarized_logs`, gets a cursor. 20 new entries arrive (15 repetitive, 5 unique).
+  - **When:** Agent calls `observe(what="summarized_logs", since_cursor="<cursor>")`
+  - **Then:** Only the 20 new entries are aggregated. Groups and anomalies reflect only the new entries.
+
+- **Test:** Expired cursor with restart_on_eviction=false
+  - **Given:** Cursor points to an evicted buffer position
+  - **When:** Agent calls `observe(what="summarized_logs", since_cursor="<expired>")` without restart_on_eviction
+  - **Then:** Returns structured error about expired cursor.
+
+- **Test:** Expired cursor with restart_on_eviction=true
+  - **Given:** Cursor points to an evicted buffer position
+  - **When:** Agent calls `observe(what="summarized_logs", since_cursor="<expired>", restart_on_eviction=true)`
+  - **Then:** Falls back to scanning from the start of the buffer. Response includes eviction metadata.
+
+### Failure & Recovery Tests
+
+- **Test:** Malformed JSON arguments
+  - **Given:** Agent sends invalid JSON in the arguments
+  - **When:** Server parses the request
+  - **Then:** Returns structured error with recovery action.
+
+- **Test:** Extension disconnected
+  - **Given:** Extension is not connected. Buffer may have stale data.
+  - **When:** Agent calls `observe(what="summarized_logs")`
+  - **Then:** Response includes disconnect warning prepended to content (same as other observe modes). Aggregation still runs on stale data.
+
+---
+
+## Technical Tests
+
+### Unit Tests
+
+#### Coverage Areas:
+
+**Fingerprinting:**
+- `normalizeMessage("")` returns empty string
+- `normalizeMessage("simple text")` returns unchanged
+- `normalizeMessage("User 12345 logged in")` replaces numeric ID with `{n}`
+- `normalizeMessage("Request abc12345-def6-7890-abcd-ef1234567890 failed")` replaces UUID with `{uuid}`
+- `normalizeMessage("Fetched https://api.example.com/users")` replaces URL with `{url}`
+- `normalizeMessage("Error at 2026-02-20T10:00:00Z")` replaces timestamp with `{timestamp}`
+- `normalizeMessage("Hash: deadbeef1234")` replaces hex hash with `{hash}`
+- `normalizeMessage("Path /var/log/app.js")` replaces file path with `{path}`
+- `normalizeMessage("Long \"this is a very long quoted string here\"")` replaces long quoted string with `{string}`
+- `normalizeMessage` with ANSI color codes strips them before processing
+- Multiple replacements in a single message apply correctly
+- `slugifyFingerprint("User {n} logged in")` returns `user_n_logged_in`
+- Fingerprint truncation at 64 characters
+
+**Grouping:**
+- Single entry becomes anomaly (below min_group_size=2)
+- Two identical entries form a group
+- Two entries differing only in variable content form a group
+- Two entries with completely different messages become two anomalies
+- Group count increments correctly for 100 identical entries
+- `first_seen` is earliest timestamp, `last_seen` is most recent
+- `level_breakdown` accurately counts per-level entries
+- `source` is set to the most common source
+- `sources` includes all unique sources when more than one
+- `sample_message` is the most recent raw message
+
+**Periodicity:**
+- 5 entries at exact 3-second intervals: `is_periodic=true`, `period_seconds=3.0`
+- 5 entries at 3-second intervals with 10% jitter: `is_periodic=true`
+- 5 entries at random intervals: `is_periodic=false`
+- 2 entries: too few for periodicity detection, `is_periodic=false`
+- 1 entry: not applicable (anomaly)
+
+**Sorting:**
+- Groups sorted by count descending
+- Anomalies: error/warn sorted before log/info/debug, then by timestamp descending within priority band
+
+**Summary calculation:**
+- `compression_ratio = 1 - (groups + anomalies) / total_entries` computed correctly
+- `compression_ratio = 0` when all entries are unique
+- `compression_ratio` near 1 when all entries are identical
+- `time_range.start` is earliest entry, `time_range.end` is latest entry
+
+**Test File:** `internal/tools/observe/summarized_logs_test.go`
+
+### Integration Tests
+
+#### Scenarios:
+- End-to-end: extension sends log entries via sync protocol, agent calls `summarized_logs`, receives grouped response
+- Filter chain: noise rules + level filter + source filter + scope filter all applied before aggregation
+- Concurrent writes + reads: log entries arriving during aggregation produce consistent results
+- Pagination: `since_cursor` incremental aggregation returns only new entries
+
+**Test File:** `cmd/dev-console/tools_observe_summarized_test.go`
+
+### UAT/Acceptance Tests
+
+**Framework:** Bash script + curl
+
+#### Scenarios:
+- Start gasoline, connect extension, navigate to a page with periodic console output
+- Call `observe(what="summarized_logs")` via MCP JSON-RPC
+- Verify response has `groups`, `anomalies`, `summary` keys
+- Verify `summary.total_entries` > 0
+- Verify `summary.compression_ratio` >= 0 and <= 1
+- Verify each group has required fields: `fingerprint`, `sample_message`, `count`, `level_breakdown`, `first_seen`, `last_seen`, `is_periodic`, `source`
+- Verify each anomaly has required fields: `level`, `message`, `source`, `timestamp`
+- Call with `min_level=error` and verify only errors are aggregated
+- Call with `limit=5` and verify `summary.total_entries` <= 5
+
+**Test File:** Addition to `scripts/test-all-tools-comprehensive.sh`
+
+### Manual Testing
+
+#### Steps:
+1. Open browser with extension enabled
+2. Navigate to a page that produces console output (e.g., a React app with HMR, or a page with WebSocket connections)
+3. Wait 30 seconds to accumulate log entries
+4. Call `observe(what="summarized_logs")` via Claude or another MCP client
+5. Verify that repetitive messages (heartbeats, polling, HMR updates) are grouped
+6. Verify that unique warnings or errors appear in `anomalies[]`
+7. Verify `summary.compression_ratio` shows meaningful compression
+8. Compare with `observe(what="logs", limit=100)` to confirm the same entries are present in aggregated form
+9. Call with `since_cursor` from the first response's metadata to verify incremental aggregation
+
+---
+
+## Test Status
+
+### Links to generated test files (update as tests are created):
+
+| Test Type | File | Status | Notes |
+|-----------|------|--------|-------|
+| Unit | `internal/tools/observe/summarized_logs_test.go` | Pending | Awaiting implementation |
+| Integration | `cmd/dev-console/tools_observe_summarized_test.go` | Pending | Awaiting implementation |
+| UAT | `scripts/test-all-tools-comprehensive.sh` | Pending | Addition to existing script |
+| Manual | N/A | Pending | Awaiting implementation |
+
+**Overall:** All product test scenarios must pass before feature is considered complete.

--- a/internal/schema/observe.go
+++ b/internal/schema/observe.go
@@ -13,7 +13,7 @@ func ObserveToolSchema() mcp.MCPTool {
 			"properties": map[string]any{
 				"what": map[string]any{
 					"type": "string",
-					"enum": []string{"errors", "logs", "extension_logs", "network_waterfall", "network_bodies", "websocket_events", "websocket_status", "actions", "vitals", "page", "tabs", "pilot", "timeline", "error_bundles", "screenshot", "command_result", "pending_commands", "failed_commands", "saved_videos", "recordings", "recording_actions", "playback_results", "log_diff_report"},
+					"enum": []string{"errors", "logs", "extension_logs", "network_waterfall", "network_bodies", "websocket_events", "websocket_status", "actions", "vitals", "page", "tabs", "pilot", "timeline", "error_bundles", "screenshot", "command_result", "pending_commands", "failed_commands", "saved_videos", "recordings", "recording_actions", "playback_results", "log_diff_report", "summarized_logs"},
 				},
 				"telemetry_mode": map[string]any{
 					"type":        "string",
@@ -140,6 +140,10 @@ func ObserveToolSchema() mcp.MCPTool {
 				"wait_for_stable": map[string]any{
 					"type":        "boolean",
 					"description": "Wait for layout to stabilize before capture (screenshot)",
+				},
+				"min_group_size": map[string]any{
+					"type":        "number",
+					"description": "Minimum occurrences to form a group (summarized_logs, default 2)",
 				},
 			},
 			"required": []string{"what"},

--- a/internal/tools/observe/handlers.go
+++ b/internal/tools/observe/handlers.go
@@ -35,6 +35,7 @@ var Handlers = map[string]Handler{
 	"error_bundles":     GetErrorBundles,
 	"screenshot":        GetScreenshot,
 	"storage":           GetStorage,
+	"summarized_logs":   GetSummarizedLogs,
 }
 
 // clampLimit applies default and max bounds to a limit parameter.

--- a/internal/tools/observe/summarized_logs.go
+++ b/internal/tools/observe/summarized_logs.go
@@ -1,0 +1,519 @@
+// summarized_logs.go — Log aggregation handler for observe(what="summarized_logs").
+// Groups console log entries by normalized message fingerprint. Returns collapsed
+// groups (with counts) and anomalies (rare entries likely to be actionable signal).
+package observe
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/dev-console/dev-console/internal/mcp"
+)
+
+// Pre-compiled fingerprinting regexes (initialized once at package load).
+var (
+	reANSI       = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	reUUID       = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	reHexHash    = regexp.MustCompile(`\b[0-9a-fA-F]{8,}\b`)
+	reNumbers    = regexp.MustCompile(`\d{3,}`)
+	reLongQuoted = regexp.MustCompile(`"[^"]{21,}"`)
+	reURL        = regexp.MustCompile(`https?://\S+`)
+	reTimestamp  = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*`)
+	rePath       = regexp.MustCompile(`/[\w._-]+(/[\w._-]+)+`)
+	reWhitespace = regexp.MustCompile(`\s+`)
+	reSlugClean  = regexp.MustCompile(`[^a-z0-9]+`)
+	reSlugDup    = regexp.MustCompile(`_+`)
+)
+
+const maxFingerprintLen = 64
+
+// logEntryView is a lightweight struct for grouping operations,
+// extracted from the raw map[string]any log entries.
+type logEntryView struct {
+	Level   string
+	Message string
+	Source  string
+	URL     string
+	Line    any
+	Column  any
+	TS      string
+	TabID   any
+}
+
+// LogGroup represents a group of repeated log entries.
+type LogGroup struct {
+	Fingerprint    string         `json:"fingerprint"`
+	SampleMessage  string         `json:"sample_message"`
+	Count          int            `json:"count"`
+	LevelBreakdown map[string]int `json:"level_breakdown"`
+	FirstSeen      string         `json:"first_seen"`
+	LastSeen       string         `json:"last_seen"`
+	IsPeriodic     bool           `json:"is_periodic"`
+	PeriodSeconds  float64        `json:"period_seconds,omitempty"`
+	Source         string         `json:"source"`
+	Sources        []string       `json:"sources,omitempty"`
+	timestamps     []string       // internal, for periodicity detection
+	sourceCounts   map[string]int // internal, for primary source detection
+}
+
+// LogAnomaly represents a rare/unique log entry (the signal).
+type LogAnomaly struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+	Source  string `json:"source,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Line    any    `json:"line,omitempty"`
+	Column  any    `json:"column,omitempty"`
+	TS      string `json:"timestamp,omitempty"`
+	TabID   any    `json:"tab_id,omitempty"`
+}
+
+// fingerprintMessage normalizes a log message into a stable fingerprint.
+func fingerprintMessage(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	s := msg
+	s = reANSI.ReplaceAllString(s, "")
+	s = reUUID.ReplaceAllString(s, "{uuid}")
+	s = reTimestamp.ReplaceAllString(s, "{timestamp}")
+	s = reURL.ReplaceAllString(s, "{url}")
+	s = reHexHash.ReplaceAllString(s, "{hash}")
+	s = reNumbers.ReplaceAllString(s, "{n}")
+	s = reLongQuoted.ReplaceAllString(s, `"{string}"`)
+	s = rePath.ReplaceAllString(s, "{path}")
+	s = reWhitespace.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	return slugify(s)
+}
+
+// slugify converts a normalized message into a URL-safe slug.
+func slugify(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return unicode.ToLower(r)
+		}
+		return '_'
+	}, s)
+	s = reSlugDup.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if len(s) > maxFingerprintLen {
+		s = s[:maxFingerprintLen]
+	}
+	return s
+}
+
+// groupLogs performs single-pass grouping of log entries by fingerprint.
+// Returns groups (entries with count >= minGroupSize) and anomalies (below threshold).
+func groupLogs(entries []logEntryView, minGroupSize int) ([]LogGroup, []LogAnomaly) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	type pendingSingle struct {
+		entry logEntryView
+	}
+
+	groups := make(map[string]*LogGroup)
+	pending := make(map[string]*pendingSingle)
+	var groupOrder []string // preserve insertion order
+
+	for _, e := range entries {
+		fp := fingerprintMessage(e.Message)
+		if fp == "" {
+			continue
+		}
+
+		if g, ok := groups[fp]; ok {
+			// Existing group — increment
+			g.Count++
+			g.LevelBreakdown[e.Level]++
+			g.SampleMessage = e.Message // most recent
+			if e.TS != "" && (g.FirstSeen == "" || e.TS < g.FirstSeen) {
+				g.FirstSeen = e.TS
+			}
+			if e.TS != "" && e.TS > g.LastSeen {
+				g.LastSeen = e.TS
+			}
+			if e.TS != "" {
+				g.timestamps = append(g.timestamps, e.TS)
+			}
+			if e.Source != "" {
+				g.sourceCounts[e.Source]++
+			}
+			continue
+		}
+
+		if p, ok := pending[fp]; ok {
+			// Second occurrence — promote to group
+			g := &LogGroup{
+				Fingerprint:    fp,
+				SampleMessage:  e.Message,
+				Count:          2,
+				LevelBreakdown: map[string]int{p.entry.Level: 1, e.Level: 1},
+				FirstSeen:      minStr(p.entry.TS, e.TS),
+				LastSeen:       maxStr(p.entry.TS, e.TS),
+				sourceCounts:   make(map[string]int),
+			}
+			if p.entry.Level == e.Level {
+				g.LevelBreakdown[e.Level] = 2
+			}
+			if p.entry.TS != "" {
+				g.timestamps = append(g.timestamps, p.entry.TS)
+			}
+			if e.TS != "" {
+				g.timestamps = append(g.timestamps, e.TS)
+			}
+			if p.entry.Source != "" {
+				g.sourceCounts[p.entry.Source]++
+			}
+			if e.Source != "" {
+				g.sourceCounts[e.Source]++
+			}
+			groups[fp] = g
+			groupOrder = append(groupOrder, fp)
+			delete(pending, fp)
+			continue
+		}
+
+		// First occurrence — hold in pending
+		pending[fp] = &pendingSingle{entry: e}
+	}
+
+	// Pending singles → groups (if minGroupSize <= 1) or anomalies
+	var anomalies []LogAnomaly
+	for fp, p := range pending {
+		if minGroupSize <= 1 {
+			g := &LogGroup{
+				Fingerprint:    fp,
+				SampleMessage:  p.entry.Message,
+				Count:          1,
+				LevelBreakdown: map[string]int{p.entry.Level: 1},
+				FirstSeen:      p.entry.TS,
+				LastSeen:       p.entry.TS,
+				Source:         p.entry.Source,
+				sourceCounts:   make(map[string]int),
+			}
+			if p.entry.TS != "" {
+				g.timestamps = append(g.timestamps, p.entry.TS)
+			}
+			if p.entry.Source != "" {
+				g.sourceCounts[p.entry.Source]++
+			}
+			groups[fp] = g
+			groupOrder = append(groupOrder, fp)
+		} else {
+			anomalies = append(anomalies, logEntryToAnomaly(p.entry))
+		}
+	}
+
+	// Build result: groups >= minGroupSize go to groups
+	var resultGroups []LogGroup
+	for _, fp := range groupOrder {
+		g := groups[fp]
+		if g.Count < minGroupSize {
+			continue
+		}
+		// Resolve sources
+		g.Source, g.Sources = resolveSources(g.sourceCounts)
+		resultGroups = append(resultGroups, *g)
+	}
+
+	// Sort groups by count desc
+	sort.Slice(resultGroups, func(i, j int) bool {
+		return resultGroups[i].Count > resultGroups[j].Count
+	})
+
+	// Sort anomalies by severity desc, then timestamp desc
+	sort.Slice(anomalies, func(i, j int) bool {
+		ri := LogLevelRank(anomalies[i].Level)
+		rj := LogLevelRank(anomalies[j].Level)
+		if ri != rj {
+			return ri > rj
+		}
+		return anomalies[i].TS > anomalies[j].TS
+	})
+
+	return resultGroups, anomalies
+}
+
+// detectPeriodicity checks each group for regular intervals.
+func detectPeriodicity(groups []LogGroup) {
+	for i := range groups {
+		g := &groups[i]
+		if len(g.timestamps) < 3 {
+			continue
+		}
+		// Parse and sort timestamps
+		times := make([]time.Time, 0, len(g.timestamps))
+		for _, ts := range g.timestamps {
+			t, err := time.Parse(time.RFC3339, ts)
+			if err == nil {
+				times = append(times, t)
+			}
+		}
+		if len(times) < 3 {
+			continue
+		}
+		sort.Slice(times, func(a, b int) bool { return times[a].Before(times[b]) })
+
+		// Compute intervals
+		intervals := make([]float64, 0, len(times)-1)
+		for j := 1; j < len(times); j++ {
+			intervals = append(intervals, times[j].Sub(times[j-1]).Seconds())
+		}
+
+		mean := mean(intervals)
+		if mean <= 0 {
+			continue
+		}
+		stddev := stddev(intervals, mean)
+		if stddev/mean < 0.20 {
+			g.IsPeriodic = true
+			g.PeriodSeconds = math.Round(mean*10) / 10 // round to 1 decimal
+		}
+	}
+}
+
+// GetSummarizedLogs handles observe(what="summarized_logs").
+func GetSummarizedLogs(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JSONRPCResponse {
+	var params struct {
+		Limit        int    `json:"limit"`
+		MinLevel     string `json:"min_level"`
+		Level        string `json:"level"`
+		Source       string `json:"source"`
+		URL          string `json:"url"`
+		Scope        string `json:"scope"`
+		MinGroupSize int    `json:"min_group_size"`
+	}
+	mcp.LenientUnmarshal(args, &params)
+
+	if params.Scope == "" {
+		params.Scope = "current_page"
+	}
+	if params.Scope != "current_page" && params.Scope != "all" {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(mcp.ErrInvalidParam, "Invalid scope: "+params.Scope, "Use 'current_page' (default) or 'all'", mcp.WithParam("scope"))}
+	}
+	params.Limit = clampLimit(params.Limit, 100)
+	if params.MinGroupSize <= 0 {
+		params.MinGroupSize = 2
+	}
+
+	_, trackedTabID, _ := deps.GetCapture().GetTrackingStatus()
+	rawEntries, _ := deps.GetLogEntries()
+
+	// Filter entries and extract views
+	noiseSuppressed := 0
+	var views []logEntryView
+	// Scan newest first (tail to head), up to limit
+	count := 0
+	for i := len(rawEntries) - 1; i >= 0 && count < params.Limit; i-- {
+		entry := rawEntries[i]
+		entryType, _ := entry["type"].(string)
+		if entryType == "lifecycle" || entryType == "tracking" || entryType == "extension" {
+			continue
+		}
+		if deps.IsConsoleNoise(entry) {
+			noiseSuppressed++
+			continue
+		}
+		if params.Scope == "current_page" && trackedTabID != 0 {
+			entryTabID, _ := entry["tabId"].(float64)
+			if int(entryTabID) != trackedTabID {
+				continue
+			}
+		}
+		level, _ := entry["level"].(string)
+		if params.Level != "" && level != params.Level {
+			continue
+		}
+		if params.MinLevel != "" && LogLevelRank(level) < LogLevelRank(params.MinLevel) {
+			continue
+		}
+		if params.Source != "" {
+			source, _ := entry["source"].(string)
+			if source != params.Source {
+				continue
+			}
+		}
+		if params.URL != "" {
+			entryURL, _ := entry["url"].(string)
+			if !ContainsIgnoreCase(entryURL, params.URL) {
+				continue
+			}
+		}
+
+		message, _ := entry["message"].(string)
+		source, _ := entry["source"].(string)
+		url, _ := entry["url"].(string)
+		ts, _ := entry["ts"].(string)
+		views = append(views, logEntryView{
+			Level:   level,
+			Message: message,
+			Source:  source,
+			URL:     url,
+			Line:    entry["line"],
+			Column:  entry["column"],
+			TS:      ts,
+			TabID:   entry["tabId"],
+		})
+		count++
+	}
+
+	groups, anomalies := groupLogs(views, params.MinGroupSize)
+	if groups == nil {
+		groups = []LogGroup{}
+	}
+	if anomalies == nil {
+		anomalies = []LogAnomaly{}
+	}
+
+	detectPeriodicity(groups)
+
+	// Compute summary
+	totalEntries := len(views)
+	compressionRatio := 0.0
+	if totalEntries > 0 {
+		compressionRatio = 1.0 - float64(len(groups)+len(anomalies))/float64(totalEntries)
+		compressionRatio = math.Round(compressionRatio*100) / 100
+	}
+
+	// Time range
+	var timeStart, timeEnd string
+	for _, v := range views {
+		if v.TS == "" {
+			continue
+		}
+		if timeStart == "" || v.TS < timeStart {
+			timeStart = v.TS
+		}
+		if timeEnd == "" || v.TS > timeEnd {
+			timeEnd = v.TS
+		}
+	}
+
+	// Clean internal fields from groups before response
+	cleanGroups := make([]map[string]any, len(groups))
+	for i, g := range groups {
+		m := map[string]any{
+			"fingerprint":     g.Fingerprint,
+			"sample_message":  g.SampleMessage,
+			"count":           g.Count,
+			"level_breakdown": g.LevelBreakdown,
+			"first_seen":      g.FirstSeen,
+			"last_seen":       g.LastSeen,
+			"is_periodic":     g.IsPeriodic,
+			"source":          g.Source,
+		}
+		if g.PeriodSeconds > 0 {
+			m["period_seconds"] = g.PeriodSeconds
+		}
+		if len(g.Sources) > 1 {
+			m["sources"] = g.Sources
+		}
+		cleanGroups[i] = m
+	}
+
+	responseMeta := BuildResponseMetadata(deps.GetCapture(), time.Time{})
+
+	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Summarized logs", map[string]any{
+		"groups":    cleanGroups,
+		"anomalies": anomalies,
+		"summary": map[string]any{
+			"total_entries":     totalEntries,
+			"groups":            len(groups),
+			"anomalies":         len(anomalies),
+			"noise_suppressed":  noiseSuppressed,
+			"compression_ratio": compressionRatio,
+			"time_range": map[string]any{
+				"start": timeStart,
+				"end":   timeEnd,
+			},
+		},
+		"metadata": responseMeta,
+	})}
+}
+
+// ============================================
+// Internal Helpers
+// ============================================
+
+func logEntryToAnomaly(e logEntryView) LogAnomaly {
+	return LogAnomaly{
+		Level:   e.Level,
+		Message: e.Message,
+		Source:  e.Source,
+		URL:     e.URL,
+		Line:    e.Line,
+		Column:  e.Column,
+		TS:      e.TS,
+		TabID:   e.TabID,
+	}
+}
+
+func resolveSources(counts map[string]int) (primary string, all []string) {
+	if len(counts) == 0 {
+		return "", nil
+	}
+	maxCount := 0
+	for src, c := range counts {
+		all = append(all, src)
+		if c > maxCount {
+			maxCount = c
+			primary = src
+		}
+	}
+	sort.Strings(all)
+	if len(all) <= 1 {
+		return primary, nil // omit sources array for single source
+	}
+	return primary, all
+}
+
+func minStr(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxStr(a, b string) string {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func mean(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+	}
+	return sum / float64(len(vals))
+}
+
+func stddev(vals []float64, mean float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sumSq := 0.0
+	for _, v := range vals {
+		d := v - mean
+		sumSq += d * d
+	}
+	return math.Sqrt(sumSq / float64(len(vals)))
+}

--- a/internal/tools/observe/summarized_logs_test.go
+++ b/internal/tools/observe/summarized_logs_test.go
@@ -1,0 +1,328 @@
+// summarized_logs_test.go — Tests for log aggregation fingerprinting and grouping.
+package observe
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================
+// Fingerprinting Tests
+// ============================================
+
+func TestFingerprint_UUID(t *testing.T) {
+	t.Parallel()
+	msg := "Connection abc12345-def6-7890-abcd-ef1234567890 established"
+	fp := fingerprintMessage(msg)
+	if strings.Contains(fp, "abc12345") {
+		t.Errorf("fingerprint should not contain UUID: %s", fp)
+	}
+}
+
+func TestFingerprint_Numbers(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage("Request took 1234ms")
+	fp2 := fingerprintMessage("Request took 5678ms")
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different numbers: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_HexHash(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage("Module loaded: abcdef1234567890")
+	fp2 := fingerprintMessage("Module loaded: 1234567890abcdef")
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different hex hashes: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_Timestamps(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage("Event at 2026-02-20T10:00:01Z")
+	fp2 := fingerprintMessage("Event at 2026-02-20T14:30:00Z")
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different timestamps: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_URLs(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage("Fetched https://api.example.com/users/123")
+	fp2 := fingerprintMessage("Fetched https://api.example.com/items/456")
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different URLs: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_QuotedStrings(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage(`Error: "this is a very long error message that should be replaced"`)
+	fp2 := fingerprintMessage(`Error: "completely different long string that should also match here"`)
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different long quoted strings: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_FilePaths(t *testing.T) {
+	t.Parallel()
+	fp1 := fingerprintMessage("Loading /Users/bob/src/app/main.js")
+	fp2 := fingerprintMessage("Loading /Users/alice/lib/util/helper.js")
+	if fp1 != fp2 {
+		t.Errorf("fingerprints should match for different paths: %q vs %q", fp1, fp2)
+	}
+}
+
+func TestFingerprint_Slugification(t *testing.T) {
+	t.Parallel()
+	fp := fingerprintMessage("WebSocket heartbeat acknowledged")
+	if len(fp) > 64 {
+		t.Errorf("fingerprint should be truncated to 64 chars, got %d", len(fp))
+	}
+	// Should be lowercase with underscores
+	for _, ch := range fp {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_') {
+			t.Errorf("fingerprint contains invalid char %c: %s", ch, fp)
+			break
+		}
+	}
+}
+
+func TestFingerprint_EmptyMessage(t *testing.T) {
+	t.Parallel()
+	fp := fingerprintMessage("")
+	if fp != "" {
+		t.Errorf("empty message should produce empty fingerprint, got %q", fp)
+	}
+}
+
+// ============================================
+// Grouping Tests
+// ============================================
+
+func TestGroupLogs_IdenticalMessages(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "heartbeat ack", "ws.js"),
+		logEntry("log", "heartbeat ack", "ws.js"),
+		logEntry("log", "heartbeat ack", "ws.js"),
+	)
+	groups, anomalies := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Count != 3 {
+		t.Errorf("expected count=3, got %d", groups[0].Count)
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected 0 anomalies, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_VariableContent(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "User 123 logged in", "auth.js"),
+		logEntry("log", "User 456 logged in", "auth.js"),
+		logEntry("log", "User 789 logged in", "auth.js"),
+	)
+	groups, anomalies := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group (variable content collapsed), got %d", len(groups))
+	}
+	if groups[0].Count != 3 {
+		t.Errorf("expected count=3, got %d", groups[0].Count)
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected 0 anomalies, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_Anomalies(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "heartbeat", "ws.js"),
+		logEntry("log", "heartbeat", "ws.js"),
+		logEntry("warn", "Something unusual happened", "app.js"),
+	)
+	groups, anomalies := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_AllUnique(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "first message", "a.js"),
+		logEntry("warn", "second message", "b.js"),
+		logEntry("error", "third message", "c.js"),
+	)
+	groups, anomalies := groupLogs(entries, 2)
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(groups))
+	}
+	if len(anomalies) != 3 {
+		t.Errorf("expected 3 anomalies, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_AllIdentical(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "same", "x.js"),
+		logEntry("log", "same", "x.js"),
+		logEntry("log", "same", "x.js"),
+	)
+	groups, anomalies := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected 0 anomalies, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_MinGroupSize1(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "unique", "x.js"),
+	)
+	groups, anomalies := groupLogs(entries, 1)
+	if len(groups) != 1 {
+		t.Errorf("expected 1 group with min_group_size=1, got %d", len(groups))
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected 0 anomalies with min_group_size=1, got %d", len(anomalies))
+	}
+}
+
+func TestGroupLogs_LevelBreakdown(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "same message", "x.js"),
+		logEntry("warn", "same message", "x.js"),
+		logEntry("log", "same message", "x.js"),
+	)
+	groups, _ := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	breakdown := groups[0].LevelBreakdown
+	if breakdown["log"] != 2 {
+		t.Errorf("expected log=2, got %d", breakdown["log"])
+	}
+	if breakdown["warn"] != 1 {
+		t.Errorf("expected warn=1, got %d", breakdown["warn"])
+	}
+}
+
+func TestGroupLogs_MultipleSources(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntries(
+		logEntry("log", "same message", "a.js"),
+		logEntry("log", "same message", "b.js"),
+		logEntry("log", "same message", "a.js"),
+	)
+	groups, _ := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Sources) != 2 {
+		t.Errorf("expected 2 sources, got %d: %v", len(groups[0].Sources), groups[0].Sources)
+	}
+}
+
+func TestGroupLogs_Empty(t *testing.T) {
+	t.Parallel()
+	groups, anomalies := groupLogs(nil, 2)
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(groups))
+	}
+	if len(anomalies) != 0 {
+		t.Errorf("expected 0 anomalies, got %d", len(anomalies))
+	}
+}
+
+// ============================================
+// Periodicity Tests
+// ============================================
+
+func TestDetectPeriodicity_Regular(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntriesWithTimestamps(
+		logEntryTS("log", "heartbeat", "ws.js", "2026-02-20T10:00:01Z"),
+		logEntryTS("log", "heartbeat", "ws.js", "2026-02-20T10:00:04Z"),
+		logEntryTS("log", "heartbeat", "ws.js", "2026-02-20T10:00:07Z"),
+		logEntryTS("log", "heartbeat", "ws.js", "2026-02-20T10:00:10Z"),
+	)
+	groups, _ := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	detectPeriodicity(groups)
+	if !groups[0].IsPeriodic {
+		t.Error("expected group to be periodic")
+	}
+	// ~3 seconds between entries
+	if groups[0].PeriodSeconds < 2.5 || groups[0].PeriodSeconds > 3.5 {
+		t.Errorf("expected period ~3s, got %f", groups[0].PeriodSeconds)
+	}
+}
+
+func TestDetectPeriodicity_Irregular(t *testing.T) {
+	t.Parallel()
+	entries := makeLogEntriesWithTimestamps(
+		logEntryTS("log", "event", "x.js", "2026-02-20T10:00:01Z"),
+		logEntryTS("log", "event", "x.js", "2026-02-20T10:00:02Z"),
+		logEntryTS("log", "event", "x.js", "2026-02-20T10:00:20Z"),
+		logEntryTS("log", "event", "x.js", "2026-02-20T10:00:21Z"),
+	)
+	groups, _ := groupLogs(entries, 2)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	detectPeriodicity(groups)
+	if groups[0].IsPeriodic {
+		t.Error("expected group to NOT be periodic (high jitter)")
+	}
+}
+
+// ============================================
+// Test Helpers
+// ============================================
+
+type testEntry struct {
+	level   string
+	message string
+	source  string
+	ts      string
+}
+
+func logEntry(level, message, source string) testEntry {
+	return testEntry{level: level, message: message, source: source}
+}
+
+func logEntryTS(level, message, source, ts string) testEntry {
+	return testEntry{level: level, message: message, source: source, ts: ts}
+}
+
+func makeLogEntries(entries ...testEntry) []logEntryView {
+	result := make([]logEntryView, len(entries))
+	for i, e := range entries {
+		result[i] = logEntryView{
+			Level:   e.level,
+			Message: e.message,
+			Source:  e.source,
+			TS:      e.ts,
+		}
+	}
+	return result
+}
+
+func makeLogEntriesWithTimestamps(entries ...testEntry) []logEntryView {
+	return makeLogEntries(entries...)
+}


### PR DESCRIPTION
## Summary
- Adds `observe(what="summarized_logs")` for LLM-native log aggregation
- Groups console log entries by normalized message fingerprint (UUIDs, timestamps, numbers, URLs, hex hashes, paths, long quoted strings all collapsed)
- Returns collapsed groups (with counts, level breakdown, source tracking) and anomalies (rare entries = actionable signal)
- Periodicity detection flags regular interval patterns (e.g., heartbeats)
- Compression ratio metric shows noise reduction effectiveness
- Supports all existing log filters: `level`, `min_level`, `source`, `url`, `scope`, `limit`, `min_group_size`

## Test plan
- [x] 19 unit tests covering fingerprinting, grouping, periodicity, and edge cases
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] Golden file updated

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)