### PR TITLE
feat(configure): differentiate tutorial and examples modes

### DIFF
--- a/cmd/dev-console/tools_configure_tutorial.go
+++ b/cmd/dev-console/tools_configure_tutorial.go
@@ -19,20 +19,37 @@ func (h *ToolHandler) toolConfigureTutorial(req JSONRPCRequest, args json.RawMes
 	}
 
 	context := h.tutorialContext()
-	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Tutorial", map[string]any{
-		"status":     "ok",
-		"mode":       mode,
-		"message":    "Quickstart snippets and context-aware guidance",
-		"context":    context,
-		"issues":     tutorialIssues(context),
-		"next_steps": tutorialNextSteps(context),
-		"snippets":   tutorialSnippets(),
-		"best_practices": []string{
-			"Start with observe to gather evidence before automating actions",
-			"Use configure tutorial/examples and describe_capabilities when argument shape is unclear",
-			"When debugging, capture correlation_id from interact/analyze and inspect with observe command_result",
-		},
-	})}
+	message := "Quickstart snippets and context-aware guidance"
+	nextSteps := tutorialNextSteps(context)
+	snippets := tutorialSnippets()
+	bestPractices := []string{
+		"Start with observe to gather evidence before automating actions",
+		"Use configure tutorial/examples and describe_capabilities when argument shape is unclear",
+		"When debugging, capture correlation_id from interact/analyze and inspect with observe command_result",
+	}
+
+	responseData := map[string]any{
+		"status":         "ok",
+		"mode":           mode,
+		"message":        message,
+		"context":        context,
+		"issues":         tutorialIssues(context),
+		"next_steps":     nextSteps,
+		"snippets":       snippets,
+		"best_practices": bestPractices,
+	}
+
+	if mode == "examples" {
+		responseData["message"] = "Task-oriented workflows for common debugging, testing, and audit scenarios"
+		responseData["next_steps"] = []string{
+			"Pick one workflow and run the first step exactly as shown",
+			"Preserve correlation_id values for async interact/analyze calls",
+			"After each workflow, generate artifact output (reproduction/test/sarif) for handoff",
+		}
+		responseData["workflows"] = exampleWorkflows()
+	}
+
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Tutorial", responseData)}
 }
 
 func (h *ToolHandler) tutorialContext() map[string]any {
@@ -164,6 +181,53 @@ func tutorialSnippets() []map[string]any {
 			"goal":      "Inspect tool/mode metadata at runtime",
 			"snippet":   `configure({what:"describe_capabilities"})`,
 			"arguments": map[string]any{"what": "describe_capabilities"},
+		},
+	}
+}
+
+func exampleWorkflows() []map[string]any {
+	return []map[string]any{
+		{
+			"id":          "debug_500_error",
+			"title":       "Debug a 500 error",
+			"description": "Capture failing requests, related console errors, and produce a reproduction artifact.",
+			"steps": []map[string]any{
+				{"tool": "interact", "call": `interact({what:"navigate", url:"https://app.example.com"})`},
+				{"tool": "observe", "call": `observe({what:"network_bodies", status_min:500, limit:20})`},
+				{"tool": "observe", "call": `observe({what:"errors", limit:20})`},
+				{"tool": "generate", "call": `generate({what:"reproduction", include_mocks:true})`},
+			},
+		},
+		{
+			"id":          "test_checkout_flow",
+			"title":       "Test a checkout flow",
+			"description": "Run end-to-end navigation and interactions, then generate a Playwright scaffold.",
+			"steps": []map[string]any{
+				{"tool": "interact", "call": `interact({what:"navigate", url:"https://shop.example.com/cart"})`},
+				{"tool": "interact", "call": `interact({what:"click", selector:"text=Checkout"})`},
+				{"tool": "observe", "call": `observe({what:"command_result", correlation_id:"<from interact>"})`},
+				{"tool": "generate", "call": `generate({what:"test", test_name:"checkout_flow", assert_no_errors:true})`},
+			},
+		},
+		{
+			"id":          "audit_accessibility",
+			"title":       "Audit page accessibility",
+			"description": "Run accessibility checks and export SARIF for CI/reporting.",
+			"steps": []map[string]any{
+				{"tool": "interact", "call": `interact({what:"navigate", url:"https://example.com"})`},
+				{"tool": "analyze", "call": `analyze({what:"accessibility", tags:["wcag2a","wcag2aa"]})`},
+				{"tool": "generate", "call": `generate({what:"sarif", include_passes:false})`},
+			},
+		},
+		{
+			"id":          "capture_crash_repro",
+			"title":       "Generate crash reproduction",
+			"description": "Bundle recent failing actions, logs, and network into a reproducible script.",
+			"steps": []map[string]any{
+				{"tool": "observe", "call": `observe({what:"error_bundles", limit:5})`},
+				{"tool": "observe", "call": `observe({what:"actions", limit:30})`},
+				{"tool": "generate", "call": `generate({what:"reproduction", include_mocks:true, include_screenshots:true})`},
+			},
 		},
 	}
 }

--- a/cmd/dev-console/tools_configure_tutorial_test.go
+++ b/cmd/dev-console/tools_configure_tutorial_test.go
@@ -62,6 +62,41 @@ func TestToolsConfigureExamples_Alias(t *testing.T) {
 	}
 }
 
+func TestToolsConfigureExamples_DiffersFromTutorialWithTaskWorkflows(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+
+	tutorialResult, ok := env.callConfigure(t, `{"what":"tutorial"}`)
+	if !ok {
+		t.Fatal("tutorial should return result")
+	}
+	if tutorialResult.IsError {
+		t.Fatalf("tutorial should not error, got: %s", tutorialResult.Content[0].Text)
+	}
+	tutorialData := parseResponseJSON(t, tutorialResult)
+
+	examplesResult, ok := env.callConfigure(t, `{"what":"examples"}`)
+	if !ok {
+		t.Fatal("examples should return result")
+	}
+	if examplesResult.IsError {
+		t.Fatalf("examples should not error, got: %s", examplesResult.Content[0].Text)
+	}
+	examplesData := parseResponseJSON(t, examplesResult)
+
+	if examplesData["message"] == tutorialData["message"] {
+		t.Fatal("examples message should be task-oriented and differ from tutorial")
+	}
+
+	if _, hasWorkflows := tutorialData["workflows"]; hasWorkflows {
+		t.Fatal("tutorial should not include task workflows")
+	}
+	workflows, ok := examplesData["workflows"].([]any)
+	if !ok || len(workflows) == 0 {
+		t.Fatalf("examples should include non-empty task workflows, got: %#v", examplesData["workflows"])
+	}
+}
+
 func TestToolsConfigureTutorial_ContextAware_PilotDisabled(t *testing.T) {
 	t.Parallel()
 	env := newConfigureTestEnv(t)


### PR DESCRIPTION
## Summary
- add TDD coverage ensuring examples content differs from tutorial
- keep tutorial mode as quickstart snippets + context-aware issues
- make examples mode task-oriented with reusable multi-step workflows (debug 500s, checkout flow, accessibility audit, crash reproduction)

## Testing
- go test ./cmd/dev-console -run 'TestToolsConfigureExamples_DiffersFromTutorialWithTaskWorkflows|TestToolsConfigureTutorial_ResponseShape|TestToolsConfigureExamples_Alias'
- go test ./cmd/dev-console

Closes #190