### PR TITLE
Docs: add CSP-safe automation playbook to configure tutorial/examples

### DIFF
--- a/cmd/dev-console/tools_async.go
+++ b/cmd/dev-console/tools_async.go
@@ -497,7 +497,7 @@ func annotateCSPFailure(responseData map[string]any, cmdError string, result jso
 		}
 	}
 	if _, exists := responseData["retry"]; !exists {
-		responseData["retry"] = "This page blocks script execution (CSP/restricted context). Use interact navigate/refresh/back/forward/new_tab to move to another page."
+		responseData["retry"] = cspRetryNavigationGuidance
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `csp_fallback_playbook` section to `configure({what:"tutorial"|"examples"})`
- document explicit CSP detection signals and fallback command sequence
- add a CSP scenario to the deterministic safe automation loop
- reuse a shared retry guidance constant so docs and runtime error hints stay aligned

## Details
This adds concrete, LLM-facing guidance for CSP-constrained pages where `execute_js` can fail:
- detection signals include:
  - `error=csp_blocked_all_worlds`
  - `failure_cause=csp`
  - `csp_blocked=true`
- explicit fallback status pattern:
  - `Error: MAIN world execution FAILED. Fallback in ISOLATED is SUCCESS|ERROR`
- exact retry guidance is surfaced verbatim in the tutorial payload and matches command-result CSP annotation.

Also extends `safe_automation_loop.scenarios` with `csp_restricted_page` showing:
- detect CSP failure via `observe(command_result)`
- pivot to `list_interactive` + scoped DOM primitives
- verify post-condition with `observe(screenshot)`

Closes #223.

## Validation
- `go test ./cmd/dev-console -run 'TestToolsConfigureTutorial_(IncludesSafeAutomationLoop|IncludesCSPFallbackPlaybook)|TestCommandResult_ErrorStatusCSPFailureIncludesRetryHint' -count=1`
- `go test ./cmd/dev-console -run 'TestToolsConfigureTutorial_' -count=1`
