### PR TITLE
feat: add per-mode schema drift checks for required params (#146)

### DIFF
--- a/cmd/dev-console/tools_action_schema_contract_test.go
+++ b/cmd/dev-console/tools_action_schema_contract_test.go
@@ -1,0 +1,173 @@
+// tools_action_schema_contract_test.go — Per-mode request schema/runtime contract checks.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/streaming"
+	cfg "github.com/dev-console/dev-console/internal/tools/configure"
+)
+
+type requiredParamContractCase struct {
+	tool      string
+	mode      string
+	wantParam string
+	args      json.RawMessage
+}
+
+func TestContractPerModeRequiredParams_RuntimeMatchesCapabilities(t *testing.T) {
+	cases := []requiredParamContractCase{
+		{tool: "configure", mode: "test_boundary_start", wantParam: "test_id"},
+		{tool: "configure", mode: "get_sequence", wantParam: "name"},
+		{tool: "observe", mode: "command_result", wantParam: "correlation_id"},
+		{tool: "observe", mode: "recording_actions", wantParam: "recording_id"},
+		{tool: "analyze", mode: "dom", wantParam: "selector"},
+		{tool: "analyze", mode: "annotation_detail", wantParam: "correlation_id"},
+		{tool: "analyze", mode: "draw_session", wantParam: "file"},
+		{tool: "analyze", mode: "link_validation", wantParam: "urls"},
+		{tool: "interact", mode: "execute_js", wantParam: "script"},
+		{tool: "interact", mode: "navigate", wantParam: "url"},
+		{tool: "interact", mode: "save_state", wantParam: "snapshot_name"},
+		{tool: "interact", mode: "set_storage", wantParam: "key", args: json.RawMessage(`{"what":"set_storage","storage_type":"localStorage"}`)},
+		{tool: "interact", mode: "subtitle", wantParam: "text"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.tool+"_"+tc.mode, func(t *testing.T) {
+			h := newTestToolHandler()
+			h.alertBuffer = streaming.NewAlertBuffer()
+			caps := cfg.BuildCapabilitiesMap(h.ToolsList())
+
+			assertModeRequiredContains(t, caps, tc.tool, tc.mode, []string{"what", tc.wantParam})
+
+			req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+			args := tc.args
+			if len(args) == 0 {
+				args = json.RawMessage(`{"what":"` + tc.mode + `"}`)
+			}
+			resp, handled := h.HandleToolCall(req, tc.tool, args)
+			if !handled {
+				t.Fatalf("%s(%s): tool call not handled", tc.tool, tc.mode)
+			}
+
+			var result MCPToolResult
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				t.Fatalf("%s(%s): unmarshal MCPToolResult: %v", tc.tool, tc.mode, err)
+			}
+			if !result.IsError {
+				t.Fatalf("%s(%s): expected error for missing %q", tc.tool, tc.mode, tc.wantParam)
+			}
+
+			errData := parseStructuredErrorData(t, result)
+			if got, _ := errData["error"].(string); got != ErrMissingParam {
+				t.Fatalf("%s(%s): error code = %q, want %q", tc.tool, tc.mode, got, ErrMissingParam)
+			}
+			if got, _ := errData["param"].(string); got != tc.wantParam {
+				msg, _ := errData["message"].(string)
+				if !strings.Contains(msg, "'"+tc.wantParam+"'") {
+					t.Fatalf("%s(%s): param/message mismatch. param=%q message=%q want param %q", tc.tool, tc.mode, got, msg, tc.wantParam)
+				}
+			}
+		})
+	}
+}
+
+func parseStructuredErrorData(t *testing.T, result MCPToolResult) map[string]any {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("structured error missing content block")
+	}
+	text := result.Content[0].Text
+	jsonText := extractJSONFromText(text)
+	if strings.TrimSpace(jsonText) == "" {
+		idx := strings.LastIndex(text, "{")
+		if idx >= 0 {
+			jsonText = text[idx:]
+		}
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		idx := strings.LastIndex(text, "{")
+		if idx >= 0 {
+			if retryErr := json.Unmarshal([]byte(text[idx:]), &data); retryErr == nil {
+				return data
+			}
+		}
+		t.Fatalf("structured error payload is not valid JSON: %v", err)
+	}
+	return data
+}
+
+func assertModeRequiredContains(
+	t *testing.T,
+	caps map[string]any,
+	toolName string,
+	mode string,
+	requiredParams []string,
+) {
+	t.Helper()
+
+	toolRaw, ok := caps[toolName]
+	if !ok {
+		t.Fatalf("tool %q missing from capabilities", toolName)
+	}
+	toolMap, ok := toolRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("tool %q type = %T, want map[string]any", toolName, toolRaw)
+	}
+
+	modeParamsRaw, ok := toolMap["mode_params"]
+	if !ok {
+		t.Fatalf("tool %q missing mode_params", toolName)
+	}
+	modeParams, ok := modeParamsRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("tool %q mode_params type = %T, want map[string]any", toolName, modeParamsRaw)
+	}
+
+	modeRaw, ok := modeParams[mode]
+	if !ok {
+		t.Fatalf("tool %q mode %q missing from mode_params", toolName, mode)
+	}
+	modeMap, ok := modeRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("tool %q mode %q type = %T, want map[string]any", toolName, mode, modeRaw)
+	}
+
+	required := toStringSliceLoose(modeMap["required"])
+	requiredSet := make(map[string]bool, len(required))
+	for _, p := range required {
+		requiredSet[p] = true
+	}
+	for _, want := range requiredParams {
+		if !requiredSet[want] {
+			t.Fatalf("tool %q mode %q required missing %q (got %v)", toolName, mode, want, required)
+		}
+	}
+}
+
+func toStringSliceLoose(raw any) []string {
+	switch typed := raw.(type) {
+	case []string:
+		out := make([]string, 0, len(typed))
+		for _, v := range typed {
+			if v != "" {
+				out = append(out, v)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/tools/configure/capabilities.go
+++ b/internal/tools/configure/capabilities.go
@@ -70,19 +70,117 @@ var configureModeSpecs = map[string]modeParamSpec{
 	},
 	"restart": {},
 	"save_sequence": {
-		Optional: []string{"name", "description", "steps", "tags"},
+		Required: []string{"name"},
+		Optional: []string{"description", "steps", "tags"},
 	},
 	"get_sequence": {
-		Optional: []string{"name"},
+		Required: []string{"name"},
 	},
 	"list_sequences": {},
 	"delete_sequence": {
-		Optional: []string{"name"},
+		Required: []string{"name"},
 	},
 	"replay_sequence": {
+		Required: []string{"name"},
 		Optional: []string{"name", "override_steps", "step_timeout_ms", "continue_on_error", "stop_after_step"},
 	},
 	"doctor": {},
+}
+
+var observeModeSpecs = map[string]modeParamSpec{
+	"command_result": {
+		Required: []string{"correlation_id"},
+	},
+	"recording_actions": {
+		Required: []string{"recording_id"},
+	},
+	"playback_results": {
+		Required: []string{"recording_id"},
+	},
+	"log_diff_report": {
+		Required: []string{"original_id", "replay_id"},
+	},
+}
+
+var analyzeModeSpecs = map[string]modeParamSpec{
+	"dom": {
+		Required: []string{"selector"},
+	},
+	"annotation_detail": {
+		Required: []string{"correlation_id"},
+	},
+	"draw_session": {
+		Required: []string{"file"},
+	},
+	"computed_styles": {
+		Required: []string{"selector"},
+	},
+	"link_validation": {
+		Required: []string{"urls"},
+	},
+	"visual_baseline": {
+		Required: []string{"name"},
+	},
+	"visual_diff": {
+		Required: []string{"baseline"},
+	},
+}
+
+var interactModeSpecs = map[string]modeParamSpec{
+	"highlight": {
+		Required: []string{"selector"},
+	},
+	"execute_js": {
+		Required: []string{"script"},
+	},
+	"navigate": {
+		Required: []string{"url"},
+	},
+	"new_tab": {
+		Required: []string{"url"},
+	},
+	"subtitle": {
+		Required: []string{"text"},
+	},
+	"save_state": {
+		Required: []string{"snapshot_name"},
+	},
+	"load_state": {
+		Required: []string{"snapshot_name"},
+	},
+	"delete_state": {
+		Required: []string{"snapshot_name"},
+	},
+	"set_storage": {
+		Required: []string{"key", "value"},
+	},
+	"delete_storage": {
+		Required: []string{"key"},
+	},
+	"set_cookie": {
+		Required: []string{"name", "value"},
+	},
+	"delete_cookie": {
+		Required: []string{"name"},
+	},
+	"upload": {
+		Required: []string{"file_path"},
+	},
+	"navigate_and_wait_for": {
+		Required: []string{"url", "wait_for"},
+	},
+	"fill_form_and_submit": {
+		Required: []string{"fields"},
+	},
+	"fill_form": {
+		Required: []string{"fields"},
+	},
+}
+
+var toolModeSpecs = map[string]map[string]modeParamSpec{
+	"observe":  observeModeSpecs,
+	"analyze":  analyzeModeSpecs,
+	"interact": interactModeSpecs,
 }
 
 // BuildCapabilitiesMap transforms tool schemas into machine-readable capability metadata.
@@ -228,6 +326,13 @@ func buildModeParams(
 				}
 				if dispatchParam != "" && !containsString(spec.Required, dispatchParam) {
 					spec.Required = append([]string{dispatchParam}, spec.Required...)
+				}
+			}
+		} else if modeSpecs, ok := toolModeSpecs[toolName]; ok {
+			if modeSpec, ok := modeSpecs[mode]; ok {
+				spec.Required = append(spec.Required, modeSpec.Required...)
+				if modeSpec.Optional != nil {
+					spec.Optional = append([]string{}, modeSpec.Optional...)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- expand `describe_capabilities` mode metadata with required params for deterministic modes in `observe`, `analyze`, and `interact`
- tighten configure mode metadata for sequence actions (`name` required)
- add CI contract tests that assert required params declared in capabilities are enforced at runtime with `missing_param` errors
- add capability-map tests to prevent per-mode request-schema drift

## Testing
- go test ./internal/tools/configure -count=1
- go test ./cmd/dev-console -run "TestContractPerModeRequiredParams_RuntimeMatchesCapabilities" -count=1
- go test ./cmd/dev-console -run "TestGoldenToolsList|TestSchemaParity_ConfigureWhatEnumMatchesHandlers|TestDescribeCapabilities_ConfigureIncludesModeParameterDetails" -count=1

Refs #146