### PR TITLE
feat: complete storage/indexeddb UX and generate warning filtering

### DIFF
--- a/cmd/dev-console/testgen.go
+++ b/cmd/dev-console/testgen.go
@@ -213,6 +213,7 @@ func (h *ToolHandler) handleGenerateTestFromContext(req JSONRPCRequest, args jso
 			Result:  mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again"),
 		}
 	}
+	warnings = filterGenerateDispatchWarnings(warnings)
 
 	if errResp, ok := validateTestFromContextParams(req.ID, params); !ok {
 		return errResp

--- a/cmd/dev-console/testgen_classify.go
+++ b/cmd/dev-console/testgen_classify.go
@@ -23,6 +23,8 @@ func (h *ToolHandler) handleGenerateTestClassify(req JSONRPCRequest, args json.R
 		}
 	}
 
+	warnings = filterGenerateDispatchWarnings(warnings)
+
 	if errResp, ok := validateClassifyParams(req.ID, params); !ok {
 		return errResp
 	}

--- a/cmd/dev-console/testgen_heal.go
+++ b/cmd/dev-console/testgen_heal.go
@@ -24,6 +24,8 @@ func (h *ToolHandler) handleGenerateTestHeal(req JSONRPCRequest, args json.RawMe
 		}
 	}
 
+	warnings = filterGenerateDispatchWarnings(warnings)
+
 	if errResp, ok := validateHealParams(req, params); ok {
 		return errResp
 	}

--- a/cmd/dev-console/tools_generate_warning_filter_test.go
+++ b/cmd/dev-console/tools_generate_warning_filter_test.go
@@ -1,0 +1,137 @@
+// tools_generate_warning_filter_test.go — Regression tests for generate dispatch warnings.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/capture"
+)
+
+func TestGenerateTestFromContext_NoWarningsForDispatchParams(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+	h.capture.AddEnhancedActionsForTest([]capture.EnhancedAction{
+		{Type: "navigate", Timestamp: 1000, URL: "https://example.com", ToURL: "https://example.com"},
+		{Type: "click", Timestamp: 1200, URL: "https://example.com", Selectors: map[string]any{"text": "Login"}},
+	})
+
+	resp := callGenerateRaw(h, `{"what":"test_from_context","context":"interaction","telemetry_mode":"auto","save_to":"tests/generated.spec.ts"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("generate(test_from_context) should succeed, got error: %s", firstText(result))
+	}
+	if warningsText, ok := warningsBlock(result); ok {
+		t.Fatalf("did not expect warnings for dispatch params, got %q", warningsText)
+	}
+}
+
+func TestGenerateTestClassify_NoWarningsForDispatchParams(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+
+	resp := callGenerateRaw(h, `{"what":"test_classify","action":"failure","telemetry_mode":"auto","save_to":"tmp/classify.json","failure":{"test_name":"login test","error":"Timeout waiting for selector \"#login-btn\""}}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("generate(test_classify) should succeed, got error: %s", firstText(result))
+	}
+	if warningsText, ok := warningsBlock(result); ok {
+		t.Fatalf("did not expect warnings for dispatch params, got %q", warningsText)
+	}
+}
+
+func TestHandleGenerateTestFromContext_FiltersOnlyDispatchWarnings(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+	h.capture.AddEnhancedActionsForTest([]capture.EnhancedAction{
+		{Type: "navigate", Timestamp: 1000, URL: "https://example.com", ToURL: "https://example.com"},
+		{Type: "click", Timestamp: 1200, URL: "https://example.com", Selectors: map[string]any{"text": "Login"}},
+	})
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.handleGenerateTestFromContext(req, json.RawMessage(`{"what":"test_from_context","context":"interaction","typo_field":true}`))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("handleGenerateTestFromContext should succeed, got error: %s", firstText(result))
+	}
+
+	warningsText, ok := warningsBlock(result)
+	if !ok {
+		t.Fatal("expected warnings block for typo_field")
+	}
+	if !strings.Contains(warningsText, "typo_field") {
+		t.Fatalf("expected warning to include typo_field, got %q", warningsText)
+	}
+	if strings.Contains(warningsText, "what") {
+		t.Fatalf("warning should not include dispatch param 'what', got %q", warningsText)
+	}
+}
+
+func TestGenerateTestHeal_NoWarningsForDispatchParams(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+	testDir := makeProjectTempDir(t)
+
+	resp := callGenerateRaw(h, fmt.Sprintf(`{"what":"test_heal","action":"batch","test_dir":%q,"telemetry_mode":"auto","save_to":"tmp/heal.json"}`, testDir))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("generate(test_heal) should succeed, got error: %s", firstText(result))
+	}
+	if warningsText, ok := warningsBlock(result); ok {
+		t.Fatalf("did not expect warnings for dispatch params, got %q", warningsText)
+	}
+}
+
+func TestHandleGenerateTestHeal_FiltersOnlyDispatchWarnings(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+	testDir := makeProjectTempDir(t)
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.handleGenerateTestHeal(req, json.RawMessage(fmt.Sprintf(`{"what":"test_heal","action":"batch","test_dir":%q,"typo_field":true}`, testDir)))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("handleGenerateTestHeal should succeed, got error: %s", firstText(result))
+	}
+
+	warningsText, ok := warningsBlock(result)
+	if !ok {
+		t.Fatal("expected warnings block for typo_field")
+	}
+	if !strings.Contains(warningsText, "typo_field") {
+		t.Fatalf("expected warning to include typo_field, got %q", warningsText)
+	}
+	if strings.Contains(warningsText, "what") {
+		t.Fatalf("warning should not include dispatch param 'what', got %q", warningsText)
+	}
+}
+
+func makeProjectTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp(".", "test-heal-")
+	if err != nil {
+		t.Fatalf("failed to create project temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return dir
+}
+
+func warningsBlock(result MCPToolResult) (string, bool) {
+	for _, block := range result.Content {
+		if strings.HasPrefix(block.Text, "_warnings:") {
+			return block.Text, true
+		}
+	}
+	return "", false
+}

--- a/cmd/dev-console/tools_generate_warning_filter_test.go
+++ b/cmd/dev-console/tools_generate_warning_filter_test.go
@@ -114,6 +114,30 @@ func TestHandleGenerateTestHeal_FiltersOnlyDispatchWarnings(t *testing.T) {
 	}
 }
 
+func TestHandleGenerateTestClassify_FiltersOnlyDispatchWarnings(t *testing.T) {
+	t.Parallel()
+
+	h := newTestToolHandler()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.handleGenerateTestClassify(req, json.RawMessage(`{"what":"test_classify","action":"failure","failure":{"test_name":"login test","error":"Timeout waiting for selector \"#login-btn\""},"typo_field":true}`))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("handleGenerateTestClassify should succeed, got error: %s", firstText(result))
+	}
+
+	warningsText, ok := warningsBlock(result)
+	if !ok {
+		t.Fatal("expected warnings block for typo_field")
+	}
+	if !strings.Contains(warningsText, "typo_field") {
+		t.Fatalf("expected warning to include typo_field, got %q", warningsText)
+	}
+	if strings.Contains(warningsText, "what") {
+		t.Fatalf("warning should not include dispatch param 'what', got %q", warningsText)
+	}
+}
+
 func makeProjectTempDir(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/dev-console/tools_interact.go
+++ b/cmd/dev-console/tools_interact.go
@@ -30,6 +30,11 @@ func (h *ToolHandler) interactDispatch() map[string]interactHandler {
 			"load_state":                h.handlePilotManageStateLoad,
 			"list_states":               h.handlePilotManageStateList,
 			"delete_state":              h.handlePilotManageStateDelete,
+			"set_storage":               h.handleSetStorage,
+			"delete_storage":            h.handleDeleteStorage,
+			"clear_storage":             h.handleClearStorage,
+			"set_cookie":                h.handleSetCookie,
+			"delete_cookie":             h.handleDeleteCookie,
 			"execute_js":                h.handlePilotExecuteJS,
 			"navigate":                  h.handleBrowserActionNavigate,
 			"refresh":                   h.handleBrowserActionRefresh,
@@ -47,7 +52,7 @@ func (h *ToolHandler) interactDispatch() map[string]interactHandler {
 			"get_markdown":              h.handleGetMarkdown,
 			"navigate_and_wait_for":     h.handleNavigateAndWaitFor,
 			"fill_form_and_submit":      h.handleFillFormAndSubmit,
-			"fill_form":                h.handleFillForm,
+			"fill_form":                 h.handleFillForm,
 			"run_a11y_and_export_sarif": h.handleRunA11yAndExportSARIF,
 		}
 	})

--- a/cmd/dev-console/tools_interact_storage.go
+++ b/cmd/dev-console/tools_interact_storage.go
@@ -1,0 +1,200 @@
+// tools_interact_storage.go — Granular storage/cookie mutation handlers for interact tool.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dev-console/dev-console/internal/queries"
+)
+
+var validStorageTypes = map[string]string{
+	"localStorage":   "localStorage",
+	"sessionStorage": "sessionStorage",
+}
+
+func (h *ToolHandler) handleSetStorage(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		StorageType string  `json:"storage_type"`
+		Key         string  `json:"key"`
+		Value       *string `json:"value"`
+		TabID       int     `json:"tab_id,omitempty"`
+		TimeoutMs   int     `json:"timeout_ms,omitempty"`
+		World       string  `json:"world,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+
+	storageExpr, ok := validStorageTypes[params.StorageType]
+	if !ok {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'storage_type' value: "+params.StorageType, "Use 'localStorage' or 'sessionStorage'", withParam("storage_type"))}
+	}
+	if params.Key == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'key' is missing for set_storage action", "Add the 'key' parameter and call again", withParam("key"))}
+	}
+	if params.Value == nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'value' is missing for set_storage action", "Add the 'value' parameter and call again", withParam("value"))}
+	}
+
+	script := fmt.Sprintf(`(() => { try { %s.setItem(%s, %s); return { ok: true, action: "set_storage", storage_type: %s, key: %s }; } catch (e) { return { ok: false, error: String((e && e.message) || e) }; } })()`,
+		storageExpr, jsQuote(params.Key), jsQuote(*params.Value), jsQuote(params.StorageType), jsQuote(params.Key))
+	return h.queueExecuteScript(req, args, "storage_set", params.TabID, params.TimeoutMs, params.World, script, "set_storage", "set_storage queued")
+}
+
+func (h *ToolHandler) handleDeleteStorage(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		StorageType string `json:"storage_type"`
+		Key         string `json:"key"`
+		TabID       int    `json:"tab_id,omitempty"`
+		TimeoutMs   int    `json:"timeout_ms,omitempty"`
+		World       string `json:"world,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+
+	storageExpr, ok := validStorageTypes[params.StorageType]
+	if !ok {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'storage_type' value: "+params.StorageType, "Use 'localStorage' or 'sessionStorage'", withParam("storage_type"))}
+	}
+	if params.Key == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'key' is missing for delete_storage action", "Add the 'key' parameter and call again", withParam("key"))}
+	}
+
+	script := fmt.Sprintf(`(() => { try { %s.removeItem(%s); return { ok: true, action: "delete_storage", storage_type: %s, key: %s }; } catch (e) { return { ok: false, error: String((e && e.message) || e) }; } })()`,
+		storageExpr, jsQuote(params.Key), jsQuote(params.StorageType), jsQuote(params.Key))
+	return h.queueExecuteScript(req, args, "storage_del", params.TabID, params.TimeoutMs, params.World, script, "delete_storage", "delete_storage queued")
+}
+
+func (h *ToolHandler) handleClearStorage(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		StorageType string `json:"storage_type"`
+		TabID       int    `json:"tab_id,omitempty"`
+		TimeoutMs   int    `json:"timeout_ms,omitempty"`
+		World       string `json:"world,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+
+	storageExpr, ok := validStorageTypes[params.StorageType]
+	if !ok {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'storage_type' value: "+params.StorageType, "Use 'localStorage' or 'sessionStorage'", withParam("storage_type"))}
+	}
+
+	script := fmt.Sprintf(`(() => { try { %s.clear(); return { ok: true, action: "clear_storage", storage_type: %s }; } catch (e) { return { ok: false, error: String((e && e.message) || e) }; } })()`,
+		storageExpr, jsQuote(params.StorageType))
+	return h.queueExecuteScript(req, args, "storage_clear", params.TabID, params.TimeoutMs, params.World, script, "clear_storage", "clear_storage queued")
+}
+
+func (h *ToolHandler) handleSetCookie(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Name      string  `json:"name"`
+		Value     *string `json:"value"`
+		Domain    string  `json:"domain,omitempty"`
+		Path      string  `json:"path,omitempty"`
+		TabID     int     `json:"tab_id,omitempty"`
+		TimeoutMs int     `json:"timeout_ms,omitempty"`
+		World     string  `json:"world,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+	if params.Name == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'name' is missing for set_cookie action", "Add the 'name' parameter and call again", withParam("name"))}
+	}
+	if params.Value == nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'value' is missing for set_cookie action", "Add the 'value' parameter and call again", withParam("value"))}
+	}
+
+	cookie := params.Name + "=" + *params.Value
+	if params.Path != "" {
+		cookie += "; path=" + params.Path
+	} else {
+		cookie += "; path=/"
+	}
+	if params.Domain != "" {
+		cookie += "; domain=" + params.Domain
+	}
+
+	script := fmt.Sprintf(`(() => { try { document.cookie = %s; return { ok: true, action: "set_cookie", name: %s }; } catch (e) { return { ok: false, error: String((e && e.message) || e) }; } })()`,
+		jsQuote(cookie), jsQuote(params.Name))
+	return h.queueExecuteScript(req, args, "cookie_set", params.TabID, params.TimeoutMs, params.World, script, "set_cookie", "set_cookie queued")
+}
+
+func (h *ToolHandler) handleDeleteCookie(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Name      string `json:"name"`
+		Domain    string `json:"domain,omitempty"`
+		Path      string `json:"path,omitempty"`
+		TabID     int    `json:"tab_id,omitempty"`
+		TimeoutMs int    `json:"timeout_ms,omitempty"`
+		World     string `json:"world,omitempty"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+	}
+	if params.Name == "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'name' is missing for delete_cookie action", "Add the 'name' parameter and call again", withParam("name"))}
+	}
+
+	cookie := params.Name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+	if params.Path != "" {
+		cookie += "; path=" + params.Path
+	} else {
+		cookie += "; path=/"
+	}
+	if params.Domain != "" {
+		cookie += "; domain=" + params.Domain
+	}
+
+	script := fmt.Sprintf(`(() => { try { document.cookie = %s; return { ok: true, action: "delete_cookie", name: %s }; } catch (e) { return { ok: false, error: String((e && e.message) || e) }; } })()`,
+		jsQuote(cookie), jsQuote(params.Name))
+	return h.queueExecuteScript(req, args, "cookie_del", params.TabID, params.TimeoutMs, params.World, script, "delete_cookie", "delete_cookie queued")
+}
+
+func (h *ToolHandler) queueExecuteScript(
+	req JSONRPCRequest,
+	waitArgs json.RawMessage,
+	correlationPrefix string,
+	tabID, timeoutMs int,
+	world, script, reason, queuedMsg string,
+) JSONRPCResponse {
+	if resp, blocked := h.requirePilot(req); blocked {
+		return resp
+	}
+
+	if timeoutMs <= 0 {
+		timeoutMs = 5000
+	}
+	if world == "" {
+		world = "auto"
+	}
+	if !validWorldValues[world] {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Invalid 'world' value: "+world, "Use 'auto' (default), 'main', or 'isolated'", withParam("world"))}
+	}
+
+	correlationID := newCorrelationID(correlationPrefix)
+	execParams, _ := json.Marshal(map[string]any{
+		"script":     script,
+		"timeout_ms": timeoutMs,
+		"world":      world,
+		"reason":     reason,
+	})
+
+	query := queries.PendingQuery{
+		Type:          "execute",
+		Params:        execParams,
+		TabID:         tabID,
+		CorrelationID: correlationID,
+	}
+	h.capture.CreatePendingQueryWithTimeout(query, queries.AsyncCommandTimeout, req.ClientID)
+
+	return h.MaybeWaitForCommand(req, correlationID, waitArgs, queuedMsg)
+}
+
+func jsQuote(v string) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/cmd/dev-console/tools_interact_storage_mutation_test.go
+++ b/cmd/dev-console/tools_interact_storage_mutation_test.go
@@ -51,6 +51,22 @@ func TestInteractStorageMutation_SetStorage_QueuesExecute(t *testing.T) {
 	}
 }
 
+func TestInteractStorageMutation_SetStorage_ActionAlias_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"action":"set_storage","storage_type":"localStorage","key":"theme","value":"light"}`)
+	if result.IsError {
+		t.Fatalf("set_storage via action alias should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+}
+
 func TestInteractStorageMutation_ClearStorage_QueuesExecute(t *testing.T) {
 	t.Parallel()
 	env := newInteractHelpersTestEnv(t)
@@ -137,6 +153,22 @@ func TestInteractStorageMutation_DeleteCookie_QueuesExecute(t *testing.T) {
 	}
 	if !strings.Contains(script, "domain=.example.com") || !strings.Contains(script, "path=/") {
 		t.Fatalf("script should include domain/path attributes, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_DeleteCookie_ActionAlias_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"action":"delete_cookie","name":"_ga","domain":".example.com","path":"/"}`)
+	if result.IsError {
+		t.Fatalf("delete_cookie via action alias should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
 	}
 }
 

--- a/cmd/dev-console/tools_interact_storage_mutation_test.go
+++ b/cmd/dev-console/tools_interact_storage_mutation_test.go
@@ -1,0 +1,201 @@
+// tools_interact_storage_mutation_test.go — TDD coverage for granular storage/cookie mutation actions.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func callInteractStorageAction(t *testing.T, env *interactHelpersTestEnv, argsJSON string) MCPToolResult {
+	t.Helper()
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := env.handler.toolInteract(req, normalizeInteractArgsForAsync(argsJSON))
+	return parseToolResult(t, resp)
+}
+
+func lastPendingQuery(t *testing.T, env *interactHelpersTestEnv) map[string]any {
+	t.Helper()
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("expected pending query to be created")
+	}
+	var params map[string]any
+	if err := json.Unmarshal(pq.Params, &params); err != nil {
+		t.Fatalf("failed to parse pending query params: %v", err)
+	}
+	params["_type"] = pq.Type
+	return params
+}
+
+func TestInteractStorageMutation_SetStorage_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"set_storage","storage_type":"localStorage","key":"theme","value":"light"}`)
+	if result.IsError {
+		t.Fatalf("set_storage should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+	script, _ := params["script"].(string)
+	if !strings.Contains(script, "localStorage.setItem") {
+		t.Fatalf("script should set localStorage key, got: %q", script)
+	}
+	if !strings.Contains(script, `"theme"`) || !strings.Contains(script, `"light"`) {
+		t.Fatalf("script should include key/value, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_ClearStorage_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"clear_storage","storage_type":"sessionStorage"}`)
+	if result.IsError {
+		t.Fatalf("clear_storage should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+	script, _ := params["script"].(string)
+	if !strings.Contains(script, "sessionStorage.clear") {
+		t.Fatalf("script should clear sessionStorage, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_DeleteStorage_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"delete_storage","storage_type":"localStorage","key":"auth_token"}`)
+	if result.IsError {
+		t.Fatalf("delete_storage should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+	script, _ := params["script"].(string)
+	if !strings.Contains(script, "localStorage.removeItem") {
+		t.Fatalf("script should remove localStorage key, got: %q", script)
+	}
+	if !strings.Contains(script, `"auth_token"`) {
+		t.Fatalf("script should include key, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_SetCookie_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"set_cookie","name":"debug","value":"true","domain":".example.com","path":"/"}`)
+	if result.IsError {
+		t.Fatalf("set_cookie should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+	script, _ := params["script"].(string)
+	if !strings.Contains(script, "document.cookie") || !strings.Contains(script, "debug=true") {
+		t.Fatalf("script should set cookie, got: %q", script)
+	}
+	if !strings.Contains(script, "domain=.example.com") || !strings.Contains(script, "path=/") {
+		t.Fatalf("script should include domain/path attributes, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_DeleteCookie_QueuesExecute(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"delete_cookie","name":"_ga","domain":".example.com","path":"/"}`)
+	if result.IsError {
+		t.Fatalf("delete_cookie should succeed, got error: %s", firstText(result))
+	}
+
+	params := lastPendingQuery(t, env)
+	if params["_type"] != "execute" {
+		t.Fatalf("pending query type = %v, want execute", params["_type"])
+	}
+	script, _ := params["script"].(string)
+	if !strings.Contains(script, "document.cookie") || !strings.Contains(script, "_ga=; expires=Thu, 01 Jan 1970") {
+		t.Fatalf("script should delete cookie, got: %q", script)
+	}
+	if !strings.Contains(script, "domain=.example.com") || !strings.Contains(script, "path=/") {
+		t.Fatalf("script should include domain/path attributes, got: %q", script)
+	}
+}
+
+func TestInteractStorageMutation_SetStorage_MissingKey(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"set_storage","storage_type":"localStorage","value":"light"}`)
+	if !result.IsError {
+		t.Fatal("set_storage without key should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "missing_param") || !strings.Contains(text, "key") {
+		t.Fatalf("expected missing_param error for key, got: %s", text)
+	}
+}
+
+func TestInteractStorageMutation_DeleteStorage_MissingKey(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"delete_storage","storage_type":"localStorage"}`)
+	if !result.IsError {
+		t.Fatal("delete_storage without key should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "missing_param") || !strings.Contains(text, "key") {
+		t.Fatalf("expected missing_param error for key, got: %s", text)
+	}
+}
+
+func TestInteractStorageMutation_DeleteCookie_MissingName(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"delete_cookie"}`)
+	if !result.IsError {
+		t.Fatal("delete_cookie without name should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "missing_param") || !strings.Contains(text, "name") {
+		t.Fatalf("expected missing_param error for name, got: %s", text)
+	}
+}
+
+func TestInteractStorageMutation_SetStorage_InvalidStorageType(t *testing.T) {
+	t.Parallel()
+	env := newInteractHelpersTestEnv(t)
+	env.enablePilot(t)
+
+	result := callInteractStorageAction(t, env, `{"what":"set_storage","storage_type":"cookieStorage","key":"theme","value":"light"}`)
+	if !result.IsError {
+		t.Fatal("set_storage with invalid storage_type should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "invalid_param") || !strings.Contains(text, "storage_type") {
+		t.Fatalf("expected invalid_param error for storage_type, got: %s", text)
+	}
+}

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -67,6 +67,9 @@ var observeHandlers = map[string]ObserveHandler{
 	"storage": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return observe.GetStorage(h, req, args)
 	},
+	"indexeddb": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return observe.GetIndexedDB(h, req, args)
+	},
 	"summarized_logs": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return observe.GetSummarizedLogs(h, req, args)
 	},
@@ -158,15 +161,15 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 // serverSideObserveModes lists modes that don't depend on live extension data.
 // Kept next to observeHandlers so additions to one are visible near the other.
 var serverSideObserveModes = map[string]bool{
-	"command_result":   true,
-	"pending_commands": true,
-	"failed_commands":  true,
-	"saved_videos":     true,
-	"recordings":       true,
+	"command_result":    true,
+	"pending_commands":  true,
+	"failed_commands":   true,
+	"saved_videos":      true,
+	"recordings":        true,
 	"recording_actions": true,
-	"playback_results": true,
-	"log_diff_report":  true,
-	"pilot":            true,
+	"playback_results":  true,
+	"log_diff_report":   true,
+	"pilot":             true,
 }
 
 // prependDisconnectWarning adds a warning to the first content block when the extension is disconnected.

--- a/cmd/dev-console/tools_observe_indexeddb_test.go
+++ b/cmd/dev-console/tools_observe_indexeddb_test.go
@@ -1,0 +1,171 @@
+// tools_observe_indexeddb_test.go — TDD coverage for IndexedDB observe flows.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestObserveIndexedDB_MissingDatabase(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+	cap.SetTrackingStatusForTest(11, "https://app.example.com")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"what":"indexeddb","store":"users"}`))
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("missing database should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "missing_param") || !strings.Contains(text, "database") {
+		t.Fatalf("expected missing_param error for database, got: %s", text)
+	}
+}
+
+func TestObserveIndexedDB_MissingStore(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+	cap.SetTrackingStatusForTest(11, "https://app.example.com")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"what":"indexeddb","database":"app-cache"}`))
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("missing store should return error")
+	}
+	text := firstText(result)
+	if !strings.Contains(text, "missing_param") || !strings.Contains(text, "store") {
+		t.Fatalf("expected missing_param error for store, got: %s", text)
+	}
+}
+
+func TestObserveIndexedDB_ReturnsEntries(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+	cap.SetTrackingStatusForTest(12, "https://app.example.com")
+
+	scriptCh := make(chan string, 1)
+	go func() {
+		deadline := time.Now().Add(1200 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			for _, q := range cap.GetPendingQueries() {
+				if q.Type != "execute" {
+					continue
+				}
+				var params map[string]any
+				_ = json.Unmarshal(q.Params, &params)
+				script, _ := params["script"].(string)
+				scriptCh <- script
+				cap.SetQueryResult(q.ID, json.RawMessage(`{"success":true,"result":{"ok":true,"database":"app-cache","store":"users","entries":[{"key":"u1","value":{"id":"u1","name":"Alice"}}],"count":1,"limit":10}}`))
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		scriptCh <- ""
+	}()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"what":"indexeddb","database":"app-cache","store":"users","limit":10}`))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("indexeddb should succeed, got: %s", firstText(result))
+	}
+
+	data := extractResultJSON(t, result)
+	if data["database"] != "app-cache" {
+		t.Fatalf("database = %v, want app-cache", data["database"])
+	}
+	if data["store"] != "users" {
+		t.Fatalf("store = %v, want users", data["store"])
+	}
+	if count, _ := data["count"].(float64); count != 1 {
+		t.Fatalf("count = %v, want 1", data["count"])
+	}
+	entries, _ := data["entries"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("entries length = %d, want 1", len(entries))
+	}
+
+	script := <-scriptCh
+	if script == "" {
+		t.Fatal("did not observe execute query for indexeddb")
+	}
+	if !strings.Contains(script, "indexedDB.open") {
+		t.Fatalf("script should query indexedDB, got: %q", script)
+	}
+	if !strings.Contains(script, "app-cache") || !strings.Contains(script, "users") {
+		t.Fatalf("script should include database/store names, got: %q", script)
+	}
+}
+
+func TestObserveStorage_IncludesIndexedDBListing(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+	cap.SetTrackingStatusForTest(13, "https://app.example.com")
+
+	scriptCh := make(chan string, 1)
+	go func() {
+		deadline := time.Now().Add(1500 * time.Millisecond)
+		handledState := false
+		handledExec := false
+		for time.Now().Before(deadline) {
+			for _, q := range cap.GetPendingQueries() {
+				switch q.Type {
+				case "state_capture":
+					if handledState {
+						continue
+					}
+					cap.SetQueryResult(q.ID, json.RawMessage(`{"url":"https://app.example.com","localStorage":{"theme":"dark"},"sessionStorage":{"token":"abc"},"cookies":"debug=true"}`))
+					handledState = true
+				case "execute":
+					if handledExec {
+						continue
+					}
+					var params map[string]any
+					_ = json.Unmarshal(q.Params, &params)
+					script, _ := params["script"].(string)
+					scriptCh <- script
+					cap.SetQueryResult(q.ID, json.RawMessage(`{"success":true,"result":{"supported":true,"databases":[{"name":"app-cache","version":3,"object_stores":["users","settings"]}]}}`))
+					handledExec = true
+				}
+			}
+
+			if handledState && handledExec {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		scriptCh <- ""
+	}()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"what":"storage"}`))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("storage should succeed, got: %s", firstText(result))
+	}
+
+	data := extractResultJSON(t, result)
+	indexeddb, ok := data["indexeddb"].(map[string]any)
+	if !ok {
+		t.Fatalf("indexeddb listing missing from storage response: %v", data)
+	}
+	if supported, _ := indexeddb["supported"].(bool); !supported {
+		t.Fatalf("indexeddb.supported = %v, want true", indexeddb["supported"])
+	}
+	databases, _ := indexeddb["databases"].([]any)
+	if len(databases) != 1 {
+		t.Fatalf("indexeddb.databases length = %d, want 1", len(databases))
+	}
+
+	script := <-scriptCh
+	if script == "" {
+		t.Fatal("did not observe execute query for storage indexeddb listing")
+	}
+	if !strings.Contains(script, "indexedDB.databases") {
+		t.Fatalf("storage indexeddb script should call indexedDB.databases, got: %q", script)
+	}
+}

--- a/cmd/dev-console/tools_schema_parity_test.go
+++ b/cmd/dev-console/tools_schema_parity_test.go
@@ -43,6 +43,16 @@ func TestSchemaParity_InteractWhatEnumMatchesDispatch(t *testing.T) {
 	assertSameStringSet(t, "interact.what enum vs interact runtime actions", schemaActions, runtimeActions)
 }
 
+func TestSchemaParity_ObserveWhatEnumMatchesHandlers(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	schemaModes := mustToolEnumValues(t, h.ToolsList(), "observe", "what")
+	runtimeModes := sortedKeysObserveHandlers()
+
+	assertSameStringSet(t, "observe.what enum vs observeHandlers", schemaModes, runtimeModes)
+}
+
 func sortedKeysGenerateHandlers() []string {
 	keys := make([]string, 0, len(generateHandlers))
 	for format := range generateHandlers {
@@ -64,6 +74,15 @@ func sortedKeysConfigureHandlers() []string {
 func sortedKeysAnalyzeHandlers() []string {
 	keys := make([]string, 0, len(analyzeHandlers))
 	for mode := range analyzeHandlers {
+		keys = append(keys, mode)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeysObserveHandlers() []string {
+	keys := make([]string, 0, len(observeHandlers))
+	for mode := range observeHandlers {
 		keys = append(keys, mode)
 	}
 	sort.Strings(keys)

--- a/internal/schema/interact.go
+++ b/internal/schema/interact.go
@@ -15,6 +15,7 @@ func InteractToolSchema() mcp.MCPTool {
 					"type": "string",
 					"enum": []string{
 						"highlight", "subtitle", "save_state", "load_state", "list_states", "delete_state",
+						"set_storage", "delete_storage", "clear_storage", "set_cookie", "delete_cookie",
 						"execute_js", "navigate", "refresh", "back", "forward", "new_tab", "screenshot",
 						"click", "type", "select", "check",
 						"get_text", "get_value", "get_attribute",
@@ -31,6 +32,7 @@ func InteractToolSchema() mcp.MCPTool {
 					"description": "Deprecated alias for 'what'",
 					"enum": []string{
 						"highlight", "subtitle", "save_state", "load_state", "list_states", "delete_state",
+						"set_storage", "delete_storage", "clear_storage", "set_cookie", "delete_cookie",
 						"execute_js", "navigate", "refresh", "back", "forward", "new_tab", "screenshot",
 						"click", "type", "select", "check",
 						"get_text", "get_value", "get_attribute",
@@ -107,6 +109,15 @@ func InteractToolSchema() mcp.MCPTool {
 					"type":        "string",
 					"description": "Value for select/set_attribute",
 				},
+				"storage_type": map[string]any{
+					"type":        "string",
+					"description": "Storage target for state mutation actions",
+					"enum":        []string{"localStorage", "sessionStorage"},
+				},
+				"key": map[string]any{
+					"type":        "string",
+					"description": "Storage key for set_storage/delete_storage",
+				},
 				"clear": map[string]any{
 					"type":        "boolean",
 					"description": "Clear before typing",
@@ -117,7 +128,15 @@ func InteractToolSchema() mcp.MCPTool {
 				},
 				"name": map[string]any{
 					"type":        "string",
-					"description": "Attribute or recording name",
+					"description": "Attribute, recording, or cookie name",
+				},
+				"domain": map[string]any{
+					"type":        "string",
+					"description": "Cookie domain (set_cookie/delete_cookie)",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Cookie path (set_cookie/delete_cookie, default /)",
 				},
 				"audio": map[string]any{
 					"type":        "string",

--- a/internal/schema/observe.go
+++ b/internal/schema/observe.go
@@ -13,7 +13,7 @@ func ObserveToolSchema() mcp.MCPTool {
 			"properties": map[string]any{
 				"what": map[string]any{
 					"type": "string",
-					"enum": []string{"errors", "logs", "extension_logs", "network_waterfall", "network_bodies", "websocket_events", "websocket_status", "actions", "vitals", "page", "tabs", "pilot", "timeline", "error_bundles", "screenshot", "storage", "command_result", "pending_commands", "failed_commands", "saved_videos", "recordings", "recording_actions", "playback_results", "log_diff_report", "summarized_logs"},
+					"enum": []string{"errors", "logs", "extension_logs", "network_waterfall", "network_bodies", "websocket_events", "websocket_status", "actions", "vitals", "page", "tabs", "pilot", "timeline", "error_bundles", "screenshot", "storage", "indexeddb", "command_result", "pending_commands", "failed_commands", "saved_videos", "recordings", "recording_actions", "playback_results", "log_diff_report", "summarized_logs"},
 				},
 				"telemetry_mode": map[string]any{
 					"type":        "string",
@@ -57,6 +57,14 @@ func ObserveToolSchema() mcp.MCPTool {
 				"url": map[string]any{
 					"type":        "string",
 					"description": "Filter by URL substring",
+				},
+				"database": map[string]any{
+					"type":        "string",
+					"description": "IndexedDB database name (indexeddb)",
+				},
+				"store": map[string]any{
+					"type":        "string",
+					"description": "IndexedDB object store name (indexeddb)",
 				},
 				"method": map[string]any{
 					"type":        "string",

--- a/internal/tools/observe/handlers.go
+++ b/internal/tools/observe/handlers.go
@@ -35,6 +35,7 @@ var Handlers = map[string]Handler{
 	"error_bundles":     GetErrorBundles,
 	"screenshot":        GetScreenshot,
 	"storage":           GetStorage,
+	"indexeddb":         GetIndexedDB,
 	"summarized_logs":   GetSummarizedLogs,
 }
 

--- a/internal/tools/observe/indexeddb.go
+++ b/internal/tools/observe/indexeddb.go
@@ -1,0 +1,373 @@
+// indexeddb.go — Handlers and helpers for IndexedDB inspection via observe tool.
+package observe
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/capture"
+	"github.com/dev-console/dev-console/internal/mcp"
+	"github.com/dev-console/dev-console/internal/queries"
+)
+
+const indexedDBQueryTimeout = 10 * time.Second
+
+// GetIndexedDB returns rows from one IndexedDB object store.
+func GetIndexedDB(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JSONRPCResponse {
+	var params struct {
+		Database string `json:"database"`
+		Store    string `json:"store"`
+		Limit    int    `json:"limit"`
+	}
+	mcp.LenientUnmarshal(args, &params)
+
+	if params.Database == "" {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(
+			mcp.ErrMissingParam,
+			"Required parameter 'database' is missing for observe(what='indexeddb')",
+			"Add the 'database' parameter and call again.",
+			mcp.WithParam("database"),
+		)}
+	}
+	if params.Store == "" {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(
+			mcp.ErrMissingParam,
+			"Required parameter 'store' is missing for observe(what='indexeddb')",
+			"Add the 'store' parameter and call again.",
+			mcp.WithParam("store"),
+		)}
+	}
+	params.Limit = clampLimit(params.Limit, 100)
+
+	cap := deps.GetCapture()
+	enabled, _, _ := cap.GetTrackingStatus()
+	if !enabled {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(
+			mcp.ErrNoData,
+			"No tab is being tracked. Open the Gasoline extension popup and click 'Track This Tab'.",
+			"Track a tab first, then call observe with what='indexeddb'.",
+			mcp.WithHint(deps.DiagnosticHintString()),
+		)}
+	}
+
+	storeData, err := getIndexedDBEntries(cap, params.Database, params.Store, params.Limit)
+	if err != nil {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(
+			mcp.ErrExtError,
+			"IndexedDB inspection failed: "+err.Error(),
+			"Ensure the tab is accessible and the database/store names are correct.",
+			mcp.WithHint(deps.DiagnosticHintString()),
+		)}
+	}
+
+	entries, _ := storeData["entries"].([]any)
+	count := len(entries)
+	if c, ok := toInt(storeData["count"]); ok {
+		count = c
+	}
+
+	response := map[string]any{
+		"database": params.Database,
+		"store":    params.Store,
+		"entries":  entries,
+		"count":    count,
+		"limit":    params.Limit,
+		"metadata": BuildResponseMetadata(cap, time.Now()),
+	}
+	if v, ok := storeData["object_stores"]; ok {
+		response["object_stores"] = v
+	}
+
+	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("IndexedDB entries", response)}
+}
+
+func getIndexedDBListing(cap *capture.Capture) (map[string]any, error) {
+	data, err := executeObserveScript(cap, indexedDBListingScript, "observe_storage_indexeddb", indexedDBQueryTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := data["supported"]; !ok {
+		data["supported"] = true
+	}
+	if _, ok := data["databases"]; !ok {
+		data["databases"] = []any{}
+	}
+
+	if dbs, ok := data["databases"].([]any); ok {
+		sort.SliceStable(dbs, func(i, j int) bool {
+			left, _ := dbs[i].(map[string]any)
+			right, _ := dbs[j].(map[string]any)
+			leftName, _ := left["name"].(string)
+			rightName, _ := right["name"].(string)
+			return leftName < rightName
+		})
+		data["databases"] = dbs
+	}
+
+	return data, nil
+}
+
+func getIndexedDBEntries(cap *capture.Capture, database, store string, limit int) (map[string]any, error) {
+	script := buildIndexedDBEntriesScript(database, store, limit)
+	data, err := executeObserveScript(cap, script, "observe_indexeddb_entries", indexedDBQueryTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if ok, hasOK := data["ok"].(bool); hasOK && !ok {
+		return nil, errors.New(executeResultErrorMessage(data))
+	}
+
+	if _, ok := data["entries"]; !ok {
+		data["entries"] = []any{}
+	}
+	if _, ok := data["count"]; !ok {
+		if entries, ok := data["entries"].([]any); ok {
+			data["count"] = len(entries)
+		} else {
+			data["count"] = 0
+		}
+	}
+	if _, ok := data["database"]; !ok {
+		data["database"] = database
+	}
+	if _, ok := data["store"]; !ok {
+		data["store"] = store
+	}
+
+	return data, nil
+}
+
+func executeObserveScript(cap *capture.Capture, script, reason string, timeout time.Duration) (map[string]any, error) {
+	params, _ := json.Marshal(map[string]any{
+		"script":     script,
+		"timeout_ms": int(timeout.Milliseconds()),
+		"world":      "auto",
+		"reason":     reason,
+	})
+
+	queryID := cap.CreatePendingQueryWithTimeout(
+		queries.PendingQuery{
+			Type:   "execute",
+			Params: params,
+		},
+		timeout,
+		"",
+	)
+
+	result, err := cap.WaitForResult(queryID, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(result, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse execute result: %w", err)
+	}
+
+	if successRaw, hasSuccess := payload["success"]; hasSuccess {
+		success, _ := successRaw.(bool)
+		if !success {
+			return nil, errors.New(executeResultErrorMessage(payload))
+		}
+		if rawResult, ok := payload["result"].(map[string]any); ok {
+			return rawResult, nil
+		}
+		return map[string]any{"value": payload["result"]}, nil
+	}
+
+	if errMsg, ok := payload["error"].(string); ok && errMsg != "" {
+		return nil, errors.New(errMsg)
+	}
+
+	return payload, nil
+}
+
+func executeResultErrorMessage(payload map[string]any) string {
+	if errMsg, ok := payload["error"].(string); ok && errMsg != "" {
+		return errMsg
+	}
+	if msg, ok := payload["message"].(string); ok && msg != "" {
+		return msg
+	}
+	if result, ok := payload["result"].(map[string]any); ok {
+		if errMsg, ok := result["error"].(string); ok && errMsg != "" {
+			return errMsg
+		}
+		if msg, ok := result["message"].(string); ok && msg != "" {
+			return msg
+		}
+	}
+	return "extension execution failed"
+}
+
+func buildIndexedDBEntriesScript(database, store string, limit int) string {
+	return fmt.Sprintf(`(() => (async () => {
+  const database = %s;
+  const store = %s;
+  const limit = %d;
+  try {
+    if (typeof indexedDB === "undefined") {
+      return { ok: false, error: "indexeddb_unsupported" };
+    }
+
+    const openReq = indexedDB.open(database);
+    const db = await new Promise((resolve, reject) => {
+      openReq.onsuccess = () => resolve(openReq.result);
+      openReq.onerror = () => reject(openReq.error || new Error("indexeddb_open_failed"));
+      openReq.onblocked = () => reject(new Error("indexeddb_open_blocked"));
+    });
+
+    const objectStores = Array.from(db.objectStoreNames || []);
+    if (!objectStores.includes(store)) {
+      db.close();
+      return { ok: false, error: "store_not_found", message: "Object store not found", object_stores: objectStores };
+    }
+
+    const tx = db.transaction(store, "readonly");
+    const objectStore = tx.objectStore(store);
+
+    function serialize(value, depth = 0) {
+      if (depth > 8) return "[max_depth]";
+      if (value === null || value === undefined) return value;
+      const t = typeof value;
+      if (t === "string" || t === "number" || t === "boolean") return value;
+      if (t === "bigint") return value.toString();
+      if (t === "symbol") return String(value);
+      if (Array.isArray(value)) return value.slice(0, 100).map((v) => serialize(v, depth + 1));
+      if (value instanceof Date) return value.toISOString();
+      if (ArrayBuffer.isView(value)) return Array.from(value).slice(0, 1000);
+      if (value instanceof ArrayBuffer) return { byte_length: value.byteLength };
+      if (t === "object") {
+        const out = {};
+        for (const key of Object.keys(value).slice(0, 100)) {
+          try {
+            out[key] = serialize(value[key], depth + 1);
+          } catch {
+            out[key] = "[unserializable]";
+          }
+        }
+        return out;
+      }
+      return String(value);
+    }
+
+    const entries = [];
+    const pushEntry = (key, value) => {
+      entries.push({ key: serialize(key), value: serialize(value) });
+    };
+
+    if (typeof objectStore.getAll === "function" && typeof objectStore.getAllKeys === "function") {
+      const [values, keys] = await Promise.all([
+        new Promise((resolve, reject) => {
+          const req = objectStore.getAll(undefined, limit);
+          req.onsuccess = () => resolve(req.result || []);
+          req.onerror = () => reject(req.error || new Error("indexeddb_get_all_failed"));
+        }),
+        new Promise((resolve, reject) => {
+          const req = objectStore.getAllKeys(undefined, limit);
+          req.onsuccess = () => resolve(req.result || []);
+          req.onerror = () => reject(req.error || new Error("indexeddb_get_all_keys_failed"));
+        })
+      ]);
+      for (let i = 0; i < Math.min(keys.length, values.length); i++) {
+        pushEntry(keys[i], values[i]);
+      }
+    } else {
+      await new Promise((resolve, reject) => {
+        const req = objectStore.openCursor();
+        req.onerror = () => reject(req.error || new Error("indexeddb_cursor_failed"));
+        req.onsuccess = () => {
+          const cursor = req.result;
+          if (!cursor || entries.length >= limit) {
+            resolve(undefined);
+            return;
+          }
+          pushEntry(cursor.key, cursor.value);
+          cursor.continue();
+        };
+      });
+    }
+
+    db.close();
+
+    return {
+      ok: true,
+      database,
+      store,
+      object_stores: objectStores,
+      entries,
+      count: entries.length,
+      limit
+    };
+  } catch (e) {
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+})())()`, jsStringLiteral(database), jsStringLiteral(store), limit)
+}
+
+const indexedDBListingScript = `(() => (async () => {
+  try {
+    if (typeof indexedDB === "undefined") {
+      return { supported: false, databases: [] };
+    }
+    if (typeof indexedDB.databases !== "function") {
+      return { supported: false, databases: [], error: "indexeddb_databases_unavailable" };
+    }
+
+    const infos = await indexedDB.databases();
+    const databases = [];
+    for (const info of infos || []) {
+      if (!info || !info.name) continue;
+      const name = String(info.name);
+      const version = typeof info.version === "number" ? info.version : null;
+      let objectStores = [];
+      try {
+        const req = indexedDB.open(name);
+        const db = await new Promise((resolve, reject) => {
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error || new Error("indexeddb_open_failed"));
+          req.onblocked = () => reject(new Error("indexeddb_open_blocked"));
+        });
+        objectStores = Array.from(db.objectStoreNames || []);
+        db.close();
+      } catch {
+        objectStores = [];
+      }
+
+      databases.push({
+        name,
+        version,
+        object_stores: objectStores
+      });
+    }
+
+    return { supported: true, databases };
+  } catch (e) {
+    return { supported: false, databases: [], error: String((e && e.message) || e) };
+  }
+})())()`
+
+func jsStringLiteral(v string) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/tools/observe/storage.go
+++ b/internal/tools/observe/storage.go
@@ -74,5 +74,16 @@ func GetStorage(deps Deps, req mcp.JSONRPCRequest, _ json.RawMessage) mcp.JSONRP
 		response["cookies"] = v
 	}
 
+	// IndexedDB listing is best-effort: return storage data even if this probe fails.
+	if indexeddb, err := getIndexedDBListing(cap); err != nil {
+		response["indexeddb"] = map[string]any{
+			"supported": false,
+			"databases": []any{},
+		}
+		response["indexeddb_error"] = err.Error()
+	} else {
+		response["indexeddb"] = indexeddb
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Browser storage", response)}
 }


### PR DESCRIPTION
## Summary
- complete follow-up storage UX work with targeted TDD coverage
- add observe(what="indexeddb") with required database + store and optional limit
- include IndexedDB database listing in observe(what="storage") response
- add/extend interact storage mutation coverage, including action alias paths
- filter false dispatch warnings for generate test modes (test_from_context, test_classify, test_heal)

## Linked issues
- fixes #153
- fixes #167

## Key changes
- new observe indexeddb handler and helper script execution flow
- observe schema + dispatch wiring + parity checks for new mode
- new interact storage mutation helper handlers + expanded tests
- generate warning filtering helper + mode-level integration

## Validation
- go test ./cmd/dev-console -run 'TestInteractStorageMutation_|TestObserveIndexedDB_|TestObserveStorage_IncludesIndexedDBListing|TestGenerateTestFromContext_NoWarningsForDispatchParams|TestGenerateTestClassify_NoWarningsForDispatchParams|TestGenerateTestHeal_NoWarningsForDispatchParams|TestHandleGenerateTestFromContext_FiltersOnlyDispatchWarnings|TestHandleGenerateTestClassify_FiltersOnlyDispatchWarnings|TestHandleGenerateTestHeal_FiltersOnlyDispatchWarnings|TestSchemaParity_ObserveWhatEnumMatchesHandlers|TestSchemaParity_InteractWhatEnumMatchesDispatch|TestContractEnforcement_UnknownParams_ProduceWarnings'
- go test ./internal/tools/observe
