### PR TITLE
feat(observe,analyze): surface proactive CSP restriction metadata

### DIFF
--- a/cmd/dev-console/tools_analyze.go
+++ b/cmd/dev-console/tools_analyze.go
@@ -135,7 +135,8 @@ func (h *ToolHandler) toolAnalyze(req JSONRPCRequest, args json.RawMessage) JSON
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+params.What, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
-	return handler(h, req, args)
+	resp := handler(h, req, args)
+	return h.annotateCSPRestrictionMetadata(resp)
 }
 
 // ============================================

--- a/cmd/dev-console/tools_analyze_handler_test.go
+++ b/cmd/dev-console/tools_analyze_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ============================================
@@ -76,6 +77,45 @@ func TestToolsAnalyzeDispatch_EmptyArgs(t *testing.T) {
 	result := parseToolResult(t, resp)
 	if !result.IsError {
 		t.Fatal("nil args (no 'what') should return isError:true")
+	}
+}
+
+func TestToolsAnalyze_ResponseMetadataIncludesCSPRestrictionHint(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+
+	corrID := "csp_meta_analyze_1"
+	cap.RegisterCommand(corrID, "q-csp-analyze", 30*time.Second)
+	cap.ApplyCommandResult(corrID, "error", json.RawMessage(`{
+		"success": false,
+		"error": "csp_blocked_all_worlds",
+		"message": "Page CSP blocks dynamic script execution",
+		"csp_blocked": true,
+		"failure_cause": "csp"
+	}`), "csp_blocked_all_worlds")
+
+	resp := callAnalyzeRaw(h, `{"what":"performance"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("analyze performance should not return isError, got: %s", result.Content[0].Text)
+	}
+
+	data := extractResultJSON(t, result)
+	meta, _ := data["metadata"].(map[string]any)
+	if meta == nil {
+		t.Fatal("metadata should be a map")
+	}
+
+	if restricted, _ := meta["csp_restricted"].(bool); !restricted {
+		t.Fatalf("metadata.csp_restricted = %v, want true", meta["csp_restricted"])
+	}
+
+	hint, _ := meta["csp_hint"].(string)
+	if hint == "" {
+		t.Fatal("metadata.csp_hint should be present")
+	}
+	if !strings.Contains(strings.ToLower(hint), "blocks script execution") {
+		t.Fatalf("metadata.csp_hint should explain script execution restriction, got: %q", hint)
 	}
 }
 

--- a/cmd/dev-console/tools_csp_metadata.go
+++ b/cmd/dev-console/tools_csp_metadata.go
@@ -1,0 +1,77 @@
+// tools_csp_metadata.go — CSP restriction metadata enrichment for observe/analyze responses.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const cspRestrictedHint = "Current page blocks script execution. Tools requiring JS injection (page_summary, accessibility, get_readable, execute_js) will fail. Features that work: screenshot, performance, forms, storage, network observation."
+
+// annotateCSPRestrictionMetadata adds proactive CSP warning metadata to JSON responses
+// when recent command history indicates a CSP-restricted page context.
+func (h *ToolHandler) annotateCSPRestrictionMetadata(resp JSONRPCResponse) JSONRPCResponse {
+	if h == nil || h.capture == nil || resp.Result == nil {
+		return resp
+	}
+	if !h.capture.HasRecentCSPRestriction() {
+		return resp
+	}
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return resp
+	}
+	if result.IsError {
+		return resp
+	}
+
+	for i := range result.Content {
+		if result.Content[i].Type != "text" {
+			continue
+		}
+		updated, ok := injectCSPMetadataIntoText(result.Content[i].Text)
+		if !ok {
+			continue
+		}
+		result.Content[i].Text = updated
+
+		resultJSON, err := json.Marshal(result)
+		if err != nil {
+			return resp
+		}
+		resp.Result = json.RawMessage(resultJSON)
+		return resp
+	}
+
+	return resp
+}
+
+func injectCSPMetadataIntoText(text string) (string, bool) {
+	jsonStart := strings.Index(text, "{")
+	if jsonStart < 0 {
+		return text, false
+	}
+
+	jsonPart := text[jsonStart:]
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(jsonPart), &payload); err != nil {
+		return text, false
+	}
+
+	metadata := map[string]any{}
+	if existing, ok := payload["metadata"].(map[string]any); ok {
+		for k, v := range existing {
+			metadata[k] = v
+		}
+	}
+	metadata["csp_restricted"] = true
+	metadata["csp_hint"] = cspRestrictedHint
+	payload["metadata"] = metadata
+
+	updatedJSON, err := json.Marshal(payload)
+	if err != nil {
+		return text, false
+	}
+	return text[:jsonStart] + string(updatedJSON), true
+}

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -143,6 +143,7 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 	}
 
 	resp := handler(h, req, args)
+	resp = h.annotateCSPRestrictionMetadata(resp)
 
 	// Warn when extension is disconnected (except for server-side modes that don't need it)
 	if !h.capture.IsExtensionConnected() && !serverSideObserveModes[params.What] {

--- a/internal/capture/query_dispatcher.go
+++ b/internal/capture/query_dispatcher.go
@@ -157,6 +157,12 @@ func (c *Capture) GetFailedCommands() []*queries.CommandResult {
 	return c.qd.GetFailedCommands()
 }
 
+// HasRecentCSPRestriction returns true when recent command history indicates
+// the tracked page is likely in a CSP/restricted execution context.
+func (c *Capture) HasRecentCSPRestriction() bool {
+	return c.qd.HasRecentCSPRestriction()
+}
+
 // QueuePosition delegates to QueryDispatcher.
 func (c *Capture) QueuePosition(correlationID string) int {
 	return c.qd.QueuePosition(correlationID)


### PR DESCRIPTION
## Summary
- add TDD coverage for proactive CSP metadata on observe/analyze responses
- detect recent CSP-restricted execution contexts from command history in queries/capture
- inject metadata.csp_restricted + metadata.csp_hint into observe and analyze JSON responses

## Testing
- go test ./cmd/dev-console -run 'TestToolsObserve_ResponseMetadataIncludesCSPRestrictionHint|TestToolsAnalyze_ResponseMetadataIncludesCSPRestrictionHint'
- go test ./internal/queries ./internal/capture ./cmd/dev-console

Closes #188