### PR TITLE
feat: harden save_state persistence redaction (#132)

### DIFF
--- a/docs/audits/api-reference.md
+++ b/docs/audits/api-reference.md
@@ -899,6 +899,12 @@ Save current page state as a named snapshot.
 |-----------|------|----------|---------|-------------|
 | snapshot_name | string | yes | -- | State name |
 
+Security policy for persisted state:
+- Server-side redaction always runs before persistence (defense in depth, independent of extension filtering).
+- Sensitive `form_values` key classes are redacted by key-name policy (for example: password/token/auth/api-key variants).
+- Token-like value patterns are redacted even when keys appear non-sensitive.
+- Legacy or malformed payload shapes (including arrays) are recursively sanitized before write.
+
 ##### interact({what: "load_state"})
 
 Load a previously saved state.


### PR DESCRIPTION
## Summary
- harden server-side save_state redaction for persisted state snapshots
- expand key-name detection to handle common variants (snake/camel/kebab)
- recurse through legacy/malformed array payload shapes during redaction
- add token-like value redaction coverage for OpenAI/Slack style prefixes
- document persisted state redaction policy in API reference

## TDD
- added failing tests first for key-name, token-like value, and legacy array-shape redaction
- implemented minimal redaction engine changes to satisfy tests
- validated with focused package test runs

## Validation
- go test ./internal/redaction -run "RedactMapValues_(RedactsSensitiveKeyNamePatterns|RedactsTokenLikeValues|RecursesSlicesForLegacyPayloads)" -count=1
- go test ./cmd/dev-console -run "Test(SaveState|LoadState)_" -count=1
- go test ./internal/redaction -count=1