### PR TITLE
feat: daemon single-instance takeover with opt-in parallel isolation

### DIFF
--- a/cmd/dev-console/config_parallel_test.go
+++ b/cmd/dev-console/config_parallel_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/state"
+)
+
+func TestApplyParallelModeStateDir_AutoGeneratesWhenMissing(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv(state.StateDirEnv, stateRoot)
+
+	stateDir := ""
+	if err := applyParallelModeStateDir(true, &stateDir); err != nil {
+		t.Fatalf("applyParallelModeStateDir() error = %v", err)
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		t.Fatal("stateDir should be auto-generated in parallel mode")
+	}
+	if !strings.HasPrefix(stateDir, filepath.Join(stateRoot, "parallel")+string(filepath.Separator)) {
+		t.Fatalf("stateDir = %q, want prefix %q", stateDir, filepath.Join(stateRoot, "parallel")+string(filepath.Separator))
+	}
+}
+
+func TestApplyParallelModeStateDir_PreservesExplicitStateDir(t *testing.T) {
+	explicit := filepath.Join(t.TempDir(), "isolated")
+	stateDir := explicit
+	if err := applyParallelModeStateDir(true, &stateDir); err != nil {
+		t.Fatalf("applyParallelModeStateDir() error = %v", err)
+	}
+	if stateDir != explicit {
+		t.Fatalf("stateDir = %q, want explicit %q", stateDir, explicit)
+	}
+}
+
+func TestApplyParallelModeStateDir_NoopWhenDisabled(t *testing.T) {
+	stateDir := ""
+	if err := applyParallelModeStateDir(false, &stateDir); err != nil {
+		t.Fatalf("applyParallelModeStateDir() error = %v", err)
+	}
+	if stateDir != "" {
+		t.Fatalf("stateDir = %q, want unchanged empty string", stateDir)
+	}
+}

--- a/cmd/dev-console/daemon_lifecycle.go
+++ b/cmd/dev-console/daemon_lifecycle.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/state"
+)
+
+type daemonLaunchOptions struct {
+	Parallel bool
+}
+
+type daemonLockRecord struct {
+	PID       int    `json:"pid"`
+	Port      int    `json:"port"`
+	StateDir  string `json:"state_dir"`
+	Version   string `json:"version,omitempty"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+var (
+	daemonIsProcessAlive     = isProcessAlive
+	daemonTryShutdown        = tryShutdownViaHTTP
+	daemonWaitForPortRelease = waitForPortRelease
+	daemonTerminatePID       = terminatePIDQuiet
+	daemonNow                = time.Now
+)
+
+func daemonLockFilePath() (string, error) {
+	return state.InRoot("run", "daemon.lock.json")
+}
+
+func daemonLockFilePathForError() string {
+	path, err := daemonLockFilePath()
+	if err != nil {
+		return "<unknown>"
+	}
+	return path
+}
+
+func readDaemonLockFile() (*daemonLockRecord, error) {
+	path, err := daemonLockFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var rec daemonLockRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("invalid daemon lock metadata at %s: %w", path, err)
+	}
+	return &rec, nil
+}
+
+func writeDaemonLockFile(rec daemonLockRecord) error {
+	path, err := daemonLockFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	if rec.UpdatedAt == "" {
+		rec.UpdatedAt = daemonNow().UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func removeDaemonLockFile() error {
+	path, err := daemonLockFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func removeDaemonLockIfOwned(pid int) {
+	rec, err := readDaemonLockFile()
+	if err != nil || rec == nil {
+		return
+	}
+	if rec.PID == pid {
+		_ = removeDaemonLockFile()
+	}
+}
+
+func persistCurrentDaemonLock(port int) error {
+	stateDir, err := state.RootDir()
+	if err != nil {
+		return err
+	}
+	return writeDaemonLockFile(daemonLockRecord{
+		PID:       os.Getpid(),
+		Port:      port,
+		StateDir:  stateDir,
+		Version:   version,
+		UpdatedAt: daemonNow().UTC().Format(time.RFC3339),
+	})
+}
+
+func enforceDaemonStartupPolicy(server *Server, port int, opts daemonLaunchOptions) error {
+	stateDir, err := state.RootDir()
+	if err != nil {
+		return fmt.Errorf("cannot resolve state dir: %w", err)
+	}
+	rec, err := readDaemonLockFile()
+	if err != nil {
+		return err
+	}
+	if rec == nil {
+		return nil
+	}
+
+	if opts.Parallel {
+		return validateParallelIsolation(rec)
+	}
+	return performDefaultTakeover(server, stateDir, port, rec)
+}
+
+func validateParallelIsolation(rec *daemonLockRecord) error {
+	if rec.PID <= 0 || rec.Port <= 0 {
+		return fmt.Errorf(
+			"parallel mode requires isolated --state-dir; invalid daemon lock metadata (pid=%d, port=%d) at %s",
+			rec.PID,
+			rec.Port,
+			daemonLockFilePathForError(),
+		)
+	}
+	if rec.PID == os.Getpid() {
+		return nil
+	}
+	if !daemonIsProcessAlive(rec.PID) {
+		return removeDaemonLockFile()
+	}
+	return fmt.Errorf(
+		"parallel mode requires isolated --state-dir; existing daemon is active (existing_pid=%d existing_port=%d state_dir=%s)",
+		rec.PID,
+		rec.Port,
+		rec.StateDir,
+	)
+}
+
+func performDefaultTakeover(server *Server, stateDir string, port int, rec *daemonLockRecord) error {
+	if rec.PID <= 0 || rec.Port <= 0 {
+		return fmt.Errorf(
+			"invalid daemon lock metadata for state_dir=%s (pid=%d, port=%d). remove %s and retry",
+			stateDir,
+			rec.PID,
+			rec.Port,
+			daemonLockFilePathForError(),
+		)
+	}
+	if rec.PID == os.Getpid() {
+		return nil
+	}
+	if !daemonIsProcessAlive(rec.PID) {
+		return removeDaemonLockFile()
+	}
+
+	pidFromPortFile := readPIDFile(rec.Port)
+	if pidFromPortFile != rec.PID {
+		return fmt.Errorf(
+			"daemon ownership mismatch for state_dir=%s: lock pid=%d port=%d, pid_file=%d; refusing takeover",
+			stateDir,
+			rec.PID,
+			rec.Port,
+			pidFromPortFile,
+		)
+	}
+
+	server.logLifecycle("daemon_takeover", port, map[string]any{
+		"existing_pid":  rec.PID,
+		"existing_port": rec.Port,
+		"takeover":      true,
+		"state_dir":     stateDir,
+		"new_pid":       os.Getpid(),
+	})
+
+	_ = daemonTryShutdown(rec.Port)
+	if !daemonWaitForPortRelease(rec.Port, 2*time.Second) {
+		daemonTerminatePID(rec.PID, false)
+		if !daemonWaitForPortRelease(rec.Port, 2*time.Second) {
+			daemonTerminatePID(rec.PID, true)
+			if !daemonWaitForPortRelease(rec.Port, 2*time.Second) {
+				return fmt.Errorf(
+					"failed to takeover existing daemon for state_dir=%s (existing_pid=%d existing_port=%d)",
+					stateDir,
+					rec.PID,
+					rec.Port,
+				)
+			}
+		}
+	}
+
+	removePIDFile(rec.Port)
+	return removeDaemonLockFile()
+}

--- a/cmd/dev-console/daemon_lifecycle_policy_test.go
+++ b/cmd/dev-console/daemon_lifecycle_policy_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/state"
+)
+
+func writeDaemonPIDFileForTest(t *testing.T, port int, pid int) {
+	t.Helper()
+	path := pidFilePath(port)
+	if path == "" {
+		t.Fatal("pidFilePath returned empty path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func readLifecycleEventsFromLogFile(t *testing.T, logFile string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", logFile, err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	events := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("json.Unmarshal(log line) error = %v, line=%q", err, line)
+		}
+		if event, _ := entry["event"].(string); event != "" {
+			events = append(events, entry)
+		}
+	}
+	return events
+}
+
+func TestEnforceDaemonStartupPolicy_DefaultTakeover(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv(state.StateDirEnv, stateRoot)
+
+	const existingPID = 42424
+	const existingPort = 7890
+	const requestedPort = 7891
+
+	if err := writeDaemonLockFile(daemonLockRecord{
+		PID:      existingPID,
+		Port:     existingPort,
+		StateDir: stateRoot,
+		Version:  "0.7.7",
+	}); err != nil {
+		t.Fatalf("writeDaemonLockFile() error = %v", err)
+	}
+	writeDaemonPIDFileForTest(t, existingPort, existingPID)
+
+	logFile := filepath.Join(t.TempDir(), "daemon-policy.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	oldIsAlive := daemonIsProcessAlive
+	oldTryShutdown := daemonTryShutdown
+	oldWaitRelease := daemonWaitForPortRelease
+	oldTerminate := daemonTerminatePID
+	defer func() {
+		daemonIsProcessAlive = oldIsAlive
+		daemonTryShutdown = oldTryShutdown
+		daemonWaitForPortRelease = oldWaitRelease
+		daemonTerminatePID = oldTerminate
+	}()
+
+	daemonIsProcessAlive = func(pid int) bool { return pid == existingPID }
+	daemonTryShutdown = func(port int) bool { return port == existingPort }
+	waitCalls := 0
+	daemonWaitForPortRelease = func(port int, _ time.Duration) bool {
+		if port != existingPort {
+			return false
+		}
+		waitCalls++
+		return waitCalls >= 2
+	}
+	terminatedPIDs := make([]int, 0, 2)
+	daemonTerminatePID = func(pid int, _ bool) {
+		terminatedPIDs = append(terminatedPIDs, pid)
+	}
+
+	if err := enforceDaemonStartupPolicy(server, requestedPort, daemonLaunchOptions{}); err != nil {
+		t.Fatalf("enforceDaemonStartupPolicy() error = %v", err)
+	}
+
+	if len(terminatedPIDs) != 1 || terminatedPIDs[0] != existingPID {
+		t.Fatalf("terminate calls = %v, want [%d]", terminatedPIDs, existingPID)
+	}
+
+	lockAfter, err := readDaemonLockFile()
+	if err != nil {
+		t.Fatalf("readDaemonLockFile() error = %v", err)
+	}
+	if lockAfter != nil {
+		t.Fatalf("daemon lock should be removed after takeover, got %+v", *lockAfter)
+	}
+
+	if _, err := os.Stat(pidFilePath(existingPort)); !os.IsNotExist(err) {
+		t.Fatalf("pid file for existing port should be removed, stat err = %v", err)
+	}
+
+	server.shutdownAsyncLogger(2 * time.Second)
+	events := readLifecycleEventsFromLogFile(t, logFile)
+	var takeover map[string]any
+	for _, evt := range events {
+		if evtName, _ := evt["event"].(string); evtName == "daemon_takeover" {
+			takeover = evt
+			break
+		}
+	}
+	if takeover == nil {
+		t.Fatal("expected daemon_takeover lifecycle event")
+	}
+	if got, _ := takeover["existing_pid"].(float64); int(got) != existingPID {
+		t.Fatalf("daemon_takeover existing_pid = %v, want %d", takeover["existing_pid"], existingPID)
+	}
+	if got, _ := takeover["existing_port"].(float64); int(got) != existingPort {
+		t.Fatalf("daemon_takeover existing_port = %v, want %d", takeover["existing_port"], existingPort)
+	}
+	if got, _ := takeover["new_pid"].(float64); int(got) != os.Getpid() {
+		t.Fatalf("daemon_takeover new_pid = %v, want %d", takeover["new_pid"], os.Getpid())
+	}
+	if takeoverFlag, _ := takeover["takeover"].(bool); !takeoverFlag {
+		t.Fatalf("daemon_takeover takeover = %v, want true", takeover["takeover"])
+	}
+	if stateDir, _ := takeover["state_dir"].(string); stateDir != stateRoot {
+		t.Fatalf("daemon_takeover state_dir = %q, want %q", stateDir, stateRoot)
+	}
+}
+
+func TestEnforceDaemonStartupPolicy_SafetyGuardRejectsPIDMismatch(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv(state.StateDirEnv, stateRoot)
+
+	const existingPID = 51515
+	const existingPort = 7900
+
+	if err := writeDaemonLockFile(daemonLockRecord{
+		PID:      existingPID,
+		Port:     existingPort,
+		StateDir: stateRoot,
+		Version:  "0.7.7",
+	}); err != nil {
+		t.Fatalf("writeDaemonLockFile() error = %v", err)
+	}
+
+	writeDaemonPIDFileForTest(t, existingPort, existingPID+1)
+
+	logFile := filepath.Join(t.TempDir(), "daemon-policy-mismatch.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer server.shutdownAsyncLogger(2 * time.Second)
+
+	oldIsAlive := daemonIsProcessAlive
+	oldTerminate := daemonTerminatePID
+	defer func() {
+		daemonIsProcessAlive = oldIsAlive
+		daemonTerminatePID = oldTerminate
+	}()
+	daemonIsProcessAlive = func(pid int) bool { return pid == existingPID }
+	terminated := false
+	daemonTerminatePID = func(_ int, _ bool) { terminated = true }
+
+	err = enforceDaemonStartupPolicy(server, 7901, daemonLaunchOptions{})
+	if err == nil {
+		t.Fatal("enforceDaemonStartupPolicy() error = nil, want ownership mismatch error")
+	}
+	if !strings.Contains(err.Error(), "ownership mismatch") {
+		t.Fatalf("error = %q, want ownership mismatch guidance", err.Error())
+	}
+	if terminated {
+		t.Fatal("safety guard should not terminate process on PID mismatch")
+	}
+}
+
+func TestEnforceDaemonStartupPolicy_ParallelRequiresIsolatedStateDir(t *testing.T) {
+	stateRoot := t.TempDir()
+	t.Setenv(state.StateDirEnv, stateRoot)
+
+	if err := writeDaemonLockFile(daemonLockRecord{
+		PID:      30303,
+		Port:     7920,
+		StateDir: stateRoot,
+		Version:  "0.7.7",
+	}); err != nil {
+		t.Fatalf("writeDaemonLockFile() error = %v", err)
+	}
+
+	logFile := filepath.Join(t.TempDir(), "daemon-policy-parallel.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer server.shutdownAsyncLogger(2 * time.Second)
+
+	oldIsAlive := daemonIsProcessAlive
+	oldTerminate := daemonTerminatePID
+	oldTryShutdown := daemonTryShutdown
+	defer func() {
+		daemonIsProcessAlive = oldIsAlive
+		daemonTerminatePID = oldTerminate
+		daemonTryShutdown = oldTryShutdown
+	}()
+	daemonIsProcessAlive = func(pid int) bool { return pid == 30303 }
+	terminated := false
+	shutdownCalled := false
+	daemonTerminatePID = func(_ int, _ bool) { terminated = true }
+	daemonTryShutdown = func(_ int) bool {
+		shutdownCalled = true
+		return false
+	}
+
+	err = enforceDaemonStartupPolicy(server, 7921, daemonLaunchOptions{Parallel: true})
+	if err == nil {
+		t.Fatal("enforceDaemonStartupPolicy() error = nil, want isolated state-dir error")
+	}
+	if !strings.Contains(err.Error(), "isolated --state-dir") {
+		t.Fatalf("error = %q, want isolated state-dir guidance", err.Error())
+	}
+	if terminated || shutdownCalled {
+		t.Fatalf("parallel mode should not takeover/kill existing daemon; terminated=%v shutdownCalled=%v", terminated, shutdownCalled)
+	}
+}

--- a/cmd/dev-console/main.go
+++ b/cmd/dev-console/main.go
@@ -379,7 +379,7 @@ func dispatchMode(server *Server, cfg *serverConfig) {
 	switch mode {
 	case modeDaemon:
 		server.logLifecycle("daemon_mode_start", cfg.port, nil)
-		if err := runMCPMode(server, cfg.port, cfg.apiKey); err != nil {
+		if err := runMCPMode(server, cfg.port, cfg.apiKey, daemonLaunchOptions{Parallel: cfg.parallelMode}); err != nil {
 			diagPath := appendExitDiagnostic("daemon_start_failed", map[string]any{
 				"port":  cfg.port,
 				"error": err.Error(),
@@ -455,6 +455,7 @@ Options:
   --port <number>        Port to listen on (default: 7890)
   --log-file <path>      Path to log file (default: in runtime state dir)
   --state-dir <path>     Directory for runtime state (default: OS app state dir)
+  --parallel             Opt-in parallel mode (isolated state dir, no takeover)
   --max-entries <number> Max log entries before rotation (default: 1000)
   --stop                 Stop the running server on the specified port
   --force                Force kill ALL running gasoline daemons (used during install)

--- a/cmd/dev-console/main_connection_coverage_test.go
+++ b/cmd/dev-console/main_connection_coverage_test.go
@@ -196,7 +196,7 @@ func TestRunMCPModePortConflictRemovesStalePID(t *testing.T) {
 	}
 	defer server.shutdownAsyncLogger(2 * time.Second)
 
-	err = runMCPMode(server, port, "")
+	err = runMCPMode(server, port, "", daemonLaunchOptions{})
 	if err == nil || !strings.Contains(err.Error(), "already in use") {
 		t.Fatalf("runMCPMode() error = %v, want port conflict", err)
 	}
@@ -226,7 +226,7 @@ func TestRunMCPModeGracefulSignalShutdown(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runMCPMode(server, port, "")
+		done <- runMCPMode(server, port, "", daemonLaunchOptions{})
 	}()
 
 	deadline := time.Now().Add(5 * time.Second)

--- a/cmd/dev-console/main_flags_compat_test.go
+++ b/cmd/dev-console/main_flags_compat_test.go
@@ -50,3 +50,24 @@ func TestRegisterFlagsAcceptsPersistFalse(t *testing.T) {
 		t.Fatalf("registerFlags() maxEntries = %v, want 777", parsed.maxEntries)
 	}
 }
+
+func TestRegisterFlagsAcceptsParallel(t *testing.T) {
+	originalArgs := os.Args
+	originalCommandLine := flag.CommandLine
+	defer func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalCommandLine
+	}()
+
+	flag.CommandLine = flag.NewFlagSet(originalArgs[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = []string{originalArgs[0], "--parallel"}
+
+	parsed := registerFlags()
+	if parsed == nil {
+		t.Fatal("registerFlags() returned nil")
+	}
+	if parsed.parallelMode == nil || !*parsed.parallelMode {
+		t.Fatalf("registerFlags() parallelMode = %v, want true", parsed.parallelMode)
+	}
+}

--- a/cmd/dev-console/main_io_unit_test.go
+++ b/cmd/dev-console/main_io_unit_test.go
@@ -40,6 +40,9 @@ func TestPrintHelpIncludesKeySections(t *testing.T) {
 	if !strings.Contains(output, "--state-dir <path>") {
 		t.Fatalf("help output missing --state-dir docs")
 	}
+	if !strings.Contains(output, "--parallel") {
+		t.Fatalf("help output missing --parallel docs")
+	}
 	if !strings.Contains(output, "CLI Mode (direct tool access):") {
 		t.Fatalf("help output missing CLI mode section")
 	}


### PR DESCRIPTION
## Summary
- add state-dir scoped daemon lock metadata (`run/daemon.lock.json`) and startup policy enforcement
- default `--daemon` startup now performs controlled takeover of an existing daemon in the same state-dir
- add safety guard: refuse takeover when lock metadata and state-dir pid ownership do not match
- add opt-in `--parallel` mode with isolated state-dir auto-generation when `--state-dir` is not provided
- persist/remove daemon lock on startup/shutdown and surface lifecycle takeover logs with required fields
- update CLI help and flag coverage tests for `--parallel`

## Testing
- GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-modcache go test ./cmd/dev-console -run 'TestEnforceDaemonStartupPolicy_|TestApplyParallelModeStateDir_|TestRegisterFlagsAcceptsParallel|TestPrintHelpIncludesKeySections|TestRunMCPMode|TestConnectWithRetries|TestHandleMCPConnection' -count=1
- GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-modcache go test ./cmd/dev-console -count=1

Closes #213