### PR TITLE
feat(tools): inline valid-param hints for structured validation errors

### DIFF
--- a/cmd/dev-console/tools_param_hint_test.go
+++ b/cmd/dev-console/tools_param_hint_test.go
@@ -1,0 +1,91 @@
+// tools_param_hint_test.go — Coverage for inline valid-param hints in structured errors.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestToolErrors_IncludeInlineValidParamsHint(t *testing.T) {
+	t.Parallel()
+
+	h, _, _ := makeToolHandler(t)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+
+	tests := []struct {
+		name       string
+		tool       string
+		args       string
+		wantCode   string
+		wantParams []string
+	}{
+		{
+			name:       "analyze dom missing selector",
+			tool:       "analyze",
+			args:       `{"what":"dom"}`,
+			wantCode:   ErrMissingParam,
+			wantParams: []string{"what", "selector"},
+		},
+		{
+			name:       "observe logs invalid scope",
+			tool:       "observe",
+			args:       `{"what":"logs","scope":"bogus"}`,
+			wantCode:   ErrInvalidParam,
+			wantParams: []string{"what", "scope"},
+		},
+		{
+			name:       "configure noise_rule remove missing rule_id",
+			tool:       "configure",
+			args:       `{"what":"noise_rule","noise_action":"remove"}`,
+			wantCode:   ErrMissingParam,
+			wantParams: []string{"what", "noise_action", "rule_id"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp, handled := h.HandleToolCall(req, tc.tool, json.RawMessage(tc.args))
+			if !handled {
+				t.Fatalf("%s: expected handled=true", tc.tool)
+			}
+
+			errData := extractStructuredErrorJSON(t, resp.Result)
+			if got, _ := errData["error"].(string); got != tc.wantCode {
+				t.Fatalf("error code = %q, want %q", got, tc.wantCode)
+			}
+
+			hint, _ := errData["hint"].(string)
+			if !strings.Contains(hint, "Valid params") {
+				t.Fatalf("hint missing inline valid params guidance: %q", hint)
+			}
+			for _, p := range tc.wantParams {
+				if !strings.Contains(hint, p) {
+					t.Fatalf("hint should include param %q, got: %q", p, hint)
+				}
+			}
+		})
+	}
+}
+
+func TestToolErrors_PreservesGenerateModeSpecificHint(t *testing.T) {
+	t.Parallel()
+
+	h, _, _ := makeToolHandler(t)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+
+	resp, handled := h.HandleToolCall(req, "generate", json.RawMessage(`{"what":"har","limit":5}`))
+	if !handled {
+		t.Fatal("generate: expected handled=true")
+	}
+
+	errData := extractStructuredErrorJSON(t, resp.Result)
+	hint, _ := errData["hint"].(string)
+	if !strings.Contains(hint, "Valid params for 'har':") {
+		t.Fatalf("expected mode-specific generate hint, got: %q", hint)
+	}
+	if strings.Count(hint, "Valid params for 'har':") != 1 {
+		t.Fatalf("expected single generate hint occurrence, got: %q", hint)
+	}
+}

--- a/cmd/dev-console/tools_param_hints.go
+++ b/cmd/dev-console/tools_param_hints.go
@@ -1,0 +1,117 @@
+// tools_param_hints.go — Inline valid-parameter hints for structured validation errors.
+package main
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// appendValidParamsHintOnError enriches structured validation errors with an inline
+// "Valid params" hint so LLMs can recover without a second discovery call.
+func (h *ToolHandler) appendValidParamsHintOnError(resp JSONRPCResponse, toolName string, args json.RawMessage) JSONRPCResponse {
+	if len(resp.Result) == 0 {
+		return resp
+	}
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil || !result.IsError || len(result.Content) == 0 {
+		return resp
+	}
+
+	var serr StructuredError
+	if err := json.Unmarshal([]byte(extractJSONFromTextBlock(result.Content[0].Text)), &serr); err != nil {
+		return resp
+	}
+	if !isParamValidationErrorCode(serr.Error) {
+		return resp
+	}
+
+	hint := buildValidParamsHint(toolName, args, h.getToolSchema(toolName))
+	if hint == "" {
+		return resp
+	}
+	if strings.Contains(strings.ToLower(serr.Hint), "valid params") {
+		return resp
+	}
+	if serr.Hint == "" {
+		serr.Hint = hint
+	} else {
+		serr.Hint += " " + hint
+	}
+
+	opts := []func(*StructuredError){
+		withRetryable(serr.Retryable),
+		withHint(serr.Hint),
+	}
+	if serr.Param != "" {
+		opts = append(opts, withParam(serr.Param))
+	}
+	if serr.RetryAfterMs > 0 {
+		opts = append(opts, withRetryAfterMs(serr.RetryAfterMs))
+	}
+	if serr.Final {
+		opts = append(opts, withFinal(true))
+	}
+	resp.Result = mcpStructuredError(serr.Error, serr.Message, serr.Retry, opts...)
+	return resp
+}
+
+func isParamValidationErrorCode(code string) bool {
+	return code == ErrMissingParam || code == ErrInvalidParam || code == ErrUnknownMode
+}
+
+func buildValidParamsHint(toolName string, args json.RawMessage, schema map[string]any) string {
+	if toolName == "generate" {
+		if hint := generateModeValidParamsHint(args); hint != "" {
+			return hint
+		}
+	}
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(props))
+	for key := range props {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return "Valid params: " + strings.Join(keys, ", ")
+}
+
+func generateModeValidParamsHint(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(args, &raw); err != nil {
+		return ""
+	}
+
+	mode, _ := raw["what"].(string)
+	if mode == "" {
+		mode, _ = raw["format"].(string)
+	}
+	valid, ok := generateValidParams[mode]
+	if !ok || len(valid) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(valid))
+	for key := range valid {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return "Valid params for '" + mode + "': " + strings.Join(keys, ", ")
+}
+
+func extractJSONFromTextBlock(text string) string {
+	for i, ch := range text {
+		if ch == '{' || ch == '[' {
+			return text[i:]
+		}
+	}
+	return text
+}


### PR DESCRIPTION
## Summary
- add TDD coverage that validation errors include inline valid-param hints across tools
- add shared error enrichment that appends `Valid params: ...` hints for structured param-validation errors
- preserve existing generate mode-specific hints (for example `Valid params for 'har': ...`)
- remove shared mutable schema cache and use safe per-call schema lookup

## Testing
- go test ./cmd/dev-console -run 'TestToolErrors_IncludeInlineValidParamsHint|TestToolErrors_PreservesGenerateModeSpecificHint' -count=1
- go test ./cmd/dev-console

Closes #192
