### PR TITLE
fix: assume pilot-enabled during startup uncertainty

### DIFF
--- a/cmd/dev-console/health_unit_test.go
+++ b/cmd/dev-console/health_unit_test.go
@@ -4,6 +4,8 @@ package main
 import (
 	"sync"
 	"testing"
+
+	"github.com/dev-console/dev-console/internal/capture"
 )
 
 func TestHealthMetrics_IncrementAndGet(t *testing.T) {
@@ -134,6 +136,35 @@ func TestHealthResponseZeroDroppedCount(t *testing.T) {
 	}
 
 	close(srv.logDone)
+}
+
+func TestBuildPilotInfo_AssumedEnabledStartupState(t *testing.T) {
+	t.Parallel()
+
+	cap := capture.NewCapture()
+	info := buildPilotInfo(cap)
+
+	if !info.Enabled {
+		t.Fatalf("enabled = false, want true during startup uncertainty")
+	}
+	if info.Source != "assumed_startup" {
+		t.Fatalf("source = %q, want assumed_startup", info.Source)
+	}
+}
+
+func TestBuildPilotInfo_ExplicitDisableState(t *testing.T) {
+	t.Parallel()
+
+	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false)
+
+	info := buildPilotInfo(cap)
+	if info.Enabled {
+		t.Fatalf("enabled = true, want false for explicit disable")
+	}
+	if info.Source != "explicitly_disabled" {
+		t.Fatalf("source = %q, want explicitly_disabled", info.Source)
+	}
 }
 
 func TestCalcUtilization_Normal(t *testing.T) {

--- a/cmd/dev-console/server_routes.go
+++ b/cmd/dev-console/server_routes.go
@@ -57,9 +57,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request, cap *captu
 	}
 	if cap != nil {
 		extStatus := cap.GetExtensionStatus()
+		pilotStatus, _ := cap.GetPilotStatus().(map[string]any)
+		pilotState, _ := pilotStatus["state"].(string)
 		resp["capture"] = map[string]any{
 			"available":           true,
-			"pilot_enabled":       cap.IsPilotEnabled(),
+			"pilot_enabled":       cap.IsPilotActionAllowed(),
+			"pilot_state":         pilotState,
 			"extension_connected": cap.IsExtensionConnected(),
 			"extension_last_seen": extStatus["last_seen"],
 			"extension_client_id": extStatus["client_id"],

--- a/cmd/dev-console/tools_configure_audit_test.go
+++ b/cmd/dev-console/tools_configure_audit_test.go
@@ -45,6 +45,7 @@ func newConfigureTestEnv(t *testing.T) *configureTestEnv {
 	}
 	t.Cleanup(func() { server.Close() })
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // explicit default for configure context tests
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
 	return &configureTestEnv{handler: handler, server: server, capture: cap}

--- a/cmd/dev-console/tools_configure_tutorial_test.go
+++ b/cmd/dev-console/tools_configure_tutorial_test.go
@@ -88,6 +88,32 @@ func TestToolsConfigureTutorial_ContextAware_PilotDisabled(t *testing.T) {
 	}
 }
 
+func TestToolsConfigureTutorial_ContextAware_AssumedPilotDoesNotReportPilotDisabled(t *testing.T) {
+	t.Parallel()
+	env := newConfigureTestEnv(t)
+	env.capture.SetPilotUnknownForTest()
+
+	result, ok := env.callConfigure(t, `{"what":"tutorial"}`)
+	if !ok {
+		t.Fatal("tutorial should return result")
+	}
+	if result.IsError {
+		t.Fatalf("tutorial should not error, got: %s", result.Content[0].Text)
+	}
+	data := parseResponseJSON(t, result)
+
+	issues, ok := data["issues"].([]any)
+	if !ok {
+		t.Fatalf("issues type = %T, want []any", data["issues"])
+	}
+	for _, issueRaw := range issues {
+		issue, _ := issueRaw.(map[string]any)
+		if issue["code"] == "pilot_disabled" {
+			t.Fatalf("unexpected pilot_disabled issue while pilot state is only assumed at startup: %+v", issue)
+		}
+	}
+}
+
 func TestToolsConfigureTutorial_ContextAware_NoTrackedTab(t *testing.T) {
 	t.Parallel()
 	env := newConfigureTestEnv(t)

--- a/cmd/dev-console/tools_interact_audit_test.go
+++ b/cmd/dev-console/tools_interact_audit_test.go
@@ -43,6 +43,7 @@ func newInteractTestEnv(t *testing.T) *interactTestEnv {
 		t.Fatalf("NewServer failed: %v", err)
 	}
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // explicit default for legacy pilot-disabled tests
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
 	return &interactTestEnv{handler: handler, server: server, capture: cap}

--- a/cmd/dev-console/tools_interact_handler_test.go
+++ b/cmd/dev-console/tools_interact_handler_test.go
@@ -313,6 +313,23 @@ func TestToolsInteractNavigate_MissingURL(t *testing.T) {
 	assertSnakeCaseFields(t, string(resp.Result))
 }
 
+func TestToolsInteractNavigate_AssumedEnabledWhenPilotStatusUncertain(t *testing.T) {
+	t.Parallel()
+	h, _, cap := makeToolHandler(t)
+	cap.SetPilotUnknownForTest()
+
+	resp := callInteractRaw(h, `{"what":"navigate","url":"https://example.com"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("navigate should not fail with pilot_disabled during startup uncertainty, got: %s", result.Content[0].Text)
+	}
+
+	data := extractResultJSON(t, result)
+	if data["status"] != "queued" {
+		t.Fatalf("status = %v, want queued", data["status"])
+	}
+}
+
 func TestToolsInteractNavigate_Success(t *testing.T) {
 	t.Parallel()
 	h, _, cap := makeToolHandler(t)

--- a/cmd/dev-console/tools_interact_helpers_test.go
+++ b/cmd/dev-console/tools_interact_helpers_test.go
@@ -28,6 +28,7 @@ func newInteractHelpersTestEnv(t *testing.T) *interactHelpersTestEnv {
 	}
 	t.Cleanup(func() { server.Close() })
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // explicit default for state/pilot-disabled test branches
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
 	return &interactHelpersTestEnv{handler: handler, server: server, capture: cap}

--- a/cmd/dev-console/tools_interact_state.go
+++ b/cmd/dev-console/tools_interact_state.go
@@ -50,7 +50,7 @@ var buildStateRestoreScript = act.BuildStateRestoreScript
 // captureState attempts to capture form values, scroll position, and web storage from the browser.
 // Always returns a stateCaptureResult with an explicit Status the caller can surface to the LLM.
 func (h *ToolHandler) captureState(req JSONRPCRequest) stateCaptureResult {
-	if !h.capture.IsPilotEnabled() {
+	if !h.capture.IsPilotActionAllowed() {
 		return stateCaptureResult{Status: stateCaptureStatusPilotDisabled}
 	}
 	if !h.capture.IsExtensionConnected() {
@@ -233,7 +233,7 @@ func (h *ToolHandler) handlePilotManageStateLoad(req JSONRPCRequest, args json.R
 
 	if !hasData {
 		responseData["state_restore"] = stateRestoreStatusNoData
-	} else if !h.capture.IsPilotEnabled() {
+	} else if !h.capture.IsPilotActionAllowed() {
 		responseData["state_restore"] = stateRestoreStatusPilotDisabled
 	} else if !h.capture.IsExtensionConnected() {
 		responseData["state_restore"] = stateRestoreStatusExtensionDown
@@ -252,7 +252,7 @@ func (h *ToolHandler) handlePilotManageStateLoad(req JSONRPCRequest, args json.R
 // and the state contains a non-empty URL. Mutates stateData to add tracking fields.
 func (h *ToolHandler) queueStateNavigation(req JSONRPCRequest, stateData map[string]any) {
 	savedURL, ok := stateData["url"].(string)
-	if !ok || savedURL == "" || !h.capture.IsPilotEnabled() || !h.capture.IsExtensionConnected() {
+	if !ok || savedURL == "" || !h.capture.IsPilotActionAllowed() || !h.capture.IsExtensionConnected() {
 		return
 	}
 	correlationID := newCorrelationID("nav")

--- a/cmd/dev-console/tools_recording_video_test.go
+++ b/cmd/dev-console/tools_recording_video_test.go
@@ -32,6 +32,7 @@ func newVideoTestEnv(t *testing.T) *videoTestEnv {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // explicit default for pilot-disabled recording tests
 	mcp := NewToolHandler(srv, cap)
 	handler, ok := mcp.toolHandler.(*ToolHandler)
 	if !ok {

--- a/cmd/dev-console/tools_stdio_test.go
+++ b/cmd/dev-console/tools_stdio_test.go
@@ -80,6 +80,7 @@ func createTestToolHandler(t *testing.T) *ToolHandler {
 	}
 
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // explicit default for legacy pilot-disabled expectations
 
 	// Create handler using proper constructor
 	mcpHandler := NewToolHandler(server, cap)

--- a/cmd/dev-console/tools_test_helpers_test.go
+++ b/cmd/dev-console/tools_test_helpers_test.go
@@ -26,6 +26,7 @@ func makeToolHandler(t *testing.T) (*ToolHandler, *Server, *capture.Capture) {
 	}
 	t.Cleanup(func() { server.Close() })
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // keep legacy test default: explicitly disabled unless test opts in
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
 	return handler, server, cap
@@ -51,6 +52,7 @@ func newToolTestEnv(t *testing.T) *toolTestEnv {
 	}
 	t.Cleanup(func() { server.Close() })
 	cap := capture.NewCapture()
+	cap.SetPilotEnabled(false) // keep legacy test default: explicitly disabled unless test opts in
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
 	return &toolTestEnv{handler: handler, server: server, capture: cap}

--- a/internal/capture/capture-struct.go
+++ b/internal/capture/capture-struct.go
@@ -127,7 +127,7 @@ type Capture struct {
 	// ============================================
 
 	lifecycleCallback  func(event string, data map[string]any) // Optional callback for lifecycle events (circuit breaker, extension state, buffer overflow)
-	navigationCallback func()                                   // Optional callback fired after a navigation action is ingested (called outside lock)
+	navigationCallback func()                                  // Optional callback fired after a navigation action is ingested (called outside lock)
 
 	// ============================================
 	// Version Information
@@ -156,6 +156,7 @@ func NewCapture() *Capture {
 		},
 		ext: ExtensionState{
 			activeTestIDs: make(map[string]bool),
+			pilotSource:   PilotSourceAssumedStartup,
 		},
 		perf: PerformanceStore{
 			snapshots:       make(map[string]performance.PerformanceSnapshot),

--- a/internal/capture/settings.go
+++ b/internal/capture/settings.go
@@ -87,7 +87,9 @@ func (c *Capture) LoadSettingsFromDisk() {
 	}
 	if settings.AIWebPilotEnabled != nil {
 		c.ext.pilotEnabled = *settings.AIWebPilotEnabled
+		c.ext.pilotStatusKnown = true
 		c.ext.pilotUpdatedAt = settings.Timestamp
+		c.ext.pilotSource = PilotSourceSettingsCache
 	}
 }
 
@@ -99,10 +101,13 @@ func (c *Capture) SaveSettingsToDisk() error {
 	}
 
 	c.mu.RLock()
-	// Copy bool by value — &c.ext.pilotEnabled would escape the lock scope
-	pilotEnabled := c.ext.pilotEnabled
+	var pilotEnabled *bool
+	if c.ext.pilotStatusKnown {
+		v := c.ext.pilotEnabled
+		pilotEnabled = &v
+	}
 	settings := PersistedSettings{
-		AIWebPilotEnabled: &pilotEnabled,
+		AIWebPilotEnabled: pilotEnabled,
 		Timestamp:         c.ext.pilotUpdatedAt,
 		ExtSessionID:      c.ext.extSessionID,
 	}

--- a/internal/capture/sync.go
+++ b/internal/capture/sync.go
@@ -137,7 +137,9 @@ func (c *Capture) updateSyncConnectionState(req SyncRequest, clientID string, no
 
 	if req.Settings != nil {
 		c.ext.pilotEnabled = req.Settings.PilotEnabled
+		c.ext.pilotStatusKnown = true
 		c.ext.pilotUpdatedAt = now
+		c.ext.pilotSource = PilotSourceExtensionSync
 		c.ext.trackingEnabled = req.Settings.TrackingEnabled
 		c.ext.trackedTabID = req.Settings.TrackedTabID
 		c.ext.trackedTabURL = req.Settings.TrackedTabURL

--- a/internal/capture/test_helpers.go
+++ b/internal/capture/test_helpers.go
@@ -61,6 +61,19 @@ func (c *Capture) SetPilotEnabled(enabled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ext.pilotEnabled = enabled
+	c.ext.pilotStatusKnown = true
+	c.ext.pilotUpdatedAt = time.Now()
+	c.ext.pilotSource = PilotSourceTestHelper
+}
+
+// SetPilotUnknownForTest resets pilot to startup-uncertain state (TEST ONLY).
+func (c *Capture) SetPilotUnknownForTest() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ext.pilotEnabled = false
+	c.ext.pilotStatusKnown = false
+	c.ext.pilotUpdatedAt = time.Time{}
+	c.ext.pilotSource = PilotSourceAssumedStartup
 }
 
 // SetTrackingStatusForTest sets the tracked tab URL and ID (TEST ONLY)


### PR DESCRIPTION
## Summary
- fixes the startup/reconnect race where `interact` could fail early with `pilot_disabled` before pilot state is authoritatively known
- adds a pilot tri-state model (`assumed_enabled`, `enabled`, `explicitly_disabled`) and gates hard failures only on explicit disable
- updates status surfaces (observe/health/doctor/hints/tutorial context) to distinguish assumed startup state from explicit disable
- keeps legacy test expectations explicit by setting pilot-disabled defaults in test env constructors, while adding direct tests for the assumed-enabled startup path

## Key Changes
- `internal/capture`:
  - added pilot status authority/source tracking and effective action gating helpers
  - sync/settings ingestion now marks pilot status as authoritative with source metadata
  - `GetPilotStatus` now includes `state`, `authoritative`, `configured_enabled`, and effective `enabled`
- `cmd/dev-console`:
  - `requirePilot` now blocks only when pilot is explicitly disabled
  - diagnostic hints include explicit startup-assumed vs explicit-disabled pilot state
  - state handlers use effective pilot action gating
  - doctor + health/server routes reflect pilot state distinction
  - tutorial context/issues no longer report `pilot_disabled` for startup-uncertain state

## Tests
- `go test ./internal/capture -count=1`
- `go test ./cmd/dev-console -count=1`

Closes #212
