### PR TITLE
feat(noise): auto-detect on first initialize + repetitive log hints (#194)

### DIFF
--- a/cmd/dev-console/handler.go
+++ b/cmd/dev-console/handler.go
@@ -276,6 +276,10 @@ func (h *MCPHandler) HandleRequest(req JSONRPCRequest) *JSONRPCResponse {
 }
 
 func (h *MCPHandler) handleInitialize(req JSONRPCRequest) JSONRPCResponse {
+	if toolHandler, ok := h.toolHandler.(*ToolHandler); ok {
+		toolHandler.runNoiseAutoDetectOnFirstConnection()
+	}
+
 	negotiatedVersion := negotiateProtocolVersion(req.Params)
 
 	result := MCPInitializeResult{

--- a/cmd/dev-console/noise_autorun_test.go
+++ b/cmd/dev-console/noise_autorun_test.go
@@ -2,9 +2,12 @@
 package main
 
 import (
+	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/dev-console/dev-console/internal/capture"
 )
 
 // ============================================
@@ -94,5 +97,42 @@ func TestNoiseAutoDetectEnabled_TruthyValues(t *testing.T) {
 				t.Fatalf("expected %q to enable noise auto-detect", val)
 			}
 		})
+	}
+}
+
+func TestNoiseAutoDetect_RunsOnceOnFirstInitialize(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer(t.TempDir()+"/noise-init.jsonl", 100)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { server.Close() })
+	cap := capture.NewCapture()
+	mcpHandler := NewToolHandler(server, cap)
+	h := mcpHandler.toolHandler.(*ToolHandler)
+
+	initReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2025-06-18"}`),
+	}
+
+	resp1 := mcpHandler.HandleRequest(initReq)
+	if resp1 == nil || resp1.Error != nil {
+		t.Fatalf("first initialize should succeed, got response: %+v", resp1)
+	}
+
+	initReq.ID = 2
+	resp2 := mcpHandler.HandleRequest(initReq)
+	if resp2 == nil || resp2.Error != nil {
+		t.Fatalf("second initialize should succeed, got response: %+v", resp2)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := atomic.LoadUint32(&h.noiseAutoInitRuns); got != 1 {
+		t.Fatalf("noise auto-detect init runs = %d, want 1", got)
 	}
 }

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -141,6 +141,8 @@ type ToolHandler struct {
 	// Concrete implementations (interface signatures differ from types package)
 	// These are used directly by tool handlers rather than through the interface fields above.
 	noiseConfig           *ai.NoiseConfig
+	noiseInitTriggered    uint32
+	noiseAutoInitRuns     uint32
 	sessionStoreImpl      *ai.SessionStore
 	securityScannerImpl   *security.SecurityScanner
 	thirdPartyAuditorImpl *analysis.ThirdPartyAuditor


### PR DESCRIPTION
Summary: run noise auto-detect once on first MCP initialize, and add metadata.noise_hint in observe logs when >50% of returned entries are repetitive. Added TDD tests for both paths. Validation: go test ./cmd/dev-console -count=1. Closes #194