### PR TITLE
Docs/Reliability: add interact failure recovery playbooks and retry alignment

### DIFF
--- a/cmd/dev-console/interact_failure_playbooks.go
+++ b/cmd/dev-console/interact_failure_playbooks.go
@@ -1,0 +1,91 @@
+package main
+
+import "strings"
+
+type interactFailurePlaybook struct {
+	DetectionSignal        string
+	OrderedRecoverySteps   []string
+	StopAndReportCondition string
+	RetrySuggestion        string
+}
+
+var interactFailurePlaybooks = map[string]interactFailurePlaybook{
+	"element_not_found": {
+		DetectionSignal: "error=element_not_found",
+		OrderedRecoverySteps: []string{
+			`Run interact({what:"list_interactive", scope_selector:"<container>"}) to refresh candidates.`,
+			`Retry action using element_id/index from scoped list_interactive results instead of a broad selector.`,
+			`If still empty, widen or remove scope_selector once and retry.`,
+		},
+		StopAndReportCondition: "If one scoped refresh and one scope-widening retry both fail, stop and report evidence (command_result + screenshot + scoped list_interactive output).",
+		RetrySuggestion:        `Recovery: run list_interactive in the intended scope, retry with element_id/index, then widen scope_selector once if needed.`,
+	},
+	"ambiguous_target": {
+		DetectionSignal: "error=ambiguous_target",
+		OrderedRecoverySteps: []string{
+			`Add scope_selector or scope_rect to narrow candidates to the active container.`,
+			`Use list_interactive in that scope and choose element_id/index instead of global text selector.`,
+			`Retry the action with the resolved element_id/index.`,
+		},
+		StopAndReportCondition: "If ambiguity persists after one scoped retry, stop and report candidate list evidence instead of repeated blind clicks.",
+		RetrySuggestion:        `Recovery: add scope_selector/scope_rect, run list_interactive, then retry using element_id/index.`,
+	},
+	"stale_element_id": {
+		DetectionSignal: "error=stale_element_id",
+		OrderedRecoverySteps: []string{
+			`Refresh handles with interact({what:"list_interactive", ...same scope...}).`,
+			`Reacquire a new element_id (or index) for the same target label/role.`,
+			`Retry the action with the refreshed element_id.`,
+		},
+		StopAndReportCondition: "If refreshed handles immediately go stale again, stop and report evidence (likely DOM churn/rerender race).",
+		RetrySuggestion:        `Recovery: refresh list_interactive, reacquire element_id, and retry once with the new handle.`,
+	},
+	"scope_not_found": {
+		DetectionSignal: "error=scope_not_found",
+		OrderedRecoverySteps: []string{
+			`Try a fallback scope_selector that matches an active dialog/container on the current page.`,
+			`If selector scoping fails, use scope_rect (annotation region) or frame targeting when content is embedded.`,
+			`Re-run list_interactive in the recovered scope before mutating actions.`,
+		},
+		StopAndReportCondition: "If selector scope, scope_rect, and frame fallback all fail, stop and report evidence (page screenshot + available frames/selectors).",
+		RetrySuggestion:        `Recovery: adjust scope_selector, then try scope_rect/frame fallback, then rerun list_interactive before retrying action.`,
+	},
+}
+
+func tutorialFailureRecoveryPlaybooks() map[string]any {
+	out := make(map[string]any, len(interactFailurePlaybooks))
+	for code, playbook := range interactFailurePlaybooks {
+		out[code] = map[string]any{
+			"detection_signal":          playbook.DetectionSignal,
+			"ordered_recovery_steps":    playbook.OrderedRecoverySteps,
+			"stop_and_report_condition": playbook.StopAndReportCondition,
+			"retry_guidance":            playbook.RetrySuggestion,
+		}
+	}
+	return out
+}
+
+func lookupInteractFailurePlaybook(rawCode string) (string, interactFailurePlaybook, bool) {
+	code := normalizeInteractFailureCode(rawCode)
+	if code == "" {
+		return "", interactFailurePlaybook{}, false
+	}
+	playbook, ok := interactFailurePlaybooks[code]
+	if !ok {
+		return "", interactFailurePlaybook{}, false
+	}
+	return code, playbook, true
+}
+
+func normalizeInteractFailureCode(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	if v == "" {
+		return ""
+	}
+	for code := range interactFailurePlaybooks {
+		if v == code || strings.Contains(v, code) {
+			return code
+		}
+	}
+	return ""
+}

--- a/cmd/dev-console/playbooks.go
+++ b/cmd/dev-console/playbooks.go
@@ -309,6 +309,22 @@ var quickstartContent = `# Gasoline MCP Quickstart
 
 ## 10. Stop Recording
 {"tool":"configure","arguments":{"what":"recording_stop","recording_id":"..."}}
+
+## 11. Interact Failure Recovery (Quick)
+
+- element_not_found
+  - Run interact({what:"list_interactive", scope_selector:"<container>"}) and retry with element_id/index.
+- ambiguous_target
+  - Add scope_selector/scope_rect, refresh list_interactive, then retry with element_id/index.
+- stale_element_id
+  - Refresh list_interactive in same scope, reacquire element_id, retry once.
+- scope_not_found
+  - Fallback from scope_selector to scope_rect/frame, then rerun list_interactive.
+
+Stop and report evidence when recovery does not converge after one scoped retry cycle:
+- observe({what:"command_result", correlation_id:"..."})
+- observe({what:"screenshot"})
+- interact({what:"list_interactive", scope_selector:"<best-known-scope>"})
 `
 
 // demoScripts maps demo names to markdown demo script content.

--- a/cmd/dev-console/playbooks_content_test.go
+++ b/cmd/dev-console/playbooks_content_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQuickstartContent_IncludesInteractFailureRecoveryExamples(t *testing.T) {
+	t.Parallel()
+
+	uri, text, ok := resolveResourceContent("gasoline://quickstart")
+	if !ok {
+		t.Fatal("resolveResourceContent(gasoline://quickstart) should succeed")
+	}
+	if uri != "gasoline://quickstart" {
+		t.Fatalf("canonical uri = %q, want gasoline://quickstart", uri)
+	}
+
+	requiredTokens := []string{
+		"element_not_found",
+		"ambiguous_target",
+		"stale_element_id",
+		"scope_not_found",
+		"Stop and report evidence",
+	}
+	for _, token := range requiredTokens {
+		if !strings.Contains(strings.ToLower(text), strings.ToLower(token)) {
+			t.Fatalf("quickstart missing token %q", token)
+		}
+	}
+}

--- a/cmd/dev-console/tools_configure_tutorial.go
+++ b/cmd/dev-console/tools_configure_tutorial.go
@@ -25,15 +25,16 @@ func (h *ToolHandler) toolConfigureTutorial(req JSONRPCRequest, args json.RawMes
 
 	context := h.tutorialContext()
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Tutorial", map[string]any{
-		"status":                "ok",
-		"mode":                  mode,
-		"message":               "Quickstart snippets and context-aware guidance",
-		"context":               context,
-		"issues":                tutorialIssues(context),
-		"next_steps":            tutorialNextSteps(context),
-		"snippets":              tutorialSnippets(),
-		"safe_automation_loop":  tutorialSafeAutomationLoop(),
-		"csp_fallback_playbook": tutorialCSPFallbackPlaybook(),
+		"status":                     "ok",
+		"mode":                       mode,
+		"message":                    "Quickstart snippets and context-aware guidance",
+		"context":                    context,
+		"issues":                     tutorialIssues(context),
+		"next_steps":                 tutorialNextSteps(context),
+		"snippets":                   tutorialSnippets(),
+		"safe_automation_loop":       tutorialSafeAutomationLoop(),
+		"csp_fallback_playbook":      tutorialCSPFallbackPlaybook(),
+		"failure_recovery_playbooks": tutorialFailureRecoveryPlaybooks(),
 		"best_practices": []string{
 			"Start with observe to gather evidence before automating actions",
 			"Use configure tutorial/examples and describe_capabilities when argument shape is unclear",


### PR DESCRIPTION
## Summary
- add a shared interact failure recovery playbook model for:
  - `element_not_found`
  - `ambiguous_target`
  - `stale_element_id`
  - `scope_not_found`
- publish these playbooks in `configure tutorial/examples` under `failure_recovery_playbooks`
- add quickstart examples for all four failure classes plus explicit stop-and-report evidence condition
- align `observe(command_result)` retry guidance with playbook steps for these errors
- extend smoke module 05 with concrete recovery scenarios for each class

## What changed
### Runtime guidance alignment
`tools_async` now enriches terminal interact errors with deterministic retry guidance when failure code matches a known playbook class. Guidance is only injected if retry text is absent, preserving higher-priority retries (e.g. CSP).

### Tutorial/docs
- `configure tutorial/examples` now includes `failure_recovery_playbooks` with:
  - detection signal
  - ordered recovery steps
  - stop-and-report condition
  - retry guidance
- `gasoline://quickstart` now includes a quick failure-recovery section covering all four classes and evidence stop condition.

### Smoke coverage
`scripts/smoke-tests/05-interact-dom.sh` now has 4 additional tests (5.16–5.19) that trigger each error class and verify a successful recovery path.

Closes #224.

## Validation
- `bash -n scripts/smoke-tests/05-interact-dom.sh`
- `go test ./cmd/dev-console -run 'TestToolsConfigureTutorial_(IncludesFailureRecoveryPlaybooks|IncludesCSPFallbackPlaybook)|TestQuickstartContent_IncludesInteractFailureRecoveryExamples|TestCommandResult_(InteractFailureCodesIncludeRecoveryRetryGuidance|ErrorStatusCSPFailureIncludesRetryHint)' -count=1`
