### PR TITLE
feat(configure): add compact capabilities cheatsheet mode

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -672,7 +672,7 @@
   },
   {
     "name": "configure",
-    "description": "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples (quick snippets + context-aware guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
+    "description": "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples/help/cheatsheet (quick snippets + compact capability guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -685,6 +685,8 @@
             "health",
             "tutorial",
             "examples",
+            "help",
+            "cheatsheet",
             "streaming",
             "test_boundary_start",
             "test_boundary_end",
@@ -794,6 +796,10 @@
         },
         "method": {
           "description": "Single-rule flattening helper for noise_action=add",
+          "type": "string"
+        },
+        "mode": {
+          "description": "Optional mode drill-down when tool is set (for help/cheatsheet)",
           "type": "string"
         },
         "name": {
@@ -955,6 +961,10 @@
           "minimum": 1,
           "type": "integer"
         },
+        "tool": {
+          "description": "Optional tool filter for help/cheatsheet (observe, analyze, interact, generate, configure)",
+          "type": "string"
+        },
         "tool_name": {
           "description": "Filter by tool name",
           "type": "string"
@@ -989,6 +999,8 @@
             "health",
             "tutorial",
             "examples",
+            "help",
+            "cheatsheet",
             "streaming",
             "test_boundary_start",
             "test_boundary_end",

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -81,6 +81,12 @@ var configureHandlers = map[string]ConfigureHandler{
 	"examples": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return h.toolConfigureTutorial(req, args)
 	},
+	"help": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return h.toolConfigureHelp(req, args)
+	},
+	"cheatsheet": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+		return h.toolConfigureHelp(req, args)
+	},
 	"save_sequence": func(h *ToolHandler, req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 		return h.toolConfigureSaveSequence(req, args)
 	},

--- a/cmd/dev-console/tools_configure_help.go
+++ b/cmd/dev-console/tools_configure_help.go
@@ -1,0 +1,215 @@
+// tools_configure_help.go — Compact configure help/cheatsheet output for LLM routing.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type helpModeSpec struct {
+	Name    string
+	Summary string
+	Params  []string
+}
+
+type helpToolSpec struct {
+	Name         string
+	Summary      string
+	CommonParams []string
+	Modes        []helpModeSpec
+}
+
+var helpSpecs = map[string]helpToolSpec{
+	"analyze": {
+		Name:         "analyze",
+		Summary:      "Active analysis",
+		CommonParams: []string{"background", "sync", "timeout_ms", "tab_id"},
+		Modes: []helpModeSpec{
+			{Name: "dom", Summary: "Query DOM elements", Params: []string{"selector", "frame"}},
+			{Name: "page_summary", Summary: "Compact page state snapshot", Params: []string{"tab_id", "world"}},
+			{Name: "accessibility", Summary: "WCAG accessibility scan", Params: []string{"scope", "selector", "tags", "force_refresh"}},
+			{Name: "forms", Summary: "Discover form fields", Params: []string{"selector"}},
+			{Name: "computed_styles", Summary: "Read computed CSS values", Params: []string{"selector", "property", "frame"}},
+			{Name: "link_validation", Summary: "Validate explicit URLs", Params: []string{"urls"}},
+			{Name: "api_validation", Summary: "Validate API calls in capture", Params: []string{"operation", "ignore_endpoints"}},
+			{Name: "security_audit", Summary: "Run security checks", Params: []string{"checks", "severity_min"}},
+		},
+	},
+	"observe": {
+		Name:         "observe",
+		Summary:      "Read captured telemetry buffers",
+		CommonParams: []string{"limit", "scope"},
+		Modes: []helpModeSpec{
+			{Name: "errors", Summary: "Console/runtime errors", Params: []string{"limit", "url", "scope"}},
+			{Name: "logs", Summary: "Console logs with filtering/pagination", Params: []string{"level", "min_level", "source", "url", "limit"}},
+			{Name: "network_waterfall", Summary: "All network timing entries", Params: []string{"url", "method", "status_min", "status_max", "limit"}},
+			{Name: "network_bodies", Summary: "Captured request/response payloads", Params: []string{"url", "method", "status_min", "status_max", "body_key", "body_path", "limit"}},
+			{Name: "actions", Summary: "Captured human/AI actions", Params: []string{"url", "limit"}},
+			{Name: "error_bundles", Summary: "Error + related context bundle", Params: []string{"limit", "window_seconds", "url"}},
+			{Name: "command_result", Summary: "Poll async command lifecycle", Params: []string{"correlation_id"}},
+		},
+	},
+	"interact": {
+		Name:         "interact",
+		Summary:      "Drive browser actions",
+		CommonParams: []string{"tab_id", "background", "sync", "timeout_ms"},
+		Modes: []helpModeSpec{
+			{Name: "navigate", Summary: "Navigate active tab", Params: []string{"url", "tab_id"}},
+			{Name: "click", Summary: "Click element by selector/index", Params: []string{"selector", "index", "frame", "world"}},
+			{Name: "type", Summary: "Type text into element", Params: []string{"selector", "index", "text", "clear", "frame", "world"}},
+			{Name: "execute_js", Summary: "Execute JavaScript in page", Params: []string{"script", "world", "timeout_ms"}},
+			{Name: "list_interactive", Summary: "List interactable elements", Params: []string{"visible_only", "frame"}},
+			{Name: "navigate_and_wait_for", Summary: "Navigate then wait for selector", Params: []string{"url", "wait_for", "timeout_ms"}},
+		},
+	},
+	"generate": {
+		Name:         "generate",
+		Summary:      "Generate artifacts from captured data",
+		CommonParams: []string{"save_to"},
+		Modes: []helpModeSpec{
+			{Name: "reproduction", Summary: "Generate reproduction script", Params: []string{"error_message", "last_n", "base_url", "include_screenshots", "generate_fixtures"}},
+			{Name: "test", Summary: "Generate Playwright test", Params: []string{"test_name", "last_n", "base_url", "assert_network", "assert_no_errors"}},
+			{Name: "sarif", Summary: "Export SARIF report", Params: []string{"scope", "include_passes", "save_to"}},
+			{Name: "csp", Summary: "Generate CSP policy", Params: []string{"mode", "include_report_uri", "exclude_origins"}},
+			{Name: "har", Summary: "Export HAR from capture", Params: []string{"url", "method", "status_min", "status_max"}},
+			{Name: "test_from_context", Summary: "Generate tests from context/error", Params: []string{"context", "error_id", "include_mocks", "output_format"}},
+		},
+	},
+	"configure": {
+		Name:         "configure",
+		Summary:      "Session controls and diagnostics",
+		CommonParams: []string{"what"},
+		Modes: []helpModeSpec{
+			{Name: "health", Summary: "Connection and readiness snapshot", Params: []string{}},
+			{Name: "doctor", Summary: "Actionable setup diagnostics", Params: []string{}},
+			{Name: "noise_rule", Summary: "Manage noise filters", Params: []string{"noise_action", "rules", "rule_id"}},
+			{Name: "streaming", Summary: "Configure notifications", Params: []string{"streaming_action", "events", "throttle_seconds"}},
+			{Name: "tutorial", Summary: "Quickstart snippets", Params: []string{}},
+			{Name: "examples", Summary: "Task-oriented workflows", Params: []string{}},
+			{Name: "help", Summary: "Compact capability cheat sheet", Params: []string{"tool", "mode"}},
+		},
+	},
+}
+
+func sortedHelpTools() []string {
+	keys := make([]string, 0, len(helpSpecs))
+	for key := range helpSpecs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func findHelpMode(spec helpToolSpec, mode string) (helpModeSpec, bool) {
+	for _, m := range spec.Modes {
+		if m.Name == mode {
+			return m, true
+		}
+	}
+	return helpModeSpec{}, false
+}
+
+func helpModeToMap(mode helpModeSpec) map[string]any {
+	return map[string]any{
+		"name":    mode.Name,
+		"summary": mode.Summary,
+		"params":  mode.Params,
+	}
+}
+
+func helpToolToMap(tool helpToolSpec) map[string]any {
+	modes := make([]map[string]any, 0, len(tool.Modes))
+	for _, mode := range tool.Modes {
+		modes = append(modes, helpModeToMap(mode))
+	}
+	return map[string]any{
+		"name":          tool.Name,
+		"summary":       tool.Summary,
+		"common_params": tool.CommonParams,
+		"modes":         modes,
+	}
+}
+
+func renderHelpText(tools []helpToolSpec) string {
+	var b strings.Builder
+	for i, tool := range tools {
+		b.WriteString(fmt.Sprintf("%s - %s\n", tool.Name, tool.Summary))
+		for _, mode := range tool.Modes {
+			params := strings.Join(mode.Params, ", ")
+			if params == "" {
+				params = "no specific params"
+			}
+			b.WriteString(fmt.Sprintf("  %s -> %s (%s)\n", mode.Name, mode.Summary, params))
+		}
+		common := strings.Join(tool.CommonParams, ", ")
+		if common == "" {
+			common = "none"
+		}
+		b.WriteString(fmt.Sprintf("  Common params: %s\n", common))
+		if i < len(tools)-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func (h *ToolHandler) toolConfigureHelp(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Tool string `json:"tool"`
+		Mode string `json:"mode"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &params); err != nil {
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
+		}
+	}
+
+	selectedTool := strings.TrimSpace(strings.ToLower(params.Tool))
+	selectedMode := strings.TrimSpace(strings.ToLower(params.Mode))
+	if selectedTool == "" && selectedMode != "" {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Parameter 'mode' requires parameter 'tool'", "Provide tool and mode together, for example configure({what:'help', tool:'analyze', mode:'accessibility'})", withParam("tool"), withParam("mode"))}
+	}
+
+	tools := make([]helpToolSpec, 0, len(helpSpecs))
+	if selectedTool != "" {
+		spec, ok := helpSpecs[selectedTool]
+		if !ok {
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Unknown tool for help: "+selectedTool, "Use tool one of: analyze, configure, generate, interact, observe", withParam("tool"))}
+		}
+		if selectedMode != "" {
+			modeSpec, ok := findHelpMode(spec, selectedMode)
+			if !ok {
+				return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Unknown mode for tool '"+selectedTool+"': "+selectedMode, "Use a mode listed in configure({what:'help', tool:'"+selectedTool+"'})", withParam("mode"))}
+			}
+			spec.Modes = []helpModeSpec{modeSpec}
+		}
+		tools = append(tools, spec)
+	} else {
+		for _, name := range sortedHelpTools() {
+			tools = append(tools, helpSpecs[name])
+		}
+	}
+
+	toolPayload := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		toolPayload = append(toolPayload, helpToolToMap(tool))
+	}
+
+	payload := map[string]any{
+		"status":  "ok",
+		"mode":    "help",
+		"message": "Compact capability cheat sheet for MCP tool routing",
+		"tools":   toolPayload,
+		"text":    renderHelpText(tools),
+	}
+	if selectedTool != "" {
+		payload["tool"] = selectedTool
+	}
+	if selectedMode != "" {
+		payload["focus_mode"] = selectedMode
+	}
+
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Capabilities cheat sheet", payload)}
+}

--- a/internal/schema/configure.go
+++ b/internal/schema/configure.go
@@ -7,18 +7,26 @@ import "github.com/dev-console/dev-console/internal/mcp"
 func ConfigureToolSchema() mcp.MCPTool {
 	return mcp.MCPTool{
 		Name:        "configure",
-		Description: "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples (quick snippets + context-aware guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
+		Description: "Session settings and utilities.\n\nKey actions: health (check server/extension status), clear (reset buffers), noise_rule (suppress recurring console noise), store/load (persist/retrieve session data), tutorial/examples/help/cheatsheet (quick snippets + compact capability guidance), streaming (enable push notifications), recording_start/recording_stop (capture browser sessions), playback (replay recordings), log_diff (compare error states), restart (force-restart daemon when unresponsive).\n\nMacro sequences: save_sequence/replay_sequence/get_sequence/list_sequences/delete_sequence — save named interact action sequences and replay them in a single call.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"what": map[string]any{
 					"type": "string",
-					"enum": []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
+					"enum": []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "help", "cheatsheet", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
 				},
 				"action": map[string]any{
 					"type":        "string",
 					"description": "Deprecated alias for 'what'",
-					"enum":        []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
+					"enum":        []string{"store", "load", "noise_rule", "clear", "health", "tutorial", "examples", "help", "cheatsheet", "streaming", "test_boundary_start", "test_boundary_end", "recording_start", "recording_stop", "playback", "log_diff", "telemetry", "describe_capabilities", "diff_sessions", "audit_log", "restart", "save_sequence", "get_sequence", "list_sequences", "delete_sequence", "replay_sequence", "doctor"},
+				},
+				"tool": map[string]any{
+					"type":        "string",
+					"description": "Optional tool filter for help/cheatsheet (observe, analyze, interact, generate, configure)",
+				},
+				"mode": map[string]any{
+					"type":        "string",
+					"description": "Optional mode drill-down when tool is set (for help/cheatsheet)",
 				},
 				"telemetry_mode": map[string]any{
 					"type":        "string",

--- a/internal/tools/configure/capabilities.go
+++ b/internal/tools/configure/capabilities.go
@@ -36,6 +36,12 @@ var configureModeSpecs = map[string]modeParamSpec{
 	"health":   {},
 	"tutorial": {},
 	"examples": {},
+	"help": {
+		Optional: []string{"tool", "mode"},
+	},
+	"cheatsheet": {
+		Optional: []string{"tool", "mode"},
+	},
 	"streaming": {
 		Optional: []string{"streaming_action", "events", "throttle_seconds", "severity_min"},
 	},


### PR DESCRIPTION
## Summary
- add `configure({what:"help"})` compact capability cheatsheet response for LLM routing
- add `cheatsheet` alias and optional `tool`/`mode` drill-down filters with structured validation errors
- wire help/cheatsheet into configure handlers, schema enums, and capability metadata
- add contract tests and refresh tool-list golden snapshot

## Testing
- go test ./cmd/dev-console -run 'TestToolsConfigureHelp|TestToolsConfigureCheatsheet|TestToolsConfigureTutorial|TestToolsConfigureDispatch|TestToolsConfigure_GetValidConfigureActions' -count=1
- go test ./internal/tools/configure -count=1
- go test ./cmd/dev-console -count=1

Closes #195
