### PR TITLE
refactor: extract CircuitBreaker to internal/circuit

### DIFF
--- a/internal/capture/capture-struct.go
+++ b/internal/capture/capture-struct.go
@@ -88,7 +88,7 @@ type Capture struct {
 	// Rate Limiting & Circuit Breaker (Own Lock)
 	// ============================================
 
-	circuit *CircuitBreaker // Rate limiting + circuit breaker state machine. Has own sync.RWMutex — independent of Capture.mu.
+	circuit *CircuitBreaker // Rate limiting + circuit breaker state machine — delegates to internal/circuit. Has own sync.RWMutex — independent of Capture.mu.
 
 	// ============================================
 	// Extension State (Protected by parent mu)

--- a/internal/capture/constants.go
+++ b/internal/capture/constants.go
@@ -1,12 +1,11 @@
-// Purpose: Owns constants.go runtime behavior and integration logic.
-// Docs: docs/features/feature/backend-log-streaming/index.md
-
 // constants.go — Buffer capacity and configuration constants.
 // All configuration values for capture package.
 package capture
 
 import (
 	"time"
+
+	"github.com/dev-console/dev-console/internal/circuit"
 )
 
 const (
@@ -15,7 +14,9 @@ const (
 	MaxNetworkBodies   = 100
 	MaxExtensionLogs   = 500
 	MaxEnhancedActions = 1000
-	RateLimitThreshold = 1000
+
+	// RateLimitThreshold is re-exported from internal/circuit for backward compatibility.
+	RateLimitThreshold = circuit.RateLimitThreshold
 
 	maxActiveConns = 20
 	maxClosedConns = 10
@@ -25,16 +26,14 @@ const (
 	MinNetworkWaterfallCapacity     = 100
 	MaxNetworkWaterfallCapacity     = 10000
 
-	defaultWSLimit         = 50
-	defaultBodyLimit       = 20
-	maxExtensionPostBody   = 5 << 20         // 5MB - max size for incoming extension POST bodies
-	maxRequestBodySize     = 8192            // 8KB - truncation limit for captured request bodies
-	maxResponseBodySize    = 16384           // 16KB
-	wsBufferMemoryLimit    = 4 * 1024 * 1024 // 4MB
-	nbBufferMemoryLimit    = 8 * 1024 * 1024 // 8MB
-	circuitOpenStreakCount = 5               // consecutive seconds over threshold to open circuit
-	circuitCloseSeconds    = 10              // seconds below threshold to close circuit
-	rateWindow             = 5 * time.Second // rolling window for msg/s calculation
+	defaultWSLimit       = 50
+	defaultBodyLimit     = 20
+	maxExtensionPostBody = 5 << 20         // 5MB - max size for incoming extension POST bodies
+	maxRequestBodySize   = 8192            // 8KB - truncation limit for captured request bodies
+	maxResponseBodySize  = 16384           // 16KB
+	wsBufferMemoryLimit  = 4 * 1024 * 1024 // 4MB
+	nbBufferMemoryLimit  = 8 * 1024 * 1024 // 8MB
+	rateWindow           = 5 * time.Second // rolling window for msg/s calculation
 
 	// extensionDisconnectThreshold is how long since last /sync before
 	// the extension is considered disconnected. Pending queries are auto-expired

--- a/internal/capture/coverage_gaps_test.go
+++ b/internal/capture/coverage_gaps_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 )
 
 // ============================================
@@ -319,21 +318,8 @@ func TestRedactExtensionLog_WithRedactor(t *testing.T) {
 }
 
 // ============================================
-// Circuit breaker
+// Circuit breaker (delegation tests — struct tests live in internal/circuit)
 // ============================================
-
-func TestCircuitBreaker_RecordEventsWindowReset(t *testing.T) {
-	t.Parallel()
-	cb := NewCircuitBreaker(func(string, map[string]any) {})
-	cb.SetWindowState(time.Now().Add(-2*time.Second), 50)
-	cb.RecordEvents(10)
-	cb.mu.RLock()
-	count := cb.windowEventCount
-	cb.mu.RUnlock()
-	if count != 10 {
-		t.Errorf("windowEventCount = %d, want 10 after reset", count)
-	}
-}
 
 func TestCircuitBreaker_GetHealthStatus_Open(t *testing.T) {
 	t.Parallel()

--- a/internal/capture/rate_limit.go
+++ b/internal/capture/rate_limit.go
@@ -1,9 +1,6 @@
-// Purpose: Owns rate_limit.go runtime behavior and integration logic.
-// Docs: docs/features/feature/backend-log-streaming/index.md
-
 // rate_limit.go — Capture delegation methods for rate limiting and circuit breaker.
-// Delegates to CircuitBreaker sub-struct. These methods preserve the existing
-// Capture API so callers (helpers.go, handlers, tests) don't need to change.
+// Delegates to CircuitBreaker sub-struct (aliased from internal/circuit).
+// These methods preserve the existing Capture API so callers don't need to change.
 package capture
 
 import (
@@ -12,24 +9,6 @@ import (
 
 	"github.com/dev-console/dev-console/internal/util"
 )
-
-// HealthResponse is returned by GET /health endpoint.
-type HealthResponse struct {
-	CircuitOpen bool   `json:"circuit_open"`
-	OpenedAt    string `json:"opened_at,omitempty"`
-	CurrentRate int    `json:"current_rate"`
-	Reason      string `json:"reason,omitempty"`
-}
-
-// RateLimitResponse is the 429 response body.
-type RateLimitResponse struct {
-	Error        string `json:"error"`
-	Message      string `json:"message"`
-	RetryAfterMs int    `json:"retry_after_ms"`
-	CircuitOpen  bool   `json:"circuit_open"`
-	CurrentRate  int    `json:"current_rate"`
-	Threshold    int    `json:"threshold"`
-}
 
 // RecordEvents delegates to CircuitBreaker.
 func (c *Capture) RecordEvents(count int) {

--- a/internal/capture/type-aliases.go
+++ b/internal/capture/type-aliases.go
@@ -7,6 +7,7 @@
 package capture
 
 import (
+	"github.com/dev-console/dev-console/internal/circuit"
 	"github.com/dev-console/dev-console/internal/performance"
 	"github.com/dev-console/dev-console/internal/queries"
 	"github.com/dev-console/dev-console/internal/recording"
@@ -31,6 +32,11 @@ type (
 	QueryDispatcher = queries.QueryDispatcher // Query lifecycle, result storage, async command tracking
 	QuerySnapshot   = queries.QuerySnapshot   // Point-in-time view of query state for health reporting
 
+	// Circuit breaker subsystem types — moved to internal/circuit package.
+	CircuitBreaker    = circuit.CircuitBreaker    // Rate limiting + circuit breaker state machine
+	HealthResponse    = circuit.HealthResponse    // GET /health response
+	RateLimitResponse = circuit.RateLimitResponse // 429 response body
+
 	// Recording subsystem types — moved to internal/recording package.
 	RecordingManager = recording.RecordingManager // Recording lifecycle, playback, and log-diff engine
 	StorageInfo      = recording.StorageInfo      // Recording storage usage info
@@ -42,3 +48,6 @@ type (
 	ValueChange      = recording.ValueChange      // Field value change between recordings
 	ActionComparison = recording.ActionComparison // Action counts and types between recordings
 )
+
+// NewCircuitBreaker is re-exported from internal/circuit for backward compatibility.
+var NewCircuitBreaker = circuit.NewCircuitBreaker


### PR DESCRIPTION
## Summary
- Phase 3 (final) of capture god package split
- Moves `CircuitBreaker` struct, `HealthResponse`, `RateLimitResponse` types, and circuit constants (`RateLimitThreshold`, `CircuitOpenStreakCount`, `CircuitCloseSeconds`) to `internal/circuit/`
- Capture retains thin delegation methods and type aliases — zero external API changes
- All 31 packages pass, 11 circuit tests + 5 capture delegation tests green

## Test plan
- [x] `go test ./internal/circuit/` — 11 tests pass
- [x] `go test ./internal/capture/` — all tests pass including circuit delegation
- [x] `go test ./cmd/...` — health/ratelimit tests pass with `capture.RateLimitThreshold` re-export
- [x] `go test ./... -short` — all 31 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)