### PR TITLE
refactor: split thirdparty, clustering, and csp files

### DIFF
--- a/internal/analysis/clustering_helpers.go
+++ b/internal/analysis/clustering_helpers.go
@@ -1,0 +1,265 @@
+// clustering_helpers.go — Stack frame parsing, message normalization, and signal matching for error clustering.
+
+package analysis
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// StackFrame represents a parsed stack trace frame.
+type StackFrame struct {
+	Function    string
+	File        string
+	Line        int
+	Column      int
+	IsFramework bool
+}
+
+// Framework path patterns — frames from these paths are excluded from similarity comparison.
+var frameworkPatterns = []string{
+	"node_modules/react",
+	"node_modules/vue",
+	"node_modules/@angular",
+	"node_modules/svelte",
+	"webpack/bootstrap",
+	"webpack/runtime",
+	"zone.js",
+	"node_modules/rxjs",
+	"node_modules/core-js",
+}
+
+var (
+	// "    at FunctionName (file.js:line:col)"
+	stackFrameWithFunc = regexp.MustCompile(`^\s*at\s+(.+?)\s+\((.+?):(\d+):(\d+)\)`)
+	// "    at file.js:line:col"
+	stackFrameAnon = regexp.MustCompile(`^\s*at\s+(.+?):(\d+):(\d+)\s*$`)
+)
+
+// parseStackFrame parses a single stack trace line into a StackFrame.
+func parseStackFrame(line string) StackFrame {
+	line = strings.TrimSpace(line)
+
+	// Try "at Function (file:line:col)"
+	if m := stackFrameWithFunc.FindStringSubmatch(line); m != nil {
+		lineNum, _ := strconv.Atoi(m[3])
+		colNum, _ := strconv.Atoi(m[4])
+		frame := StackFrame{
+			Function: m[1],
+			File:     m[2],
+			Line:     lineNum,
+			Column:   colNum,
+		}
+		frame.IsFramework = isFrameworkPath(frame.File)
+		return frame
+	}
+
+	// Try "at file:line:col" (anonymous)
+	if m := stackFrameAnon.FindStringSubmatch(line); m != nil {
+		lineNum, _ := strconv.Atoi(m[2])
+		colNum, _ := strconv.Atoi(m[3])
+		frame := StackFrame{
+			Function: "<anonymous>",
+			File:     m[1],
+			Line:     lineNum,
+			Column:   colNum,
+		}
+		frame.IsFramework = isFrameworkPath(frame.File)
+		return frame
+	}
+
+	return StackFrame{Function: "<unknown>", File: line}
+}
+
+// isFrameworkPath returns true if the file path matches a known framework pattern.
+func isFrameworkPath(path string) bool {
+	for _, pattern := range frameworkPatterns {
+		if strings.Contains(path, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseStack parses a multi-line stack trace into frames.
+func parseStack(stack string) []StackFrame {
+	if stack == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimSpace(stack), "\n")
+	frames := make([]StackFrame, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		frames = append(frames, parseStackFrame(line))
+	}
+	return frames
+}
+
+// appFrames returns only non-framework frames.
+func appFrames(frames []StackFrame) []StackFrame {
+	result := make([]StackFrame, 0)
+	for _, f := range frames {
+		if !f.IsFramework {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+var (
+	clusterUUIDRegex      = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	clusterURLRegex       = regexp.MustCompile(`https?://[^\s"']+`)
+	clusterTimestampRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[^\s]*`)
+	clusterNumericIDRegex = regexp.MustCompile(`\b\d{3,}\b`) // 3+ digit numbers as IDs
+)
+
+// normalizeErrorMessage replaces variable content with placeholders.
+func normalizeErrorMessage(msg string) string {
+	// Order matters: UUIDs before numeric IDs (UUIDs contain digits)
+	result := clusterUUIDRegex.ReplaceAllString(msg, "{uuid}")
+	result = clusterURLRegex.ReplaceAllString(result, "{url}")
+	result = clusterTimestampRegex.ReplaceAllString(result, "{timestamp}")
+	result = clusterNumericIDRegex.ReplaceAllString(result, "{id}")
+	return result
+}
+
+// matchesCluster checks if an error matches an existing cluster.
+func (cm *ClusterManager) matchesCluster(cluster *ErrorCluster, err ErrorInstance, appFr []StackFrame, normMsg string) bool {
+	// For errors without stacks, message match alone is sufficient
+	if err.Stack == "" && len(cluster.Instances) > 0 && cluster.Instances[0].Stack == "" && cluster.NormalizedMsg == normMsg {
+		return true
+	}
+	return cm.clusterSignalCount(cluster, err, appFr, normMsg) >= 2
+}
+
+// clusterSignalCount counts how many of the 3 signals match between an error and a cluster.
+func (cm *ClusterManager) clusterSignalCount(cluster *ErrorCluster, err ErrorInstance, appFr []StackFrame, normMsg string) int {
+	signals := 0
+	if cluster.NormalizedMsg == normMsg {
+		signals++
+	}
+	if len(appFr) > 0 && len(cluster.CommonFrames) > 0 && countSharedFrames(appFr, cluster.CommonFrames) >= 1 {
+		signals++
+	}
+	if !cluster.LastSeen.IsZero() && err.Timestamp.Sub(cluster.LastSeen) < 2*time.Second {
+		signals++
+	}
+	return signals
+}
+
+// countSignals counts how many signals match between two errors.
+// Core signal matching logic used by matchesCluster decision.
+// Returns count of matched signals (0-3).
+//
+// Three Signals Evaluated:
+//  1. Message Signal: normalized messages identical
+//  2. Frames Signal: 2+ shared application-level frames (countSharedFrames)
+//  3. Temporal Signal: time between errors < 2 seconds (temporal proximity)
+//
+// Decision Rule (caller's responsibility):
+//   - 2+ signals matching → likely same root cause
+//   - 1 signal matching → could be coincidence, require more evidence
+//   - 0 signals matching → different errors
+//
+// Note on Signal Independence:
+//   - Signals are roughly independent (one signal doesn't imply another)
+//   - Message alone could be coincidence (same generic message, different code)
+//   - Frame signature alone could be coincidence (different bugs in same function)
+//   - Time proximity alone could be coincidence (rapid error bursts from unrelated bugs)
+//   - 2+ signals together indicate correlation likely > coincidence
+//
+// Caller must provide:
+//   - existing: Error already in this cluster
+//   - new: Error being considered for addition
+//   - newAppFr: Application frames from new error (already filtered via appFrames())
+//   - newNormMsg: Normalized message from new error (already normalized)
+func (cm *ClusterManager) countSignals(existing, new ErrorInstance, newAppFr []StackFrame, newNormMsg string) int {
+	signals := 0
+
+	// Message similarity
+	existingNorm := normalizeErrorMessage(existing.Message)
+	if existingNorm == newNormMsg {
+		signals++
+	}
+
+	// Stack similarity
+	existingFrames := appFrames(parseStack(existing.Stack))
+	if len(existingFrames) > 0 && len(newAppFr) > 0 {
+		if countSharedFrames(existingFrames, newAppFr) >= 1 {
+			signals++
+		}
+	}
+
+	// Temporal proximity
+	if new.Timestamp.Sub(existing.Timestamp) < 2*time.Second {
+		signals++
+	}
+
+	return signals
+}
+
+// countSharedFrames counts frames that appear in both slices (by file:line).
+func countSharedFrames(a, b []StackFrame) int {
+	bSet := make(map[string]bool)
+	for _, f := range b {
+		bSet[fmt.Sprintf("%s:%d", f.File, f.Line)] = true
+	}
+	count := 0
+	for _, f := range a {
+		if bSet[fmt.Sprintf("%s:%d", f.File, f.Line)] {
+			count++
+		}
+	}
+	return count
+}
+
+// findCommonFrames returns frames present in both slices.
+func findCommonFrames(a, b []StackFrame) []StackFrame {
+	bSet := make(map[string]StackFrame)
+	for _, f := range b {
+		key := fmt.Sprintf("%s:%d", f.File, f.Line)
+		bSet[key] = f
+	}
+	var common []StackFrame
+	for _, f := range a {
+		key := fmt.Sprintf("%s:%d", f.File, f.Line)
+		if _, ok := bSet[key]; ok {
+			common = append(common, f)
+		}
+	}
+	return common
+}
+
+// inferRootCause returns the deepest common app-code frame, or the normalized message.
+func inferRootCause(commonFrames []StackFrame, normMsg string) string {
+	// The deepest frame (first in the list, since stacks go from deepest to shallowest)
+	for _, f := range commonFrames {
+		if !f.IsFramework {
+			if f.Function != "<anonymous>" && f.Function != "<unknown>" {
+				return fmt.Sprintf("%s (%s:%d)", f.Function, f.File, f.Line)
+			}
+			return fmt.Sprintf("%s:%d", f.File, f.Line)
+		}
+	}
+	return normMsg
+}
+
+// collectAffectedFiles returns unique source files from two frame sets.
+func collectAffectedFiles(a, b []StackFrame) []string {
+	seen := make(map[string]bool)
+	var files []string
+	for _, frames := range [][]StackFrame{a, b} {
+		for _, f := range frames {
+			if f.File != "" && !f.IsFramework && !seen[f.File] {
+				seen[f.File] = true
+				files = append(files, f.File)
+			}
+		}
+	}
+	return files
+}

--- a/internal/analysis/thirdparty_reputation.go
+++ b/internal/analysis/thirdparty_reputation.go
@@ -1,0 +1,139 @@
+// thirdparty_reputation.go — Domain reputation classification and DGA detection heuristics.
+package analysis
+
+import (
+	"math"
+	"net/url"
+	"strings"
+)
+
+// knownCDNs is a hardcoded set of known CDN hostnames.
+var knownCDNs = map[string]bool{
+	"cdn.jsdelivr.net":           true,
+	"cdnjs.cloudflare.com":       true,
+	"unpkg.com":                  true,
+	"fonts.googleapis.com":       true,
+	"fonts.gstatic.com":          true,
+	"ajax.googleapis.com":        true,
+	"code.jquery.com":            true,
+	"maxcdn.bootstrapcdn.com":    true,
+	"stackpath.bootstrapcdn.com": true,
+	"cdn.cloudflare.com":         true,
+	"raw.githubusercontent.com":  true,
+	"github.githubassets.com":    true,
+	"cdn.tailwindcss.com":        true,
+	"esm.sh":                     true,
+	"deno.land":                  true,
+	"cdn.skypack.dev":            true,
+}
+
+// abuseTLDs is a hardcoded set of TLDs commonly associated with abuse.
+var abuseTLDs = map[string]bool{
+	".xyz":     true,
+	".top":     true,
+	".click":   true,
+	".loan":    true,
+	".work":    true,
+	".tk":      true,
+	".ml":      true,
+	".ga":      true,
+	".cf":      true,
+	".gq":      true,
+	".buzz":    true,
+	".monster": true,
+}
+
+// classifyReputation determines the reputation classification for a hostname.
+func classifyReputation(hostname string, customLists *CustomLists) DomainReputation {
+	if rep, ok := checkCustomLists(hostname, customLists); ok {
+		return rep
+	}
+	if knownCDNs[hostname] {
+		return DomainReputation{Classification: "known_cdn", Source: "bundled_list"}
+	}
+	return checkSuspicionHeuristics(hostname)
+}
+
+// checkCustomLists checks if hostname matches enterprise allowed/blocked lists.
+func checkCustomLists(hostname string, customLists *CustomLists) (DomainReputation, bool) {
+	if customLists == nil {
+		return DomainReputation{}, false
+	}
+	if matchesDomainList(hostname, customLists.Allowed) {
+		return DomainReputation{Classification: "enterprise_allowed", Source: "custom_list"}, true
+	}
+	if matchesDomainList(hostname, customLists.Blocked) {
+		return DomainReputation{Classification: "enterprise_blocked", Source: "custom_list"}, true
+	}
+	return DomainReputation{}, false
+}
+
+// matchesDomainList returns true if hostname matches any domain in the list.
+func matchesDomainList(hostname string, domains []string) bool {
+	for _, d := range domains {
+		if hostname == d || strings.HasSuffix(hostname, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkSuspicionHeuristics applies abuse-TLD and DGA heuristics.
+func checkSuspicionHeuristics(hostname string) DomainReputation {
+	var flags []string
+	if abuseTLDs[extractTLD(hostname)] {
+		flags = append(flags, "abuse_tld")
+	}
+	subdomain := extractSubdomain(hostname)
+	if subdomain != "" && len(subdomain) > 8 && shannonEntropy(subdomain) > 3.5 {
+		flags = append(flags, "possible_dga")
+	}
+	if len(flags) > 0 {
+		return DomainReputation{Classification: "suspicious", SuspicionFlags: flags, Source: "heuristic"}
+	}
+	return DomainReputation{Classification: "unknown"}
+}
+
+// shannonEntropy computes Shannon entropy in bits per character.
+func shannonEntropy(s string) float64 {
+	freq := make(map[rune]float64)
+	for _, c := range s {
+		freq[c]++
+	}
+	length := float64(len([]rune(s)))
+	entropy := 0.0
+	for _, count := range freq {
+		p := count / length
+		if p > 0 {
+			entropy -= p * math.Log2(p)
+		}
+	}
+	return entropy
+}
+
+// extractHostname extracts the hostname from a URL or origin string.
+func extractHostname(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+// extractTLD extracts the TLD with dot prefix from a hostname.
+func extractTLD(hostname string) string {
+	parts := strings.Split(hostname, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return "." + parts[len(parts)-1]
+}
+
+// extractSubdomain extracts the first subdomain label from a hostname.
+func extractSubdomain(hostname string) string {
+	parts := strings.Split(hostname, ".")
+	if len(parts) <= 2 {
+		return ""
+	}
+	return parts[0]
+}

--- a/internal/analysis/thirdparty_summary.go
+++ b/internal/analysis/thirdparty_summary.go
@@ -1,0 +1,117 @@
+// thirdparty_summary.go — Aggregate summary and recommendation generation for third-party audits.
+package analysis
+
+import (
+	"fmt"
+	"strings"
+)
+
+// buildThirdPartySummary computes aggregate counts from entries.
+func buildThirdPartySummary(entries []ThirdPartyEntry) ThirdPartySummary {
+	s := ThirdPartySummary{
+		TotalThirdParties: len(entries),
+	}
+	for _, e := range entries {
+		switch e.RiskLevel {
+		case "critical":
+			s.CriticalRisk++
+		case "high":
+			s.HighRisk++
+		case "medium":
+			s.MediumRisk++
+		case "low":
+			s.LowRisk++
+		}
+		if e.Resources.Scripts > 0 {
+			s.ScriptsFromThirdParty++
+		}
+		if e.DataOutbound {
+			s.OriginsReceivingData++
+		}
+		if e.SetsCookies {
+			s.OriginsSettingCookies++
+		}
+		if e.Reputation.Classification == "suspicious" {
+			s.SuspiciousOrigins++
+		}
+	}
+	return s
+}
+
+// buildRecommendations generates actionable recommendation strings.
+func buildRecommendations(entries []ThirdPartyEntry) []string {
+	var recs []string
+	recs = append(recs, suspiciousScriptRecs(entries)...)
+	recs = append(recs, dataReceiverRecs(entries)...)
+	recs = append(recs, piiOutboundRecs(entries)...)
+	recs = append(recs, cookieSetterRecs(entries)...)
+	return recs
+}
+
+// suspiciousScriptRecs returns recommendations for suspicious origins loading scripts.
+func suspiciousScriptRecs(entries []ThirdPartyEntry) []string {
+	var recs []string
+	for _, e := range entries {
+		if e.Reputation.Classification == "suspicious" && e.Resources.Scripts > 0 {
+			recs = append(recs, fmt.Sprintf("CRITICAL: %s loads scripts AND is flagged suspicious — investigate immediately", e.Origin))
+		}
+	}
+	return recs
+}
+
+// dataReceiverRecs returns a recommendation if any origins receive outbound data.
+func dataReceiverRecs(entries []ThirdPartyEntry) []string {
+	count := countEntries(entries, func(e ThirdPartyEntry) bool { return e.DataOutbound })
+	if count == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf("%d origin(s) receive user data — verify these are intentional", count)}
+}
+
+// piiOutboundRecs returns recommendations for origins receiving PII data.
+func piiOutboundRecs(entries []ThirdPartyEntry) []string {
+	var recs []string
+	for _, e := range entries {
+		if e.OutboundDetails != nil && len(e.OutboundDetails.PIIFields) > 0 {
+			recs = append(recs, fmt.Sprintf("%s receives PII fields (%s) — ensure privacy policy covers this",
+				e.Origin, strings.Join(e.OutboundDetails.PIIFields, ", ")))
+		}
+	}
+	return recs
+}
+
+// cookieSetterRecs returns a recommendation if third parties set cookies.
+func cookieSetterRecs(entries []ThirdPartyEntry) []string {
+	count := countEntries(entries, func(e ThirdPartyEntry) bool { return e.SetsCookies })
+	if count == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf("%d third-party origin(s) set cookies — review for GDPR/CCPA compliance", count)}
+}
+
+// countEntries counts entries matching a predicate.
+func countEntries(entries []ThirdPartyEntry, pred func(ThirdPartyEntry) bool) int {
+	n := 0
+	for _, e := range entries {
+		if pred(e) {
+			n++
+		}
+	}
+	return n
+}
+
+// riskOrder returns a sort order for risk levels (lower = more severe).
+func riskOrder(level string) int {
+	switch level {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	case "low":
+		return 3
+	default:
+		return 4
+	}
+}

--- a/internal/security/csp.go
+++ b/internal/security/csp.go
@@ -1,6 +1,3 @@
-// Purpose: Owns csp.go runtime behavior and integration logic.
-// Docs: docs/features/feature/observe/index.md
-
 // csp.go — CSP Generator: produces Content-Security-Policy headers from observed traffic.
 // Maintains an append-only origin accumulator that records every unique
 // origin+resourceType+pageURL combination. Independent of the ring buffer,
@@ -14,16 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dev-console/dev-console/internal/capture"
-	"net/url"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 )
-
-// ============================================
-// CSP Generator Types
-// ============================================
 
 // OriginEntry records observations of a specific origin+resourceType pair.
 type OriginEntry struct {
@@ -93,9 +83,28 @@ type CSPObservations struct {
 	PagesVisited    int `json:"pages_visited"`
 }
 
-// ============================================
-// CSP Generator Constructor
-// ============================================
+// resourceTypeToDirective maps resource types to CSP directive names.
+var resourceTypeToDirective = map[string]string{
+	"script":  "script-src",
+	"style":   "style-src",
+	"font":    "font-src",
+	"img":     "img-src",
+	"connect": "connect-src",
+	"frame":   "frame-src",
+	"media":   "media-src",
+	"worker":  "worker-src",
+}
+
+// originProcessingResult holds intermediate state from processing origin entries.
+type originProcessingResult struct {
+	directives      map[string]map[string]bool
+	originDetails   []OriginDetail
+	filteredOrigins []FilteredOrigin
+	totalResources  int
+	uniqueOrigins   int
+	originsIncluded int
+	originsFiltered int
+}
 
 // NewCSPGenerator creates a new CSP generator with an empty origin accumulator.
 func NewCSPGenerator() *CSPGenerator {
@@ -104,10 +113,6 @@ func NewCSPGenerator() *CSPGenerator {
 		pages:   make(map[string]bool),
 	}
 }
-
-// ============================================
-// Origin Recording
-// ============================================
 
 // RecordOrigin adds an observation of an origin+resourceType from a specific page.
 func (g *CSPGenerator) RecordOrigin(origin, resourceType, pageURL string) {
@@ -178,33 +183,6 @@ func (g *CSPGenerator) GetPages() []string {
 		pages = append(pages, p)
 	}
 	return pages
-}
-
-// ============================================
-// CSP Generation
-// ============================================
-
-// resourceTypeToDirective maps resource types to CSP directive names.
-var resourceTypeToDirective = map[string]string{
-	"script":  "script-src",
-	"style":   "style-src",
-	"font":    "font-src",
-	"img":     "img-src",
-	"connect": "connect-src",
-	"frame":   "frame-src",
-	"media":   "media-src",
-	"worker":  "worker-src",
-}
-
-// originProcessingResult holds intermediate state from processing origin entries.
-type originProcessingResult struct {
-	directives      map[string]map[string]bool
-	originDetails   []OriginDetail
-	filteredOrigins []FilteredOrigin
-	totalResources  int
-	uniqueOrigins   int
-	originsIncluded int
-	originsFiltered int
 }
 
 // GenerateCSP produces a CSP policy from accumulated origin observations.
@@ -295,23 +273,6 @@ func (g *CSPGenerator) processOriginEntries(excludeSet map[string]bool) originPr
 	return r
 }
 
-// directiveForResourceType returns the CSP directive name for a resource type,
-// falling back to "default-src" for unknown types.
-func directiveForResourceType(resourceType string) string {
-	if d := resourceTypeToDirective[resourceType]; d != "" {
-		return d
-	}
-	return "default-src"
-}
-
-// addDirectiveSource adds an origin to the given directive's source set.
-func addDirectiveSource(directives map[string]map[string]bool, directive, origin string) {
-	if directives[directive] == nil {
-		directives[directive] = make(map[string]bool)
-	}
-	directives[directive][origin] = true
-}
-
 // buildOriginDetail creates an OriginDetail for a single entry with confidence scoring.
 func (g *CSPGenerator) buildOriginDetail(entry *OriginEntry, directive string) OriginDetail {
 	confidence := g.computeConfidence(entry)
@@ -332,25 +293,6 @@ func (g *CSPGenerator) buildOriginDetail(entry *OriginEntry, directive string) O
 		detail.ExclusionReason = "Low confidence: observed only once. May be injected by extension or ad network. Add to exclude_origins or manually include after verification."
 	}
 	return detail
-}
-
-// sortDirectiveSources converts directive sets to sorted string slices.
-func sortDirectiveSources(directives map[string]map[string]bool) map[string][]string {
-	sorted := make(map[string][]string, len(directives))
-	for dir, sources := range directives {
-		list := make([]string, 0, len(sources))
-		for src := range sources {
-			list = append(list, src)
-		}
-		sort.Strings(list)
-		sorted[dir] = list
-	}
-	return sorted
-}
-
-// formatMetaTag wraps a CSP header string in an HTML meta tag.
-func formatMetaTag(cspHeader string) string {
-	return fmt.Sprintf(`<meta http-equiv="Content-Security-Policy" content="%s">`, cspHeader)
 }
 
 // applyWhitelistOverrides applies session-only whitelist origins and logs security events.
@@ -396,152 +338,6 @@ func (g *CSPGenerator) applyWhitelistOverrides(response *CSPResponse, overrides 
 	}
 }
 
-// ============================================
-// Confidence Scoring
-// ============================================
-
-// computeConfidence determines the confidence level for an origin entry.
-// High: 3+ observations AND 2+ pages
-// Medium: 2+ observations OR 2+ pages
-// Low: exactly 1 observation on 1 page
-// Exception: connect-src has relaxed threshold (1 observation = medium)
-func (g *CSPGenerator) computeConfidence(entry *OriginEntry) string {
-	pageCount := len(entry.Pages)
-	obsCount := entry.Count
-
-	if isHighConfidence(obsCount, pageCount) {
-		return "high"
-	}
-	if resourceTypeToDirective[entry.ResourceType] == "connect-src" {
-		return "medium"
-	}
-	if obsCount >= 2 || pageCount >= 2 {
-		return "medium"
-	}
-	return "low"
-}
-
-func isHighConfidence(obsCount, pageCount int) bool {
-	return obsCount >= 3 && pageCount >= 2
-}
-
-// ============================================
-// Development Pollution Filtering
-// ============================================
-
-// extensionPrefixes maps browser extension URL prefixes to their filter reasons.
-var extensionPrefixes = []struct {
-	prefix string
-	reason string
-}{
-	{"chrome-extension://", "Browser extension origin (auto-filtered)"},
-	{"moz-extension://", "Firefox extension origin (auto-filtered)"},
-}
-
-// isDevPollution checks if an origin is a known development-only pattern.
-// Returns the reason string if filtered, empty string if not filtered.
-func (g *CSPGenerator) isDevPollution(origin string, pageOrigins map[string]bool) string {
-	if reason := matchExtensionPrefix(origin); reason != "" {
-		return reason
-	}
-	return g.checkLocalhostDevServer(origin, pageOrigins)
-}
-
-// matchExtensionPrefix returns a filter reason if the origin matches a known browser extension prefix.
-func matchExtensionPrefix(origin string) string {
-	for _, ext := range extensionPrefixes {
-		if strings.HasPrefix(origin, ext.prefix) {
-			return ext.reason
-		}
-	}
-	return ""
-}
-
-// checkLocalhostDevServer filters localhost origins that differ from observed page origins.
-func (g *CSPGenerator) checkLocalhostDevServer(origin string, pageOrigins map[string]bool) string {
-	parsed, err := url.Parse(origin)
-	if err != nil {
-		return ""
-	}
-	host := parsed.Hostname()
-	if host != "localhost" && host != "127.0.0.1" {
-		return ""
-	}
-	if pageOrigins[origin] {
-		return ""
-	}
-	return "Development server (auto-filtered, different port from app)"
-}
-
-// extractPageOrigins returns the set of origins from observed page URLs.
-func (g *CSPGenerator) extractPageOrigins() map[string]bool {
-	origins := make(map[string]bool)
-	for pageURL := range g.pages {
-		parsed, err := url.Parse(pageURL)
-		if err != nil {
-			continue
-		}
-		// Reconstruct origin: scheme://host[:port]
-		origin := parsed.Scheme + "://" + parsed.Host
-		origins[origin] = true
-	}
-	return origins
-}
-
-// ============================================
-// CSP Header Building
-// ============================================
-
-// directiveOrder defines the canonical order for CSP directives.
-var directiveOrder = []string{
-	"default-src",
-	"script-src",
-	"style-src",
-	"img-src",
-	"font-src",
-	"connect-src",
-	"frame-src",
-	"media-src",
-	"worker-src",
-	"base-uri",
-	"form-action",
-	"frame-ancestors",
-}
-
-// directiveOrderSet is built from directiveOrder for O(1) membership checks.
-var directiveOrderSet = buildDirectiveOrderSet()
-
-func buildDirectiveOrderSet() map[string]bool {
-	s := make(map[string]bool, len(directiveOrder))
-	for _, d := range directiveOrder {
-		s[d] = true
-	}
-	return s
-}
-
-// buildCSPHeader builds the CSP header string from sorted directives.
-func (g *CSPGenerator) buildCSPHeader(directives map[string][]string) string {
-	parts := make([]string, 0, len(directives))
-
-	for _, dir := range directiveOrder {
-		if sources, ok := directives[dir]; ok && len(sources) > 0 {
-			parts = append(parts, dir+" "+strings.Join(sources, " "))
-		}
-	}
-
-	for dir, sources := range directives {
-		if !directiveOrderSet[dir] && len(sources) > 0 {
-			parts = append(parts, dir+" "+strings.Join(sources, " "))
-		}
-	}
-
-	return strings.Join(parts, "; ")
-}
-
-// ============================================
-// Warnings
-// ============================================
-
 // buildWarnings generates advisory warnings based on the observation state.
 func (g *CSPGenerator) buildWarnings(pagesVisited, originsFiltered int, details []OriginDetail) []string {
 	if len(g.origins) == 0 {
@@ -558,38 +354,6 @@ func (g *CSPGenerator) buildWarnings(pagesVisited, originsFiltered int, details 
 	return warnings
 }
 
-// countLowConfidenceExclusions returns the number of origin details excluded due to low confidence.
-func countLowConfidenceExclusions(details []OriginDetail) int {
-	count := 0
-	for _, d := range details {
-		if d.Confidence == "low" && !d.Included {
-			count++
-		}
-	}
-	return count
-}
-
-// ============================================
-// Helper Functions
-// ============================================
-
-// entryPages returns a sorted list of page URLs for an origin entry (up to 10).
-func (g *CSPGenerator) entryPages(entry *OriginEntry) []string {
-	var pages []string
-	for p := range entry.Pages {
-		pages = append(pages, p)
-		if len(pages) >= 10 {
-			break
-		}
-	}
-	sort.Strings(pages)
-	return pages
-}
-
-// ============================================
-// Network Body Integration
-// ============================================
-
 // RecordOriginFromBody extracts origin and resource type from a NetworkBody
 // and records it in the origin accumulator. Called from the network ingestion path.
 func (g *CSPGenerator) RecordOriginFromBody(body capture.NetworkBody, pageURL string) {
@@ -600,57 +364,6 @@ func (g *CSPGenerator) RecordOriginFromBody(body capture.NetworkBody, pageURL st
 	resourceType := contentTypeToResourceType(body.ContentType)
 	g.RecordOrigin(origin, resourceType, pageURL)
 }
-
-// extractOriginFromURL extracts scheme://host[:port] from a URL string.
-func extractOriginFromURL(rawURL string) string {
-	parsed, err := url.Parse(rawURL)
-	if err != nil || parsed.Host == "" {
-		return ""
-	}
-	return parsed.Scheme + "://" + parsed.Host
-}
-
-// exactContentTypeMap maps exact Content-Type values to CSP resource categories.
-var exactContentTypeMap = map[string]string{
-	"text/css":                "style",
-	"application/x-font-ttf":  "font",
-	"application/x-font-woff": "font",
-}
-
-// contentTypeToResourceType maps HTTP Content-Type to CSP resource category.
-func contentTypeToResourceType(ct string) string {
-	ct = strings.ToLower(ct)
-	if idx := strings.IndexByte(ct, ';'); idx >= 0 {
-		ct = ct[:idx]
-	}
-	ct = strings.TrimSpace(ct)
-
-	if res, ok := exactContentTypeMap[ct]; ok {
-		return res
-	}
-	return contentTypePrefixMatch(ct)
-}
-
-// contentTypePrefixMatch classifies content types by prefix or substring patterns.
-func contentTypePrefixMatch(ct string) string {
-	if strings.Contains(ct, "javascript") {
-		return "script"
-	}
-	if strings.HasPrefix(ct, "font/") || strings.Contains(ct, "application/font") {
-		return "font"
-	}
-	if strings.HasPrefix(ct, "image/") {
-		return "img"
-	}
-	if strings.HasPrefix(ct, "audio/") || strings.HasPrefix(ct, "video/") {
-		return "media"
-	}
-	return "connect"
-}
-
-// ============================================
-// MCP Tool Handler
-// ============================================
 
 // HandleGenerateCSP is the MCP tool handler for generate_csp.
 func (g *CSPGenerator) HandleGenerateCSP(params json.RawMessage) (any, error) {

--- a/internal/security/csp_helpers.go
+++ b/internal/security/csp_helpers.go
@@ -1,0 +1,246 @@
+// csp_helpers.go — CSP helper functions: dev pollution filtering, confidence scoring, header building, and content type mapping.
+package security
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// computeConfidence determines the confidence level for an origin entry.
+// High: 3+ observations AND 2+ pages
+// Medium: 2+ observations OR 2+ pages
+// Low: exactly 1 observation on 1 page
+// Exception: connect-src has relaxed threshold (1 observation = medium)
+func (g *CSPGenerator) computeConfidence(entry *OriginEntry) string {
+	pageCount := len(entry.Pages)
+	obsCount := entry.Count
+
+	if isHighConfidence(obsCount, pageCount) {
+		return "high"
+	}
+	if resourceTypeToDirective[entry.ResourceType] == "connect-src" {
+		return "medium"
+	}
+	if obsCount >= 2 || pageCount >= 2 {
+		return "medium"
+	}
+	return "low"
+}
+
+func isHighConfidence(obsCount, pageCount int) bool {
+	return obsCount >= 3 && pageCount >= 2
+}
+
+// extensionPrefixes maps browser extension URL prefixes to their filter reasons.
+var extensionPrefixes = []struct {
+	prefix string
+	reason string
+}{
+	{"chrome-extension://", "Browser extension origin (auto-filtered)"},
+	{"moz-extension://", "Firefox extension origin (auto-filtered)"},
+}
+
+// isDevPollution checks if an origin is a known development-only pattern.
+// Returns the reason string if filtered, empty string if not filtered.
+func (g *CSPGenerator) isDevPollution(origin string, pageOrigins map[string]bool) string {
+	if reason := matchExtensionPrefix(origin); reason != "" {
+		return reason
+	}
+	return g.checkLocalhostDevServer(origin, pageOrigins)
+}
+
+// matchExtensionPrefix returns a filter reason if the origin matches a known browser extension prefix.
+func matchExtensionPrefix(origin string) string {
+	for _, ext := range extensionPrefixes {
+		if strings.HasPrefix(origin, ext.prefix) {
+			return ext.reason
+		}
+	}
+	return ""
+}
+
+// checkLocalhostDevServer filters localhost origins that differ from observed page origins.
+func (g *CSPGenerator) checkLocalhostDevServer(origin string, pageOrigins map[string]bool) string {
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		return ""
+	}
+	host := parsed.Hostname()
+	if host != "localhost" && host != "127.0.0.1" {
+		return ""
+	}
+	if pageOrigins[origin] {
+		return ""
+	}
+	return "Development server (auto-filtered, different port from app)"
+}
+
+// extractPageOrigins returns the set of origins from observed page URLs.
+func (g *CSPGenerator) extractPageOrigins() map[string]bool {
+	origins := make(map[string]bool)
+	for pageURL := range g.pages {
+		parsed, err := url.Parse(pageURL)
+		if err != nil {
+			continue
+		}
+		// Reconstruct origin: scheme://host[:port]
+		origin := parsed.Scheme + "://" + parsed.Host
+		origins[origin] = true
+	}
+	return origins
+}
+
+// directiveOrder defines the canonical order for CSP directives.
+var directiveOrder = []string{
+	"default-src",
+	"script-src",
+	"style-src",
+	"img-src",
+	"font-src",
+	"connect-src",
+	"frame-src",
+	"media-src",
+	"worker-src",
+	"base-uri",
+	"form-action",
+	"frame-ancestors",
+}
+
+// directiveOrderSet is built from directiveOrder for O(1) membership checks.
+var directiveOrderSet = buildDirectiveOrderSet()
+
+func buildDirectiveOrderSet() map[string]bool {
+	s := make(map[string]bool, len(directiveOrder))
+	for _, d := range directiveOrder {
+		s[d] = true
+	}
+	return s
+}
+
+// buildCSPHeader builds the CSP header string from sorted directives.
+func (g *CSPGenerator) buildCSPHeader(directives map[string][]string) string {
+	parts := make([]string, 0, len(directives))
+
+	for _, dir := range directiveOrder {
+		if sources, ok := directives[dir]; ok && len(sources) > 0 {
+			parts = append(parts, dir+" "+strings.Join(sources, " "))
+		}
+	}
+
+	for dir, sources := range directives {
+		if !directiveOrderSet[dir] && len(sources) > 0 {
+			parts = append(parts, dir+" "+strings.Join(sources, " "))
+		}
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+// directiveForResourceType returns the CSP directive name for a resource type,
+// falling back to "default-src" for unknown types.
+func directiveForResourceType(resourceType string) string {
+	if d := resourceTypeToDirective[resourceType]; d != "" {
+		return d
+	}
+	return "default-src"
+}
+
+// addDirectiveSource adds an origin to the given directive's source set.
+func addDirectiveSource(directives map[string]map[string]bool, directive, origin string) {
+	if directives[directive] == nil {
+		directives[directive] = make(map[string]bool)
+	}
+	directives[directive][origin] = true
+}
+
+// sortDirectiveSources converts directive sets to sorted string slices.
+func sortDirectiveSources(directives map[string]map[string]bool) map[string][]string {
+	sorted := make(map[string][]string, len(directives))
+	for dir, sources := range directives {
+		list := make([]string, 0, len(sources))
+		for src := range sources {
+			list = append(list, src)
+		}
+		sort.Strings(list)
+		sorted[dir] = list
+	}
+	return sorted
+}
+
+// formatMetaTag wraps a CSP header string in an HTML meta tag.
+func formatMetaTag(cspHeader string) string {
+	return fmt.Sprintf(`<meta http-equiv="Content-Security-Policy" content="%s">`, cspHeader)
+}
+
+// entryPages returns a sorted list of page URLs for an origin entry (up to 10).
+func (g *CSPGenerator) entryPages(entry *OriginEntry) []string {
+	var pages []string
+	for p := range entry.Pages {
+		pages = append(pages, p)
+		if len(pages) >= 10 {
+			break
+		}
+	}
+	sort.Strings(pages)
+	return pages
+}
+
+// countLowConfidenceExclusions returns the number of origin details excluded due to low confidence.
+func countLowConfidenceExclusions(details []OriginDetail) int {
+	count := 0
+	for _, d := range details {
+		if d.Confidence == "low" && !d.Included {
+			count++
+		}
+	}
+	return count
+}
+
+// extractOriginFromURL extracts scheme://host[:port] from a URL string.
+func extractOriginFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+// exactContentTypeMap maps exact Content-Type values to CSP resource categories.
+var exactContentTypeMap = map[string]string{
+	"text/css":                "style",
+	"application/x-font-ttf":  "font",
+	"application/x-font-woff": "font",
+}
+
+// contentTypeToResourceType maps HTTP Content-Type to CSP resource category.
+func contentTypeToResourceType(ct string) string {
+	ct = strings.ToLower(ct)
+	if idx := strings.IndexByte(ct, ';'); idx >= 0 {
+		ct = ct[:idx]
+	}
+	ct = strings.TrimSpace(ct)
+
+	if res, ok := exactContentTypeMap[ct]; ok {
+		return res
+	}
+	return contentTypePrefixMatch(ct)
+}
+
+// contentTypePrefixMatch classifies content types by prefix or substring patterns.
+func contentTypePrefixMatch(ct string) string {
+	if strings.Contains(ct, "javascript") {
+		return "script"
+	}
+	if strings.HasPrefix(ct, "font/") || strings.Contains(ct, "application/font") {
+		return "font"
+	}
+	if strings.HasPrefix(ct, "image/") {
+		return "img"
+	}
+	if strings.HasPrefix(ct, "audio/") || strings.HasPrefix(ct, "video/") {
+		return "media"
+	}
+	return "connect"
+}


### PR DESCRIPTION
## Summary
- Split `internal/analysis/thirdparty.go` (704 LOC) into 3 files: core (455), reputation/DGA (139), summary/recommendations (117)
- Split `internal/analysis/clustering.go` (701 LOC) into 2 files: core manager (427), helpers/stack parsing/signals (265)
- Split `internal/security/csp.go` (666 LOC) into 2 files: core generator (379), helpers/dev pollution/content type (246)

## Test plan
- [x] `go build ./internal/analysis/...` compiles clean
- [x] `go build ./internal/security/...` compiles clean
- [x] `make test` — all Go tests pass
- [x] All files well under 800 LOC limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)