### PR TITLE
feat: add configure tutorial/examples mode (#178)

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -672,7 +672,7 @@
   },
   {
     "name": "configure",
-    "description": "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
+    "description": "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples (quick snippets + context-aware guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -683,6 +683,8 @@
             "noise_rule",
             "clear",
             "health",
+            "tutorial",
+            "examples",
             "streaming",
             "test_boundary_start",
             "test_boundary_end",
@@ -985,6 +987,8 @@
             "noise_rule",
             "clear",
             "health",
+            "tutorial",
+            "examples",
             "streaming",
             "test_boundary_start",
             "test_boundary_end",

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -75,6 +75,12 @@ var configureHandlers = map[string]ConfigureHandler{
 	"doctor": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return h.toolDoctor(req)
 	},
+	"tutorial": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return h.toolConfigureTutorial(req, args)
+	},
+	"examples": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return h.toolConfigureTutorial(req, args)
+	},
 	"save_sequence": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return h.toolConfigureSaveSequence(req, args)
 	},

--- a/cmd/dev-console/tools_configure_tutorial.go
+++ b/cmd/dev-console/tools_configure_tutorial.go
@@ -1,0 +1,169 @@
+// tools_configure_tutorial.go — Tutorial/examples helpers for configure tool UX.
+package main
+
+import "encoding/json"
+
+func (h *ToolHandler) toolConfigureTutorial(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		What string `json:"what"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &params); err != nil {
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+		}
+	}
+
+	mode := "tutorial"
+	if params.What == "examples" {
+		mode = "examples"
+	}
+
+	context := h.tutorialContext()
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Tutorial", map[string]any{
+		"status":     "ok",
+		"mode":       mode,
+		"message":    "Quickstart snippets and context-aware guidance",
+		"context":    context,
+		"issues":     tutorialIssues(context),
+		"next_steps": tutorialNextSteps(context),
+		"snippets":   tutorialSnippets(),
+		"best_practices": []string{
+			"Start with observe to gather evidence before automating actions",
+			"Use configure tutorial/examples and describe_capabilities when argument shape is unclear",
+			"When debugging, capture correlation_id from interact/analyze and inspect with observe command_result",
+		},
+	})}
+}
+
+func (h *ToolHandler) tutorialContext() map[string]any {
+	ctx := map[string]any{
+		"pilot_enabled":       false,
+		"extension_connected": false,
+		"tracking_enabled":    false,
+		"tracked_tab_id":      0,
+		"tracked_tab_url":     "",
+	}
+	if h == nil || h.capture == nil {
+		return ctx
+	}
+
+	trackingEnabled, tabID, tabURL := h.capture.GetTrackingStatus()
+	ctx["pilot_enabled"] = h.capture.IsPilotEnabled()
+	ctx["extension_connected"] = h.capture.IsExtensionConnected()
+	ctx["tracking_enabled"] = trackingEnabled
+	ctx["tracked_tab_id"] = tabID
+	ctx["tracked_tab_url"] = tabURL
+	return ctx
+}
+
+func tutorialIssues(context map[string]any) []map[string]any {
+	pilotEnabled, _ := context["pilot_enabled"].(bool)
+	extensionConnected, _ := context["extension_connected"].(bool)
+	trackingEnabled, _ := context["tracking_enabled"].(bool)
+	tabID, _ := context["tracked_tab_id"].(int)
+	tabURL, _ := context["tracked_tab_url"].(string)
+
+	issues := make([]map[string]any, 0, 3)
+	if !pilotEnabled {
+		issues = append(issues, map[string]any{
+			"code":     "pilot_disabled",
+			"severity": "warning",
+			"message":  "AI Web Pilot is disabled; interact actions that require extension control will be skipped.",
+			"fix":      "Enable AI Web Pilot in the extension popup, then run configure tutorial again.",
+			"example":  `configure({what:"doctor"})`,
+		})
+		return issues
+	}
+
+	if !extensionConnected {
+		issues = append(issues, map[string]any{
+			"code":     "extension_disconnected",
+			"severity": "warning",
+			"message":  "Extension is not connected; active browser automation and async command polling may fail.",
+			"fix":      "Open the extension and verify status is Connected, then retry.",
+			"example":  `configure({what:"doctor"})`,
+		})
+		return issues
+	}
+
+	if !trackingEnabled || tabID <= 0 || tabURL == "" {
+		issues = append(issues, map[string]any{
+			"code":     "no_tracked_tab",
+			"severity": "warning",
+			"message":  "No tracked tab is active; observe/interact responses may be empty or stale.",
+			"fix":      "Track a tab in the extension and run a simple interact navigate call.",
+			"example":  `interact({what:"navigate", url:"https://example.com"})`,
+		})
+	}
+
+	return issues
+}
+
+func tutorialNextSteps(context map[string]any) []string {
+	issues := tutorialIssues(context)
+	if len(issues) > 0 {
+		return []string{
+			"Run configure doctor to verify environment status",
+			"Resolve the warning shown in issues",
+			"Retry with a minimal snippet from tutorial snippets",
+		}
+	}
+	return []string{
+		"Run observe errors to inspect current page issues",
+		"Run interact navigate to move to a target page",
+		"Run analyze page_summary for a compact state summary",
+	}
+}
+
+func tutorialSnippets() []map[string]any {
+	return []map[string]any{
+		{
+			"tool":      "observe",
+			"goal":      "Read recent console errors",
+			"snippet":   `observe({what:"errors", limit:20})`,
+			"arguments": map[string]any{"what": "errors", "limit": 20},
+		},
+		{
+			"tool":      "observe",
+			"goal":      "Get latest command result by correlation id",
+			"snippet":   `observe({what:"command_result", correlation_id:"corr_123"})`,
+			"arguments": map[string]any{"what": "command_result", "correlation_id": "corr_123"},
+		},
+		{
+			"tool":      "interact",
+			"goal":      "Navigate to a URL",
+			"snippet":   `interact({what:"navigate", url:"https://example.com"})`,
+			"arguments": map[string]any{"what": "navigate", "url": "https://example.com"},
+		},
+		{
+			"tool":      "interact",
+			"goal":      "Click a button with semantic selector",
+			"snippet":   `interact({what:"click", selector:"text=Submit"})`,
+			"arguments": map[string]any{"what": "click", "selector": "text=Submit"},
+		},
+		{
+			"tool":      "analyze",
+			"goal":      "Get a high-level page summary",
+			"snippet":   `analyze({what:"page_summary"})`,
+			"arguments": map[string]any{"what": "page_summary"},
+		},
+		{
+			"tool":      "generate",
+			"goal":      "Generate a reproduction script from recent actions",
+			"snippet":   `generate({what:"reproduction", last_n:20})`,
+			"arguments": map[string]any{"what": "reproduction", "last_n": 20},
+		},
+		{
+			"tool":      "configure",
+			"goal":      "Check daemon + extension health",
+			"snippet":   `configure({what:"health"})`,
+			"arguments": map[string]any{"what": "health"},
+		},
+		{
+			"tool":      "configure",
+			"goal":      "Inspect tool/mode metadata at runtime",
+			"snippet":   `configure({what:"describe_capabilities"})`,
+			"arguments": map[string]any{"what": "describe_capabilities"},
+		},
+	}
+}

--- a/cmd/dev-console/tools_configure_tutorial_test.go
+++ b/cmd/dev-console/tools_configure_tutorial_test.go
@@ -1,0 +1,121 @@
+// tools_configure_tutorial_test.go — Tests for configure tutorial/examples mode.
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func seedSyncSettings(t *testing.T, env *configureTestEnv, settingsJSON string) {
+	t.Helper()
+	reqBody := `{"ext_session_id":"tutorial-test","settings":` + settingsJSON + `}`
+	httpReq := httptest.NewRequest("POST", "/sync", strings.NewReader(reqBody))
+	httpReq.Header.Set("X-Gasoline-Client", "test-client")
+	env.capture.HandleSync(httptest.NewRecorder(), httpReq)
+}
+
+func TestToolsConfigureTutorial_ResponseShape(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+
+	result, ok := env.callConfigure(t, `{"what":"tutorial"}`)
+	if !ok {
+		t.Fatal("tutorial should return result")
+	}
+	if result.IsError {
+		t.Fatalf("tutorial should not error, got: %s", result.Content[0].Text)
+	}
+
+	data := parseResponseJSON(t, result)
+	if data["status"] != "ok" {
+		t.Fatalf("status = %v, want ok", data["status"])
+	}
+	if data["mode"] != "tutorial" {
+		t.Fatalf("mode = %v, want tutorial", data["mode"])
+	}
+	if _, ok := data["snippets"].([]any); !ok {
+		t.Fatalf("snippets type = %T, want []any", data["snippets"])
+	}
+	if _, ok := data["context"].(map[string]any); !ok {
+		t.Fatalf("context type = %T, want map[string]any", data["context"])
+	}
+	if _, ok := data["issues"].([]any); !ok {
+		t.Fatalf("issues type = %T, want []any", data["issues"])
+	}
+}
+
+func TestToolsConfigureExamples_Alias(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+
+	result, ok := env.callConfigure(t, `{"what":"examples"}`)
+	if !ok {
+		t.Fatal("examples should return result")
+	}
+	if result.IsError {
+		t.Fatalf("examples should not error, got: %s", result.Content[0].Text)
+	}
+	data := parseResponseJSON(t, result)
+	if data["mode"] != "examples" {
+		t.Fatalf("mode = %v, want examples", data["mode"])
+	}
+}
+
+func TestToolsConfigureTutorial_ContextAware_PilotDisabled(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+
+	result, ok := env.callConfigure(t, `{"what":"tutorial"}`)
+	if !ok {
+		t.Fatal("tutorial should return result")
+	}
+	if result.IsError {
+		t.Fatalf("tutorial should not error, got: %s", result.Content[0].Text)
+	}
+	data := parseResponseJSON(t, result)
+
+	issues, ok := data["issues"].([]any)
+	if !ok {
+		t.Fatalf("issues type = %T, want []any", data["issues"])
+	}
+	if len(issues) == 0 {
+		t.Fatal("expected at least one context issue when pilot is disabled")
+	}
+	first, _ := issues[0].(map[string]any)
+	if first["code"] != "pilot_disabled" {
+		t.Fatalf("first issue code = %v, want pilot_disabled", first["code"])
+	}
+}
+
+func TestToolsConfigureTutorial_ContextAware_NoTrackedTab(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+	seedSyncSettings(t, env, `{"pilot_enabled":true,"tracking_enabled":false,"tracked_tab_id":0,"tracked_tab_url":"","tracked_tab_title":""}`)
+
+	result, ok := env.callConfigure(t, `{"what":"tutorial"}`)
+	if !ok {
+		t.Fatal("tutorial should return result")
+	}
+	if result.IsError {
+		t.Fatalf("tutorial should not error, got: %s", result.Content[0].Text)
+	}
+	data := parseResponseJSON(t, result)
+
+	issues, ok := data["issues"].([]any)
+	if !ok {
+		t.Fatalf("issues type = %T, want []any", data["issues"])
+	}
+	found := false
+	for _, issueRaw := range issues {
+		issue, _ := issueRaw.(map[string]any)
+		if issue["code"] == "no_tracked_tab" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected no_tracked_tab issue, got: %+v", issues)
+	}
+}

--- a/docs/audits/api-reference.md
+++ b/docs/audits/api-reference.md
@@ -642,9 +642,10 @@ Persist session data.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | store_action | string | no | "list" | save, load, list, delete, stats |
-| namespace | string | no | -- | Storage grouping |
+| namespace | string | no | "session" | Storage grouping |
 | key | string | no | -- | Storage key |
 | data | object | no | -- | JSON data to persist |
+| value | string | no | -- | Flat value alias for save action |
 
 ##### configure({what: "load"})
 
@@ -662,7 +663,21 @@ Manage console noise filtering.
 | rules | object[] | no | -- | Noise rules to add (with match_spec) |
 | rule_id | string | no | -- | Rule ID to remove |
 | pattern | string | no | -- | Regex pattern |
-| category | string | no | -- | console, network, websocket |
+| category | string | no | "console" (flattened add) | console, network, websocket |
+
+`noise_action="add"` accepts either a `rules` array or flattened single-rule fields such as `pattern`, `message_regex`, `source_regex`, `url_regex`, `method`, `status_min`, `status_max`, `level`, and `classification`.
+
+##### configure({what: "tutorial"})
+
+Return quickstart snippets and context-aware setup guidance.
+
+No additional parameters.
+
+##### configure({what: "examples"})
+
+Alias of `tutorial`; returns the same snippet catalog and context guidance.
+
+No additional parameters.
 
 ##### configure({what: "streaming"})
 

--- a/internal/schema/configure.go
+++ b/internal/schema/configure.go
@@ -7,18 +7,18 @@ import "github.com/dev-console/dev-console/internal/mcp"
 func ConfigureToolSchema() mcp.MCPTool {
 	return mcp.MCPTool{
 		Name:        "configure",
-		Description: "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
+		Description: "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples (quick snippets + context-aware guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"what": map[string]any{
 					"type": "string",
-					"enum": []string{"store", "load", "noise_rule", "clear", "health", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
+					"enum": []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
 				},
 				"action": map[string]any{
 					"type":        "string",
 					"description": "Deprecated alias for 'what'",
-					"enum":        []string{"store", "load", "noise_rule", "clear", "health", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
+					"enum":        []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
 				},
 				"telemetry_mode": map[string]any{
 					"type":        "string",

--- a/internal/tools/configure/capabilities.go
+++ b/internal/tools/configure/capabilities.go
@@ -33,7 +33,9 @@ var configureModeSpecs = map[string]modeParamSpec{
 	"clear": {
 		Optional: []string{"buffer"},
 	},
-	"health": {},
+	"health":   {},
+	"tutorial": {},
+	"examples": {},
 	"streaming": {
 		Optional: []string{"streaming_action", "events", "throttle_seconds", "severity_min"},
 	},


### PR DESCRIPTION
## Summary
- add configure tutorial and examples modes as context-aware guidance
- include actionable snippets, next steps, and best-practice guidance based on pilot/extension/tracked-tab state
- extend configure schema + capabilities to expose the new modes
- document the new modes and keep API reference aligned

## Testing
- go test ./cmd/dev-console -run "TestToolsConfigureTutorial_|TestToolsConfigureExamples_Alias|TestSchemaParity_ConfigureWhatEnumMatchesHandlers|TestGoldenToolsList" -count=1
- go test ./internal/tools/configure -count=1

Closes #178