### PR TITLE
refactor: extract recording subsystem from capture god package

### DIFF
--- a/internal/capture/capture-struct.go
+++ b/internal/capture/capture-struct.go
@@ -105,7 +105,7 @@ type Capture struct {
 	// Redaction engine for scrubbing sensitive values from extension debug logs.
 	logRedactor *redaction.RedactionEngine
 
-	// Recording Management — delegates to RecordingManager sub-struct.
+	// Recording Management — delegates to RecordingManager sub-struct (aliased from internal/recording).
 	rec *RecordingManager // Recording lifecycle, playback, and log-diff. Has own sync.Mutex — independent of Capture.mu.
 
 	// ============================================

--- a/internal/capture/recording_compat.go
+++ b/internal/capture/recording_compat.go
@@ -1,0 +1,18 @@
+// recording_compat.go — Unexported re-exports for backward compatibility.
+// These thin wrappers let existing capture-package tests keep using the
+// unexported names after the logic moved to internal/recording.
+package capture
+
+import "github.com/dev-console/dev-console/internal/recording"
+
+// Constants re-exported as unexported for capture-package test compatibility.
+const (
+	recordingStorageMax   = recording.RecordingStorageMax
+	recordingWarningLevel = recording.RecordingWarningLevel
+)
+
+// Function re-exports for capture-package test compatibility.
+var (
+	validateRecordingID    = recording.ValidateRecordingID
+	calculateRecordingSize = recording.CalculateRecordingSize
+)

--- a/internal/capture/recording_delegation_test.go
+++ b/internal/capture/recording_delegation_test.go
@@ -1,0 +1,64 @@
+// recording_delegation_test.go — Tests for Capture delegation to RecordingManager.
+package capture
+
+import (
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/state"
+)
+
+func TestNewCaptureDelegation_RecordingManager(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv(state.StateDirEnv, stateRoot)
+
+	c := NewCapture()
+	t.Cleanup(c.Close)
+
+	id, err := c.StartRecording("delegate-test", "https://example.com", true)
+	if err != nil {
+		t.Fatalf("StartRecording error = %v", err)
+	}
+	if id == "" {
+		t.Fatal("StartRecording returned empty id")
+	}
+
+	err = c.AddRecordingAction(RecordingAction{Type: "click", Selector: "#btn"})
+	if err != nil {
+		t.Fatalf("AddRecordingAction error = %v", err)
+	}
+
+	actionCount, duration, err := c.StopRecording(id)
+	if err != nil {
+		t.Fatalf("StopRecording error = %v", err)
+	}
+	if actionCount != 1 {
+		t.Errorf("actionCount = %d, want 1", actionCount)
+	}
+	if duration < 0 {
+		t.Errorf("duration = %d, want >= 0", duration)
+	}
+
+	info, err := c.GetStorageInfo()
+	if err != nil {
+		t.Fatalf("GetStorageInfo error = %v", err)
+	}
+	if info.MaxBytes != recordingStorageMax {
+		t.Errorf("MaxBytes = %d, want %d", info.MaxBytes, recordingStorageMax)
+	}
+	if info.WarningBytes != recordingWarningLevel {
+		t.Errorf("WarningBytes = %d, want %d", info.WarningBytes, recordingWarningLevel)
+	}
+
+	err = c.RecalculateStorageUsed()
+	if err != nil {
+		t.Fatalf("RecalculateStorageUsed error = %v", err)
+	}
+
+	rec := &Recording{
+		Actions: []RecordingAction{{Type: "click"}, {Type: "type"}},
+	}
+	counts := c.CategorizeActionTypes(rec)
+	if counts["click"] != 1 || counts["type"] != 1 {
+		t.Errorf("CategorizeActionTypes = %+v, want click=1,type=1", counts)
+	}
+}

--- a/internal/capture/recording_manager.go
+++ b/internal/capture/recording_manager.go
@@ -1,32 +1,18 @@
 // Purpose: Owns recording_manager.go runtime behavior and integration logic.
 // Docs: docs/features/feature/backend-log-streaming/index.md
 
-// recording_manager.go — Recording lifecycle, persistence, and state management.
-// Extracted from the Capture god object. Owns its own sync.Mutex,
-// independent of Capture.mu. Zero cross-cutting dependencies.
+// recording_manager.go — Capture delegation methods for recording subsystem.
+// All recording logic lives in internal/recording. These thin methods preserve
+// the external Capture API by delegating to c.rec.
 package capture
 
 import (
-	"sync"
-
 	"github.com/dev-console/dev-console/internal/recording"
 )
 
-// RecordingManager manages recording lifecycle, persistence, and storage tracking.
-// Owns its own sync.Mutex — independent of Capture.mu.
-type RecordingManager struct {
-	mu                   sync.Mutex
-	activeRecordingID    string
-	recordings           map[string]*recording.Recording
-	recordingStorageUsed int64
-}
-
 // NewRecordingManager creates a RecordingManager with initialized state.
-func NewRecordingManager() *RecordingManager {
-	return &RecordingManager{
-		recordings: make(map[string]*recording.Recording),
-	}
-}
+// Re-exported for backward compatibility with tests that call it directly.
+var NewRecordingManager = recording.NewRecordingManager
 
 // ============================================================================
 // Capture delegation methods — preserve external API.

--- a/internal/capture/type-aliases.go
+++ b/internal/capture/type-aliases.go
@@ -26,4 +26,15 @@ type (
 	PendingQueryResponse  = queries.PendingQueryResponse      // Alias for convenience (avoid qualifying as queries.PendingQueryResponse everywhere)
 	PendingQuery          = queries.PendingQuery              // Alias for convenience
 	CommandResult         = queries.CommandResult             // Alias for convenience (avoid qualifying as queries.CommandResult everywhere)
+
+	// Recording subsystem types — moved to internal/recording package.
+	RecordingManager = recording.RecordingManager // Recording lifecycle, playback, and log-diff engine
+	StorageInfo      = recording.StorageInfo      // Recording storage usage info
+	PlaybackSession  = recording.PlaybackSession  // Active playback session state
+	PlaybackResult   = recording.PlaybackResult   // Result of executing a single recorded action
+	Coordinates      = recording.Coordinates      // X/Y position on the page
+	LogDiffResult    = recording.LogDiffResult    // Comparison of two recordings
+	DiffLogEntry     = recording.DiffLogEntry     // Single log entry for diff comparison
+	ValueChange      = recording.ValueChange      // Field value change between recordings
+	ActionComparison = recording.ActionComparison // Action counts and types between recordings
 )

--- a/internal/recording/logdiff.go
+++ b/internal/recording/logdiff.go
@@ -1,10 +1,7 @@
-// Purpose: Owns log-diff.go runtime behavior and integration logic.
-// Docs: docs/features/feature/backend-log-streaming/index.md
-
-// log-diff.go — Log diffing and regression detection for recordings.
+// logdiff.go — Log diffing and regression detection for recordings.
 // Compares original vs replay recordings to detect regressions, fixes, and value changes.
 // Categories: Match (no issues), Regression (new errors), Fixed (errors resolved).
-package capture
+package recording
 
 import (
 	"fmt"
@@ -98,8 +95,8 @@ func (r *RecordingManager) DiffRecordings(originalRecordingID, replayRecordingID
 	return result, nil
 }
 
-// countActionTypes returns counts for error, click, type, navigate actions.
-func countActionTypes(actions []RecordingAction) (errors, clicks, types, navigates int) {
+// CountActionTypes returns counts for error, click, type, navigate actions.
+func CountActionTypes(actions []RecordingAction) (errors, clicks, types, navigates int) {
 	for _, action := range actions {
 		switch action.Type {
 		case "error":
@@ -121,8 +118,8 @@ func (r *RecordingManager) compareActions(original, replay *Recording) ActionCom
 		OriginalCount: original.ActionCount,
 		ReplayCount:   replay.ActionCount,
 	}
-	stats.ErrorsOriginal, stats.ClicksOriginal, stats.TypesOriginal, stats.NavigatesOriginal = countActionTypes(original.Actions)
-	stats.ErrorsReplay, stats.ClicksReplay, stats.TypesReplay, stats.NavigatesReplay = countActionTypes(replay.Actions)
+	stats.ErrorsOriginal, stats.ClicksOriginal, stats.TypesOriginal, stats.NavigatesOriginal = CountActionTypes(original.Actions)
+	stats.ErrorsReplay, stats.ClicksReplay, stats.TypesReplay, stats.NavigatesReplay = CountActionTypes(replay.Actions)
 	return stats
 }
 
@@ -184,8 +181,8 @@ func (r *RecordingManager) detectFixes(original, replay *Recording, result *LogD
 	}
 }
 
-// buildTypeValueMap extracts selector->text for "type" actions.
-func buildTypeValueMap(actions []RecordingAction) map[string]string {
+// BuildTypeValueMap extracts selector->text for "type" actions.
+func BuildTypeValueMap(actions []RecordingAction) map[string]string {
 	values := make(map[string]string)
 	for _, action := range actions {
 		if action.Type == "type" && action.Selector != "" {
@@ -197,7 +194,7 @@ func buildTypeValueMap(actions []RecordingAction) map[string]string {
 
 // detectValueChanges finds changed field values between recordings.
 func (r *RecordingManager) detectValueChanges(original, replay *Recording, result *LogDiffResult) {
-	originalValues := buildTypeValueMap(original.Actions)
+	originalValues := BuildTypeValueMap(original.Actions)
 
 	for _, action := range replay.Actions {
 		if action.Type != "type" || action.Selector == "" {

--- a/internal/recording/logdiff_unit_test.go
+++ b/internal/recording/logdiff_unit_test.go
@@ -1,4 +1,5 @@
-package capture
+// logdiff_unit_test.go — Unit tests for log diff internals.
+package recording
 
 import (
 	"strings"

--- a/internal/recording/manager_test.go
+++ b/internal/recording/manager_test.go
@@ -1,5 +1,5 @@
-// recording_manager_test.go — Tests for RecordingManager lifecycle, validation, and actions.
-package capture
+// manager_test.go — Tests for RecordingManager lifecycle, validation, and actions.
+package recording
 
 import (
 	"fmt"
@@ -34,7 +34,7 @@ func TestNewNewRecordingManager_Initialization(t *testing.T) {
 }
 
 // ============================================
-// validateRecordingID Tests
+// ValidateRecordingID Tests
 // ============================================
 
 func TestNewValidateRecordingID_ValidID(t *testing.T) {
@@ -49,8 +49,8 @@ func TestNewValidateRecordingID_ValidID(t *testing.T) {
 	}
 
 	for _, id := range validIDs {
-		if err := validateRecordingID(id); err != nil {
-			t.Errorf("validateRecordingID(%q) = %v, want nil", id, err)
+		if err := ValidateRecordingID(id); err != nil {
+			t.Errorf("ValidateRecordingID(%q) = %v, want nil", id, err)
 		}
 	}
 }
@@ -58,9 +58,9 @@ func TestNewValidateRecordingID_ValidID(t *testing.T) {
 func TestNewValidateRecordingID_EmptyID(t *testing.T) {
 	t.Parallel()
 
-	err := validateRecordingID("")
+	err := ValidateRecordingID("")
 	if err == nil {
-		t.Fatal("validateRecordingID('') should return error")
+		t.Fatal("ValidateRecordingID('') should return error")
 	}
 	if !strings.Contains(err.Error(), "recording_id_empty") {
 		t.Errorf("error = %q, want recording_id_empty prefix", err.Error())
@@ -79,13 +79,13 @@ func TestNewValidateRecordingID_PathTraversal(t *testing.T) {
 	}
 
 	for _, id := range dangerous {
-		err := validateRecordingID(id)
+		err := ValidateRecordingID(id)
 		if err == nil {
-			t.Errorf("validateRecordingID(%q) should return error for path traversal", id)
+			t.Errorf("ValidateRecordingID(%q) should return error for path traversal", id)
 			continue
 		}
 		if !strings.Contains(err.Error(), "recording_id_invalid") {
-			t.Errorf("validateRecordingID(%q) error = %q, want recording_id_invalid", id, err.Error())
+			t.Errorf("ValidateRecordingID(%q) error = %q, want recording_id_invalid", id, err.Error())
 		}
 	}
 }
@@ -194,7 +194,7 @@ func TestNewStartRecording_StorageFull(t *testing.T) {
 	t.Parallel()
 
 	mgr := NewRecordingManager()
-	mgr.recordingStorageUsed = recordingStorageMax
+	mgr.recordingStorageUsed = RecordingStorageMax
 
 	_, err := mgr.StartRecording("test", "https://example.com", false)
 	if err == nil {
@@ -405,7 +405,7 @@ func TestNewAddRecordingAction_NonTypeActionNotRedacted(t *testing.T) {
 }
 
 // ============================================
-// calculateRecordingSize Tests
+// CalculateRecordingSize Tests
 // ============================================
 
 func TestNewCalculateRecordingSize_EmptyRecording(t *testing.T) {
@@ -413,7 +413,7 @@ func TestNewCalculateRecordingSize_EmptyRecording(t *testing.T) {
 
 	rec := &Recording{Name: "", Actions: []RecordingAction{}}
 
-	size := calculateRecordingSize(rec)
+	size := CalculateRecordingSize(rec)
 	if size < 500 {
 		t.Errorf("size = %d, want >= 500 (base overhead)", size)
 	}
@@ -429,7 +429,7 @@ func TestNewCalculateRecordingSize_WithActions(t *testing.T) {
 		Actions:  []RecordingAction{{Type: "click"}, {Type: "type"}, {Type: "navigate"}},
 	}
 
-	size := calculateRecordingSize(rec)
+	size := CalculateRecordingSize(rec)
 	expectedMin := int64(len(rec.Name) + len(rec.StartURL) + len(rec.TestID) + 500 + 3*200)
 	if size != expectedMin {
 		t.Errorf("size = %d, want %d", size, expectedMin)
@@ -446,7 +446,7 @@ func TestNewCalculateRecordingSize_LargeRecording(t *testing.T) {
 
 	rec := &Recording{Name: "large-test", StartURL: "https://example.com", Actions: actions}
 
-	size := calculateRecordingSize(rec)
+	size := CalculateRecordingSize(rec)
 	if size < 20000 {
 		t.Errorf("size = %d, want >= 20000 for 100 actions", size)
 	}

--- a/internal/recording/playback_engine.go
+++ b/internal/recording/playback_engine.go
@@ -1,10 +1,7 @@
-// Purpose: Owns playback.go runtime behavior and integration logic.
-// Docs: docs/features/feature/backend-log-streaming/index.md
-
-// playback.go — Recording playback and action execution engine.
+// playback_engine.go — Recording playback and action execution engine.
 // Replays recorded actions with self-healing selectors, timeout handling,
 // and non-blocking error recovery. Detects fragile selectors across multiple runs.
-package capture
+package recording
 
 import (
 	"fmt"
@@ -18,15 +15,15 @@ import (
 
 // PlaybackResult represents the result of executing a single action
 type PlaybackResult struct {
-	Status        string // "ok", "error", "partial"
-	ActionIndex   int
-	ActionType    string
-	SelectorUsed  string      // Which selector strategy succeeded
-	ExecutedAt    time.Time
-	DurationMs    int64
-	Error         string
-	Coordinates   *Coordinates // Where the action was executed
-	SelectorFragile bool        // Flag if selector detected as fragile
+	Status          string // "ok", "error", "partial"
+	ActionIndex     int
+	ActionType      string
+	SelectorUsed    string      // Which selector strategy succeeded
+	ExecutedAt      time.Time
+	DurationMs      int64
+	Error           string
+	Coordinates     *Coordinates // Where the action was executed
+	SelectorFragile bool         // Flag if selector detected as fragile
 }
 
 // Coordinates represent x/y position on the page

--- a/internal/recording/playback_unit_test.go
+++ b/internal/recording/playback_unit_test.go
@@ -1,4 +1,5 @@
-package capture
+// playback_unit_test.go — Unit tests for playback engine internals.
+package recording
 
 import (
 	"strings"

--- a/internal/recording/state_path_test.go
+++ b/internal/recording/state_path_test.go
@@ -1,4 +1,5 @@
-package capture
+// state_path_test.go — Tests for recording storage directory migration and state location.
+package recording
 
 import (
 	"encoding/json"
@@ -7,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	recordingtypes "github.com/dev-console/dev-console/internal/recording"
 	"github.com/dev-console/dev-console/internal/state"
 )
 
@@ -90,14 +90,14 @@ func writeLegacyRecording(t *testing.T, id string) {
 		t.Fatalf("os.MkdirAll(%q) error = %v", recordingDir, err)
 	}
 
-	meta := recordingtypes.RecordingMetadata{
+	meta := RecordingMetadata{
 		ID:          id,
 		Name:        "legacy",
 		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 		StartURL:    "https://example.com",
 		Duration:    10,
 		ActionCount: 1,
-		Actions: []recordingtypes.RecordingAction{
+		Actions: []RecordingAction{
 			{Type: "click", Selector: "#btn", TimestampMs: time.Now().UnixMilli()},
 		},
 	}

--- a/internal/recording/testing_helpers.go
+++ b/internal/recording/testing_helpers.go
@@ -1,0 +1,28 @@
+// testing_helpers.go — Exported accessors for cross-package test access.
+// These methods expose internal state that tests in other packages (e.g., capture)
+// need to verify recording behavior. Not intended for production use.
+package recording
+
+// GetInMemoryRecording returns a recording from the in-memory map by ID.
+// Returns nil if not found. For test verification only.
+func (r *RecordingManager) GetInMemoryRecording(id string) *Recording {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.recordings[id]
+}
+
+// SetRecordingStorageUsed sets the in-memory storage tracking value.
+// For test setup only (e.g., simulating full storage).
+func (r *RecordingManager) SetRecordingStorageUsed(bytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recordingStorageUsed = bytes
+}
+
+// GetActiveRecordingID returns the currently active recording ID.
+// For test verification only.
+func (r *RecordingManager) GetActiveRecordingID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.activeRecordingID
+}


### PR DESCRIPTION
## Summary
- Moves RecordingManager, playback engine, and log-diff logic (~1,170 LOC) from `internal/capture` into `internal/recording`
- Phase 1 of 3 in the capture god package split (recording → queries → circuit breaker)
- Zero external API changes — type aliases preserve backward compatibility for all consumers

## What moved
| From (capture) | To (recording) | LOC |
|---|---|---|
| recording.go | manager.go | 566 |
| playback.go | playback_engine.go | 307 |
| log-diff.go | logdiff.go | 302 |
| 5 test files | alongside source | ~1,400 |

## What stays in capture
- Thin delegation methods (`recording_manager.go`)
- Type aliases (`type-aliases.go`) — `capture.PlaybackSession`, `capture.StorageInfo`, etc. still work
- `recording_compat.go` — unexported const/func re-exports for capture-package tests
- `recording_delegation_test.go` — Capture-level integration tests

## Test plan
- [x] `go build ./...` — zero compilation errors
- [x] `go test ./internal/recording/...` — all tests pass
- [x] `go test ./internal/capture/...` — all tests pass
- [x] `go test ./cmd/... -run "Recording|Playback"` — all external consumer tests pass
- [x] `npm run typecheck` — TS unaffected
- [x] No import cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)