### PR TITLE
feat(generate): make reproduction output runnable by default

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -590,7 +590,13 @@
           "type": "array"
         },
         "output_format": {
-          "description": "Output format: file or inline (test_from_context)",
+          "description": "Output format: playwright|gasoline (reproduction), file|inline (test_from_context)",
+          "enum": [
+            "playwright",
+            "gasoline",
+            "file",
+            "inline"
+          ],
           "type": "string"
         },
         "resource_types": {

--- a/cmd/dev-console/tools_configure_help.go
+++ b/cmd/dev-console/tools_configure_help.go
@@ -69,7 +69,7 @@ var helpSpecs = map[string]helpToolSpec{
 		Summary:      "Generate artifacts from captured data",
 		CommonParams: []string{"save_to"},
 		Modes: []helpModeSpec{
-			{Name: "reproduction", Summary: "Generate reproduction script", Params: []string{"error_message", "last_n", "base_url", "include_screenshots", "generate_fixtures"}},
+			{Name: "reproduction", Summary: "Generate reproduction script", Params: []string{"error_message", "last_n", "base_url", "include_screenshots", "generate_fixtures", "output_format"}},
 			{Name: "test", Summary: "Generate Playwright test", Params: []string{"test_name", "last_n", "base_url", "assert_network", "assert_no_errors"}},
 			{Name: "sarif", Summary: "Export SARIF report", Params: []string{"scope", "include_passes", "save_to"}},
 			{Name: "csp", Summary: "Generate CSP policy", Params: []string{"mode", "include_report_uri", "exclude_origins"}},

--- a/cmd/dev-console/tools_generate.go
+++ b/cmd/dev-console/tools_generate.go
@@ -23,7 +23,7 @@ type GenerateHandler func(h *ToolHandler, req JSONRPCRequest, args json.RawMessa
 // generateValidParams defines the allowed parameter names per generate format.
 // The "format" and "telemetry_mode" params are always allowed.
 var generateValidParams = map[string]map[string]bool{
-	"reproduction":      {"error_message": true, "last_n": true, "base_url": true, "include_screenshots": true, "generate_fixtures": true, "visual_assertions": true, "save_to": true},
+	"reproduction":      {"error_message": true, "last_n": true, "base_url": true, "include_screenshots": true, "generate_fixtures": true, "visual_assertions": true, "output_format": true, "save_to": true},
 	"test":              {"test_name": true, "last_n": true, "base_url": true, "assert_network": true, "assert_no_errors": true, "assert_response_shape": true, "save_to": true},
 	"pr_summary":        {"save_to": true},
 	"har":               {"url": true, "method": true, "status_min": true, "status_max": true, "save_to": true},

--- a/internal/reproduction/reproduction.go
+++ b/internal/reproduction/reproduction.go
@@ -59,7 +59,7 @@ func ParseParams(args json.RawMessage) Params {
 		_ = json.Unmarshal(args, &params)
 	}
 	if params.OutputFormat == "" {
-		params.OutputFormat = "gasoline"
+		params.OutputFormat = "playwright"
 	}
 	return params
 }

--- a/internal/reproduction/reproduction_test.go
+++ b/internal/reproduction/reproduction_test.go
@@ -466,14 +466,9 @@ func TestReproduction_LastN(t *testing.T) {
 
 func TestReproduction_DefaultFormat(t *testing.T) {
 	t.Parallel()
-	// When output_format is empty, should default to "gasoline"
-	params := Params{}
-	format := params.OutputFormat
-	if format == "" {
-		format = "gasoline" // default
-	}
-	if format != "gasoline" {
-		t.Errorf("expected default format 'gasoline', got %q", format)
+	params := ParseParams(nil)
+	if params.OutputFormat != "playwright" {
+		t.Errorf("expected default format 'playwright', got %q", params.OutputFormat)
 	}
 }
 

--- a/internal/schema/generate.go
+++ b/internal/schema/generate.go
@@ -183,7 +183,8 @@ func GenerateToolSchema() mcp.MCPTool {
 				},
 				"output_format": map[string]any{
 					"type":        "string",
-					"description": "Output format: file or inline (test_from_context)",
+					"description": "Output format: playwright|gasoline (reproduction), file|inline (test_from_context)",
+					"enum":        []string{"playwright", "gasoline", "file", "inline"},
 				},
 			},
 			"required": []string{"what"},


### PR DESCRIPTION
## Summary
- make `generate({what:"reproduction"})` return runnable Playwright by default
- allow `output_format` for reproduction mode and preserve `output_format:"gasoline"` natural-language output
- keep structured validation for invalid `output_format` values
- update generate schema/help metadata and refresh tool-list golden

## Testing
- go test ./cmd/dev-console -run 'TestToolsGenerateReproduction_DefaultsToPlaywright|TestToolsGenerateReproduction_AcceptsOutputFormatGasoline|TestToolsGenerateReproduction_InvalidOutputFormatReturnsStructuredError' -count=1
- go test ./internal/reproduction -run 'TestReproduction_DefaultFormat' -count=1
- go test ./cmd/dev-console -run 'TestToolsGenerate|TestGenerateAudit|TestContractGenerate_Reproduction|TestContractGenerate_Test|TestToolsConfigureHelp' -count=1
- go test ./internal/reproduction -count=1
- go test ./internal/tools/configure -count=1
- go test ./cmd/dev-console -count=1

Closes #196
