### PR TITLE
feat: simplify configure UX and enrich capability metadata (#174 #175 #176)

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -719,11 +719,17 @@
           "type": "string"
         },
         "category": {
+          "default": "console",
+          "description": "Noise category (default: console for flattened add)",
           "enum": [
             "console",
             "network",
             "websocket"
           ],
+          "type": "string"
+        },
+        "classification": {
+          "description": "Single-rule flattening helper for noise_action=add",
           "type": "string"
         },
         "compare_a": {
@@ -772,19 +778,34 @@
           "description": "Test boundary label",
           "type": "string"
         },
+        "level": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
+        },
         "limit": {
           "description": "Max entries to return (default 100, max 1000)",
           "type": "number"
+        },
+        "message_regex": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
+        },
+        "method": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
         },
         "name": {
           "description": "Snapshot name, or sequence name for save_sequence/get_sequence/delete_sequence/replay_sequence",
           "type": "string"
         },
         "namespace": {
-          "description": "Store grouping",
+          "default": "session",
+          "description": "Store grouping (default: session)",
           "type": "string"
         },
         "noise_action": {
+          "default": "list",
+          "description": "Noise operation (default: list)",
           "enum": [
             "add",
             "remove",
@@ -813,7 +834,7 @@
           "type": "array"
         },
         "pattern": {
-          "description": "Regex pattern",
+          "description": "Regex pattern (single-rule flattening helper for noise_action=add)",
           "type": "string"
         },
         "reason": {
@@ -855,6 +876,18 @@
           "description": "Entries after ISO 8601 timestamp",
           "type": "string"
         },
+        "source_regex": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
+        },
+        "status_max": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "integer"
+        },
+        "status_min": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "integer"
+        },
         "step_timeout_ms": {
           "description": "Timeout per step during replay (default 10000)",
           "type": "number"
@@ -871,6 +904,8 @@
           "type": "number"
         },
         "store_action": {
+          "default": "list",
+          "description": "Store operation (default: list)",
           "enum": [
             "save",
             "load",
@@ -924,6 +959,14 @@
         },
         "url": {
           "description": "URL filter for snapshot capture (diff_sessions)",
+          "type": "string"
+        },
+        "url_regex": {
+          "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
+        },
+        "value": {
+          "description": "Flat value alias for save action; treated as data when provided",
           "type": "string"
         },
         "verif_session_action": {

--- a/internal/schema/configure.go
+++ b/internal/schema/configure.go
@@ -26,12 +26,15 @@ func ConfigureToolSchema() mcp.MCPTool {
 					"enum":        []string{"off", "auto", "full"},
 				},
 				"store_action": map[string]any{
-					"type": "string",
-					"enum": []string{"save", "load", "list", "delete", "stats"},
+					"type":        "string",
+					"description": "Store operation (default: list)",
+					"enum":        []string{"save", "load", "list", "delete", "stats"},
+					"default":     "list",
 				},
 				"namespace": map[string]any{
 					"type":        "string",
-					"description": "Store grouping",
+					"description": "Store grouping (default: session)",
+					"default":     "session",
 				},
 				"key": map[string]any{
 					"type":        "string",
@@ -41,14 +44,52 @@ func ConfigureToolSchema() mcp.MCPTool {
 					"type":        "object",
 					"description": "JSON data to persist",
 				},
+				"value": map[string]any{
+					"type":        "string",
+					"description": "Flat value alias for save action; treated as data when provided",
+				},
 				"noise_action": map[string]any{
-					"type": "string",
-					"enum": []string{"add", "remove", "list", "reset", "auto_detect"},
+					"type":        "string",
+					"description": "Noise operation (default: list)",
+					"enum":        []string{"add", "remove", "list", "reset", "auto_detect"},
+					"default":     "list",
 				},
 				"rules": map[string]any{
 					"type":        "array",
 					"description": "Noise rules to add",
 					"items":       map[string]any{"type": "object"},
+				},
+				"classification": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"message_regex": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"source_regex": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"url_regex": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"method": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"status_min": map[string]any{
+					"type":        "integer",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"status_max": map[string]any{
+					"type":        "integer",
+					"description": "Single-rule flattening helper for noise_action=add",
+				},
+				"level": map[string]any{
+					"type":        "string",
+					"description": "Single-rule flattening helper for noise_action=add",
 				},
 				"rule_id": map[string]any{
 					"type":        "string",
@@ -56,11 +97,13 @@ func ConfigureToolSchema() mcp.MCPTool {
 				},
 				"pattern": map[string]any{
 					"type":        "string",
-					"description": "Regex pattern",
+					"description": "Regex pattern (single-rule flattening helper for noise_action=add)",
 				},
 				"category": map[string]any{
-					"type": "string",
-					"enum": []string{"console", "network", "websocket"},
+					"type":        "string",
+					"description": "Noise category (default: console for flattened add)",
+					"enum":        []string{"console", "network", "websocket"},
+					"default":     "console",
 				},
 				"reason": map[string]any{
 					"type":        "string",

--- a/internal/tools/configure/capabilities.go
+++ b/internal/tools/configure/capabilities.go
@@ -1,52 +1,356 @@
-// capabilities.go — Pure function for building machine-readable tool capability maps.
+// capabilities.go — Pure functions for building machine-readable tool capability maps.
 package configure
 
 import (
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/dev-console/dev-console/internal/mcp"
 )
 
-// BuildCapabilitiesMap transforms a list of MCP tools into a machine-readable
-// map of tool metadata. For each tool, it extracts the dispatch parameter
-// (first required field), its enum values (modes), and all other parameter names.
+type modeParamSpec struct {
+	Required []string
+	Optional []string
+}
+
+var (
+	defaultParenPattern = regexp.MustCompile(`(?i)\(default[:\s]*([^)]+)\)`)
+	defaultsToPattern   = regexp.MustCompile(`(?i)defaults?\s+to\s+([a-zA-Z0-9_./:-]+)`)
+)
+
+var configureModeSpecs = map[string]modeParamSpec{
+	"store": {
+		Optional: []string{"store_action", "namespace", "key", "data", "value"},
+	},
+	"load": {},
+	"noise_rule": {
+		Optional: []string{
+			"noise_action", "rules", "rule_id", "pattern", "category", "classification",
+			"message_regex", "source_regex", "url_regex", "method", "status_min", "status_max", "level", "reason",
+		},
+	},
+	"clear": {
+		Optional: []string{"buffer"},
+	},
+	"health": {},
+	"streaming": {
+		Optional: []string{"streaming_action", "events", "throttle_seconds", "severity_min"},
+	},
+	"test_boundary_start": {
+		Required: []string{"test_id"},
+		Optional: []string{"label"},
+	},
+	"test_boundary_end": {
+		Required: []string{"test_id"},
+	},
+	"recording_start": {
+		Optional: []string{"name", "tab_id", "sensitive_data_enabled"},
+	},
+	"recording_stop": {
+		Optional: []string{"recording_id"},
+	},
+	"playback": {
+		Optional: []string{"recording_id"},
+	},
+	"log_diff": {
+		Optional: []string{"original_id", "replay_id"},
+	},
+	"telemetry": {
+		Optional: []string{"telemetry_mode"},
+	},
+	"describe_capabilities": {},
+	"diff_sessions": {
+		Optional: []string{"verif_session_action", "name", "compare_a", "compare_b", "url"},
+	},
+	"audit_log": {
+		Optional: []string{"operation", "audit_session_id", "tool_name", "since", "limit"},
+	},
+	"restart": {},
+	"save_sequence": {
+		Optional: []string{"name", "description", "steps", "tags"},
+	},
+	"get_sequence": {
+		Optional: []string{"name"},
+	},
+	"list_sequences": {},
+	"delete_sequence": {
+		Optional: []string{"name"},
+	},
+	"replay_sequence": {
+		Optional: []string{"name", "override_steps", "step_timeout_ms", "continue_on_error", "stop_after_step"},
+	},
+	"doctor": {},
+}
+
+// BuildCapabilitiesMap transforms tool schemas into machine-readable capability metadata.
+// It preserves legacy fields (dispatch_param, modes, params, description) and adds:
+// - param_details: per-parameter type/enum/default metadata
+// - mode_params: per-mode required/optional params and metadata
 func BuildCapabilitiesMap(tools []mcp.MCPTool) map[string]any {
 	toolsMap := make(map[string]any, len(tools))
 	for _, tool := range tools {
 		props, _ := tool.InputSchema["properties"].(map[string]any)
-		required, _ := tool.InputSchema["required"].([]string)
+		required := toStringSlice(tool.InputSchema["required"])
 
-		// Extract the dispatch parameter (first required field)
 		dispatchParam := ""
 		if len(required) > 0 {
 			dispatchParam = required[0]
 		}
 
-		// Extract enum values for the dispatch parameter
-		var modes []string
-		if dispatchParam != "" {
-			if dp, ok := props[dispatchParam].(map[string]any); ok {
-				if enumVals, ok := dp["enum"].([]string); ok {
-					modes = enumVals
-				}
-			}
-		}
+		modes := extractModes(dispatchParam, props)
 
-		// Extract parameter names
 		paramNames := make([]string, 0, len(props))
-		for k := range props {
-			if k != dispatchParam {
-				paramNames = append(paramNames, k)
+		for name := range props {
+			if name != dispatchParam {
+				paramNames = append(paramNames, name)
 			}
 		}
 		sort.Strings(paramNames)
+
+		paramDetails := buildParamDetails(props)
+		modeParams := buildModeParams(tool.Name, modes, dispatchParam, paramNames, paramDetails)
 
 		toolsMap[tool.Name] = map[string]any{
 			"dispatch_param": dispatchParam,
 			"modes":          modes,
 			"params":         paramNames,
+			"param_details":  paramDetails,
+			"mode_params":    modeParams,
 			"description":    tool.Description,
 		}
 	}
 	return toolsMap
+}
+
+func extractModes(dispatchParam string, props map[string]any) []string {
+	if dispatchParam == "" {
+		return nil
+	}
+	prop, ok := props[dispatchParam].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return toStringSlice(prop["enum"])
+}
+
+func buildParamDetails(props map[string]any) map[string]any {
+	details := make(map[string]any, len(props))
+	for name, propRaw := range props {
+		prop, ok := propRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		meta := map[string]any{}
+
+		if typ, ok := prop["type"].(string); ok && typ != "" {
+			meta["type"] = typ
+		}
+
+		if enumVals := toStringSlice(prop["enum"]); len(enumVals) > 0 {
+			meta["enum"] = enumVals
+		}
+
+		if desc, ok := prop["description"].(string); ok && desc != "" {
+			meta["description"] = desc
+			if _, hasDefault := meta["default"]; !hasDefault {
+				if parsedDefault, ok := extractDefaultFromDescription(desc); ok {
+					meta["default"] = parsedDefault
+				}
+			}
+		}
+
+		if explicitDefault, ok := prop["default"]; ok {
+			meta["default"] = explicitDefault
+		}
+
+		if items, ok := prop["items"].(map[string]any); ok {
+			if itemType, ok := items["type"].(string); ok && itemType != "" {
+				meta["item_type"] = itemType
+			}
+		}
+
+		if len(meta) > 0 {
+			details[name] = meta
+		}
+	}
+	return details
+}
+
+func extractDefaultFromDescription(description string) (string, bool) {
+	if description == "" {
+		return "", false
+	}
+	if match := defaultParenPattern.FindStringSubmatch(description); len(match) == 2 {
+		return cleanDefaultText(match[1]), true
+	}
+	if match := defaultsToPattern.FindStringSubmatch(description); len(match) == 2 {
+		return cleanDefaultText(match[1]), true
+	}
+	return "", false
+}
+
+func cleanDefaultText(v string) string {
+	trimmed := strings.TrimSpace(v)
+	trimmed = strings.Trim(trimmed, "`'\"")
+	trimmed = strings.TrimRight(trimmed, ".,;")
+	return trimmed
+}
+
+func buildModeParams(
+	toolName string,
+	modes []string,
+	dispatchParam string,
+	paramNames []string,
+	paramDetails map[string]any,
+) map[string]any {
+	if len(modes) == 0 {
+		return map[string]any{}
+	}
+
+	modeParams := make(map[string]any, len(modes))
+	for _, mode := range modes {
+		spec := modeParamSpec{
+			Required: nil,
+			Optional: append([]string(nil), paramNames...),
+		}
+		if dispatchParam != "" {
+			spec.Required = append(spec.Required, dispatchParam)
+		}
+
+		if toolName == "configure" {
+			if configureSpec, ok := configureModeSpecs[mode]; ok {
+				spec = modeParamSpec{
+					Required: append([]string{}, configureSpec.Required...),
+					Optional: append([]string{}, configureSpec.Optional...),
+				}
+				if dispatchParam != "" && !containsString(spec.Required, dispatchParam) {
+					spec.Required = append([]string{dispatchParam}, spec.Required...)
+				}
+			}
+		}
+
+		spec.Required = filterKnownParams(spec.Required, paramDetails)
+		spec.Optional = filterKnownParams(spec.Optional, paramDetails)
+		spec.Optional = removeAll(spec.Optional, spec.Required)
+		sort.Strings(spec.Required)
+		sort.Strings(spec.Optional)
+
+		params := make(map[string]any)
+		for _, name := range append(append([]string{}, spec.Required...), spec.Optional...) {
+			if metaRaw, ok := paramDetails[name]; ok {
+				if meta, ok := metaRaw.(map[string]any); ok {
+					params[name] = cloneAnyMap(meta)
+				}
+			}
+		}
+
+		applyConfigureModeDefaults(toolName, mode, params)
+
+		modeParams[mode] = map[string]any{
+			"required": spec.Required,
+			"optional": spec.Optional,
+			"params":   params,
+		}
+	}
+
+	return modeParams
+}
+
+func applyConfigureModeDefaults(toolName, mode string, params map[string]any) {
+	if toolName != "configure" {
+		return
+	}
+
+	switch mode {
+	case "store":
+		ensureParamDefault(params, "store_action", "list")
+	case "noise_rule":
+		ensureParamDefault(params, "noise_action", "list")
+	}
+}
+
+func ensureParamDefault(params map[string]any, name, defaultValue string) {
+	metaRaw, ok := params[name]
+	if !ok {
+		return
+	}
+	meta, ok := metaRaw.(map[string]any)
+	if !ok {
+		return
+	}
+	if _, exists := meta["default"]; !exists {
+		meta["default"] = defaultValue
+	}
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	out := make(map[string]any, len(input))
+	for k, v := range input {
+		out[k] = v
+	}
+	return out
+}
+
+func filterKnownParams(names []string, details map[string]any) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := details[name]; ok {
+			out = append(out, name)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func removeAll(input []string, blocked []string) []string {
+	blockedSet := make(map[string]bool, len(blocked))
+	for _, name := range blocked {
+		blockedSet[name] = true
+	}
+	out := make([]string, 0, len(input))
+	for _, name := range input {
+		if !blockedSet[name] {
+			out = append(out, name)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func toStringSlice(raw any) []string {
+	switch typed := raw.(type) {
+	case []string:
+		return append([]string{}, typed...)
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }

--- a/internal/tools/configure/rewrite.go
+++ b/internal/tools/configure/rewrite.go
@@ -30,9 +30,83 @@ func RewriteNoiseRuleArgs(args json.RawMessage) (json.RawMessage, error) {
 	if rawMap["action"] == "" {
 		rawMap["action"] = "list"
 	}
+	if action, _ := rawMap["action"].(string); action == "add" {
+		maybeFlattenSingleNoiseRule(rawMap)
+	}
 	// Error impossible: rawMap contains only primitive types and strings from input
 	rewritten, _ := json.Marshal(rawMap)
 	return rewritten, nil
+}
+
+func maybeFlattenSingleNoiseRule(rawMap map[string]any) {
+	if rules, ok := rawMap["rules"].([]any); ok && len(rules) > 0 {
+		return
+	}
+	rule, ok := buildFlatNoiseRule(rawMap)
+	if !ok {
+		return
+	}
+	rawMap["rules"] = []any{rule}
+}
+
+func buildFlatNoiseRule(rawMap map[string]any) (map[string]any, bool) {
+	messageRegex := stringOrEmpty(rawMap["message_regex"])
+	if messageRegex == "" {
+		messageRegex = stringOrEmpty(rawMap["pattern"])
+	}
+	sourceRegex := stringOrEmpty(rawMap["source_regex"])
+	urlRegex := stringOrEmpty(rawMap["url_regex"])
+	method := stringOrEmpty(rawMap["method"])
+	level := stringOrEmpty(rawMap["level"])
+
+	statusMin, hasStatusMin := rawMap["status_min"]
+	statusMax, hasStatusMax := rawMap["status_max"]
+
+	if messageRegex == "" && sourceRegex == "" && urlRegex == "" && method == "" && level == "" && !hasStatusMin && !hasStatusMax {
+		return nil, false
+	}
+
+	category := stringOrEmpty(rawMap["category"])
+	if category == "" {
+		category = "console"
+	}
+
+	matchSpec := map[string]any{}
+	if messageRegex != "" {
+		matchSpec["message_regex"] = messageRegex
+	}
+	if sourceRegex != "" {
+		matchSpec["source_regex"] = sourceRegex
+	}
+	if urlRegex != "" {
+		matchSpec["url_regex"] = urlRegex
+	}
+	if method != "" {
+		matchSpec["method"] = method
+	}
+	if level != "" {
+		matchSpec["level"] = level
+	}
+	if hasStatusMin {
+		matchSpec["status_min"] = statusMin
+	}
+	if hasStatusMax {
+		matchSpec["status_max"] = statusMax
+	}
+
+	rule := map[string]any{
+		"category":   category,
+		"match_spec": matchSpec,
+	}
+	if classification := stringOrEmpty(rawMap["classification"]); classification != "" {
+		rule["classification"] = classification
+	}
+	return rule, true
+}
+
+func stringOrEmpty(v any) string {
+	s, _ := v.(string)
+	return s
 }
 
 // RewriteStreamingArgs rewrites streaming_action to action in the raw argument map.


### PR DESCRIPTION
## Summary
- simplify configure store by defaulting namespace to session
- support store sub-action alias via action when what=store
- support flat value alias for store save payloads
- support flattened single-rule noise additions for noise_rule add (no rules array required)
- default flattened noise rule category to console
- enrich describe_capabilities with param_details and per-mode mode_params metadata (required/optional params, types, defaults)
- update configure schema and golden tool list to reflect new parameters/defaults

## TDD coverage added
- rewrite: flatten single noise rule and category defaults
- configure noise: flat add lifecycle validation
- configure store: default namespace + action alias + flat value save/load
- capabilities: mode-level params and parameter metadata/default extraction

## Validation
- go test ./internal/tools/configure -count=1
- go test ./cmd/dev-console -run "TestConfigure|TestToolsConfigure|TestToolConfigureNoise|TestDescribeCapabilities" -count=1
- go test ./cmd/dev-console -run "TestToolsSchemaParity|TestToolsList|TestGoldenToolsList" -count=1
- go test ./internal/schema -count=1