### PR TITLE
QA: add proof-first smoke module for ambiguous/CSP/social flows

### DIFF
--- a/docs/testing/proof-first-smoke-nightly.md
+++ b/docs/testing/proof-first-smoke-nightly.md
@@ -1,0 +1,69 @@
+# Proof-First Smoke (Nightly)
+
+This document describes how to run the proof-first smoke module (`28-proof-first.sh`) that validates ambiguous UI handling, CSP fallback behavior, and optional real social composer flows.
+
+## Scope
+
+The proof-first module checks:
+
+1. Ambiguous selector flow: broad selector fails (`ambiguous_target`), scoped recovery succeeds.
+2. CSP flow: `execute_js` fails on CSP-restricted page, DOM primitive fallback succeeds.
+3. Optional LinkedIn composer flow: open, type, submit, verify close cue.
+4. Optional Facebook composer flow: open, type, submit, verify close cue.
+
+Each test captures reproducible evidence:
+
+- screenshot artifacts (before/after checkpoints)
+- command correlation IDs
+
+Artifacts are written to:
+
+- `~/.gasoline/smoke-results/proof-first-artifacts.log`
+- screenshot paths returned by `observe({what:"screenshot"})`
+
+## Preconditions
+
+Required:
+
+- Extension connected and tracking a tab.
+- AI Web Pilot enabled.
+- Smoke daemon reachable (default `localhost:7890`).
+
+Optional social flows:
+
+- Logged-in browser session for the target site(s).
+- `SMOKE_SOCIAL=1`.
+- `SMOKE_LINKEDIN_URL` and/or `SMOKE_FACEBOOK_URL`.
+
+## Run Modes
+
+Run only proof-first module:
+
+```bash
+SMOKE_PROOF_FIRST=1 ./smoketest --only 28
+```
+
+Run proof-first with social flows:
+
+```bash
+SMOKE_PROOF_FIRST=1 \
+SMOKE_SOCIAL=1 \
+SMOKE_LINKEDIN_URL="https://www.linkedin.com/feed/" \
+SMOKE_FACEBOOK_URL="https://www.facebook.com/" \
+SMOKE_SOCIAL_POST_TEXT="This post written with Gasoline MCP" \
+./smoketest --only 28
+```
+
+Override CSP target URL:
+
+```bash
+SMOKE_PROOF_FIRST=1 \
+SMOKE_CSP_URL="https://news.google.com/home?hl=en-US" \
+./smoketest --only 28
+```
+
+## CI/Nightly Recommendation
+
+- Keep module 28 disabled in default PR smoke runs.
+- Enable it in nightly or dedicated QA pipelines with the environment variables above.
+- Treat missing visual checkpoints or missing close cue as test failures.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -34,7 +34,7 @@ while [ $# -gt 0 ]; do
             echo "  13-draw-mode, 15-file-upload, 20-inspect-visual,"
             echo "  21-macro-recording, 22-log-aggregation, 23-doctor-preflight,"
             echo "  24-retryable-errors, 25-action-enrichment, 26-default-upload-dir,"
-            echo "  27-extension-refactor, 30-stability-shutdown"
+            echo "  27-extension-refactor, 28-proof-first, 30-stability-shutdown"
             exit 0
             ;;
         --start-from)
@@ -113,6 +113,7 @@ MODULES=(
     "25-action-enrichment.sh"
     "26-default-upload-dir.sh"
     "27-extension-refactor.sh"
+    "28-proof-first.sh"
     "30-stability-shutdown.sh" # 30 must be last: it kills the daemon
 )
 

--- a/scripts/smoke-tests/28-proof-first.sh
+++ b/scripts/smoke-tests/28-proof-first.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# 28-proof-first.sh — Proof-first smoke validations for ambiguous/CSP/social flows.
+#
+# Preconditions (documented for nightly use):
+# - SMOKE_PROOF_FIRST=1 to enable this module (default: skip entire module)
+# - Pilot + extension connected
+# - Optional social flows:
+#   - SMOKE_SOCIAL=1
+#   - SMOKE_LINKEDIN_URL (e.g. https://www.linkedin.com/feed/)
+#   - SMOKE_FACEBOOK_URL (e.g. https://www.facebook.com/)
+#   - Logged-in session in browser profile used by the extension
+#
+# Artifacts:
+# - Writes screenshot paths and correlation IDs to:
+#   ~/.gasoline/smoke-results/proof-first-artifacts.log
+set -eo pipefail
+
+begin_category "28" "Proof-First Real-World Flows" "4"
+
+PROOF_FIRST_ENABLED="${SMOKE_PROOF_FIRST:-0}"
+PROOF_SOCIAL_ENABLED="${SMOKE_SOCIAL:-0}"
+PROOF_ARTIFACT_FILE="${SMOKE_OUTPUT_DIR}/proof-first-artifacts.log"
+mkdir -p "$(dirname "$PROOF_ARTIFACT_FILE")"
+
+if [ ! -f "$PROOF_ARTIFACT_FILE" ]; then
+    {
+        echo "Proof-First Artifacts — $(date)"
+        echo "======================================"
+    } > "$PROOF_ARTIFACT_FILE"
+fi
+
+record_proof_artifact() {
+    local key="$1"
+    local value="$2"
+    local line
+    line="$(date +%Y-%m-%dT%H:%M:%S%z) | test=${CURRENT_TEST_ID:-unknown} | ${key}=${value}"
+    echo "$line" >> "$PROOF_ARTIFACT_FILE"
+    echo "  [artifact] ${key}: ${value}"
+}
+
+record_last_corr_id() {
+    local corr
+    corr=$(echo "$INTERACT_RESULT" | grep -oE '"correlation_id":\s*"[^"]+"' | head -1 | sed -E 's/.*"correlation_id":\s*"([^"]+)".*/\1/' || true)
+    if [ -n "$corr" ]; then
+        record_proof_artifact "corr_id" "$corr"
+    fi
+}
+
+capture_screenshot_artifact() {
+    local label="$1"
+    local screenshot_response
+    screenshot_response=$(call_tool "observe" '{"what":"screenshot"}')
+    local text
+    text=$(extract_content_text "$screenshot_response")
+    if [ -z "$text" ] && [ -n "$screenshot_response" ]; then
+        text="$screenshot_response"
+    fi
+    local screenshot_path
+    screenshot_path=$(echo "$text" | python3 -c 'import sys,json; t=sys.stdin.read(); i=t.find("{"); print(json.loads(t[i:]).get("path","") if i>=0 else "")' 2>/dev/null || true)
+    if [ -n "$screenshot_path" ]; then
+        record_proof_artifact "screenshot_${label}" "$screenshot_path"
+    else
+        record_proof_artifact "screenshot_${label}" "missing_path"
+    fi
+}
+
+module_enabled_or_skip() {
+    if [ "$PROOF_FIRST_ENABLED" != "1" ]; then
+        skip "Set SMOKE_PROOF_FIRST=1 to enable proof-first flows."
+        return 1
+    fi
+    if [ "$PILOT_ENABLED" != "true" ]; then
+        skip "Pilot not enabled."
+        return 1
+    fi
+    return 0
+}
+
+# ── Test 28.1: Ambiguous selector proof + recovery ───────────────────────────
+begin_test "28.1" "[BROWSER] Proof-first ambiguous selector flow" \
+    "Broad selector must fail with ambiguous_target, then scoped retry must succeed with screenshot checkpoints" \
+    "Tests: real state transition proof + artifacts (screenshots + trace IDs)"
+
+run_test_28_1() {
+    module_enabled_or_skip || return
+
+    interact_and_wait "navigate" '{"action":"navigate","url":"https://example.com","reason":"Proof-first ambiguous flow baseline"}' 20
+    record_last_corr_id
+
+    interact_and_wait "execute_js" '{"action":"execute_js","reason":"Inject ambiguous controls","script":"(function(){var old=document.getElementById(\"pf-ambig-root\"); if(old) old.remove(); var root=document.createElement(\"div\"); root.id=\"pf-ambig-root\"; root.innerHTML=\"<div id=\\\"pf-ambig-a\\\"><button class=\\\"pf-ambig-btn\\\" type=\\\"button\\\">Post</button></div><div id=\\\"pf-ambig-b\\\"><button class=\\\"pf-ambig-btn\\\" type=\\\"button\\\">Post</button></div>\"; document.body.appendChild(root); return \"ambig-ready\";})()"}'
+    record_last_corr_id
+    capture_screenshot_artifact "ambiguous_before"
+
+    interact_and_wait "click" '{"action":"click","selector":".pf-ambig-btn","reason":"Proof-first trigger ambiguous target"}'
+    record_last_corr_id
+    if ! echo "$INTERACT_RESULT" | grep -qi "ambiguous_target"; then
+        fail "Expected ambiguous_target for broad selector. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    interact_and_wait "click" '{"action":"click","selector":".pf-ambig-btn","scope_selector":"#pf-ambig-a","reason":"Proof-first scoped recovery"}'
+    record_last_corr_id
+    capture_screenshot_artifact "ambiguous_after"
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "Scoped recovery failed after ambiguous_target. Result: $(truncate "$INTERACT_RESULT" 240)"
+    else
+        pass "Ambiguous flow proved: broad selector failed, scoped recovery succeeded, artifacts captured."
+    fi
+}
+run_test_28_1
+
+# ── Test 28.2: CSP execute_js failure + DOM fallback proof ──────────────────
+begin_test "28.2" "[BROWSER] Proof-first CSP fallback flow" \
+    "execute_js must fail on CSP page, DOM primitive fallback must still succeed, with screenshot checkpoints" \
+    "Tests: CSP regression proof with artifacts"
+
+run_test_28_2() {
+    module_enabled_or_skip || return
+
+    local csp_url="${SMOKE_CSP_URL:-https://news.google.com/home?hl=en-US}"
+    interact_and_wait "navigate" "{\"action\":\"navigate\",\"url\":\"$csp_url\",\"reason\":\"Proof-first CSP target\"}" 30
+    record_last_corr_id
+    capture_screenshot_artifact "csp_before"
+
+    interact_and_wait "execute_js" '{"action":"execute_js","world":"main","reason":"Expect CSP block in MAIN world","script":"document.title"}'
+    record_last_corr_id
+    if ! echo "$INTERACT_RESULT" | grep -qi "csp\|content security policy\|trusted type\|unsafe-eval"; then
+        skip "CSP block not reproducible on configured URL ($csp_url). Result: $(truncate "$INTERACT_RESULT" 200)"
+        return
+    fi
+
+    interact_and_wait "list_interactive" '{"action":"list_interactive","selector":"main","reason":"CSP-safe fallback via DOM primitive"}'
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "DOM fallback failed after CSP execute_js failure. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    local elem_count
+    elem_count=$(echo "$INTERACT_RESULT" | python3 -c '
+import sys, json
+t = sys.stdin.read()
+i = t.find("{")
+if i < 0:
+    print(0); raise SystemExit
+try:
+    data = json.loads(t[i:])
+except Exception:
+    print(0); raise SystemExit
+elems = data.get("elements", [])
+print(len(elems) if isinstance(elems, list) else 0)
+' 2>/dev/null || echo "0")
+    capture_screenshot_artifact "csp_after"
+    if [ "${elem_count:-0}" -le 0 ] 2>/dev/null; then
+        fail "DOM fallback returned no elements after CSP failure. Result: $(truncate "$INTERACT_RESULT" 240)"
+    else
+        pass "CSP flow proved: execute_js blocked, DOM fallback succeeded with ${elem_count} elements and artifacts."
+    fi
+}
+run_test_28_2
+
+# ── Test 28.3: LinkedIn composer proof (optional) ───────────────────────────
+begin_test "28.3" "[INTERACTIVE - BROWSER] Proof-first LinkedIn composer flow (optional)" \
+    "Open composer, type, submit, verify dialog closes, with before/after screenshots" \
+    "Tests: real social workflow proof; requires logged-in preconditions"
+
+run_test_28_3() {
+    module_enabled_or_skip || return
+
+    if [ "$PROOF_SOCIAL_ENABLED" != "1" ]; then
+        skip "Set SMOKE_SOCIAL=1 to run social composer flows."
+        return
+    fi
+    local linkedin_url="${SMOKE_LINKEDIN_URL:-}"
+    if [ -z "$linkedin_url" ]; then
+        skip "SMOKE_LINKEDIN_URL is not set."
+        return
+    fi
+
+    interact_and_wait "navigate" "{\"action\":\"navigate\",\"url\":\"$linkedin_url\",\"reason\":\"Proof-first LinkedIn baseline\"}" 30
+    record_last_corr_id
+    capture_screenshot_artifact "linkedin_before"
+
+    interact_and_wait "open_composer" '{"action":"open_composer","reason":"Open LinkedIn composer"}' 30
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "LinkedIn open_composer failed. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    local post_text="${SMOKE_SOCIAL_POST_TEXT:-This post written with Gasoline MCP}"
+    local post_text_json
+    post_text_json=$(printf '%s' "$post_text" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+    interact_and_wait "type" "{\"action\":\"type\",\"selector\":\"[role='dialog'] [contenteditable='true']\",\"text\":${post_text_json},\"clear\":true,\"reason\":\"Type LinkedIn post\"}" 30
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "LinkedIn type failed. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    interact_and_wait "submit_active_composer" '{"action":"submit_active_composer","reason":"Submit LinkedIn post"}' 40
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "LinkedIn submit_active_composer failed. Result: $(truncate "$INTERACT_RESULT" 260)"
+        return
+    fi
+
+    sleep 2
+    interact_and_wait "list_interactive" '{"action":"list_interactive","selector":"[role=\"dialog\"][aria-modal=\"true\"]","reason":"Verify LinkedIn composer closed"}'
+    record_last_corr_id
+    capture_screenshot_artifact "linkedin_after"
+
+    if echo "$INTERACT_RESULT" | grep -qi "scope_not_found\|elements\":\\[\\]"; then
+        pass "LinkedIn proof flow succeeded: composer submitted and dialog appears closed."
+    else
+        fail "LinkedIn composer close/success cue not confirmed. Result: $(truncate "$INTERACT_RESULT" 260)"
+    fi
+}
+run_test_28_3
+
+# ── Test 28.4: Facebook composer proof (optional) ───────────────────────────
+begin_test "28.4" "[INTERACTIVE - BROWSER] Proof-first Facebook composer flow (optional)" \
+    "Open composer, type, submit, verify dialog closes, with before/after screenshots" \
+    "Tests: real social workflow proof; requires logged-in preconditions"
+
+run_test_28_4() {
+    module_enabled_or_skip || return
+
+    if [ "$PROOF_SOCIAL_ENABLED" != "1" ]; then
+        skip "Set SMOKE_SOCIAL=1 to run social composer flows."
+        return
+    fi
+    local facebook_url="${SMOKE_FACEBOOK_URL:-}"
+    if [ -z "$facebook_url" ]; then
+        skip "SMOKE_FACEBOOK_URL is not set."
+        return
+    fi
+
+    interact_and_wait "navigate" "{\"action\":\"navigate\",\"url\":\"$facebook_url\",\"reason\":\"Proof-first Facebook baseline\"}" 30
+    record_last_corr_id
+    capture_screenshot_artifact "facebook_before"
+
+    interact_and_wait "open_composer" '{"action":"open_composer","reason":"Open Facebook composer"}' 30
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "Facebook open_composer failed. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    local post_text="${SMOKE_SOCIAL_POST_TEXT:-This post written with Gasoline MCP}"
+    local post_text_json
+    post_text_json=$(printf '%s' "$post_text" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+    interact_and_wait "type" "{\"action\":\"type\",\"selector\":\"[role='dialog'] [contenteditable='true']\",\"text\":${post_text_json},\"clear\":true,\"reason\":\"Type Facebook post\"}" 30
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "Facebook type failed. Result: $(truncate "$INTERACT_RESULT" 240)"
+        return
+    fi
+
+    interact_and_wait "submit_active_composer" '{"action":"submit_active_composer","reason":"Submit Facebook post"}' 40
+    record_last_corr_id
+    if echo "$INTERACT_RESULT" | grep -qi "error\|failed"; then
+        fail "Facebook submit_active_composer failed. Result: $(truncate "$INTERACT_RESULT" 260)"
+        return
+    fi
+
+    sleep 2
+    interact_and_wait "list_interactive" '{"action":"list_interactive","selector":"[role=\"dialog\"][aria-modal=\"true\"]","reason":"Verify Facebook composer closed"}'
+    record_last_corr_id
+    capture_screenshot_artifact "facebook_after"
+
+    if echo "$INTERACT_RESULT" | grep -qi "scope_not_found\|elements\":\\[\\]"; then
+        pass "Facebook proof flow succeeded: composer submitted and dialog appears closed."
+    else
+        fail "Facebook composer close/success cue not confirmed. Result: $(truncate "$INTERACT_RESULT" 260)"
+    fi
+}
+run_test_28_4
+
+echo "  Proof-first artifacts file: $PROOF_ARTIFACT_FILE"


### PR DESCRIPTION
## Summary
- add new smoke module: `scripts/smoke-tests/28-proof-first.sh`
- wire module into runner (`scripts/smoke-test.sh`) and help output
- add nightly/precondition runbook: `docs/testing/proof-first-smoke-nightly.md`

## What the new module covers
1. Ambiguous controls proof flow:
   - broad selector expected to fail with `ambiguous_target`
   - scoped retry expected to succeed
   - screenshot checkpoints before/after
   - correlation IDs logged
2. CSP flow:
   - `execute_js` expected to fail on CSP target URL
   - DOM primitive fallback (`list_interactive`) expected to succeed
   - screenshot checkpoints + correlation IDs logged
3. Optional LinkedIn flow (gated):
   - open composer, type, submit, verify close cue
4. Optional Facebook flow (gated):
   - open composer, type, submit, verify close cue

## Artifact output
All proof-first tests emit reproducible artifact metadata to:
- `~/.gasoline/smoke-results/proof-first-artifacts.log`

Includes:
- screenshot paths
- command correlation IDs

## Run gating / preconditions
- Module disabled by default.
- Enable with `SMOKE_PROOF_FIRST=1`.
- Social flows require logged-in session + `SMOKE_SOCIAL=1` and target URLs.
- Preconditions and run modes are documented in `docs/testing/proof-first-smoke-nightly.md`.

Closes #226.

## Validation
- `bash -n scripts/smoke-tests/28-proof-first.sh`
- `bash -n scripts/smoke-test.sh`
- `bash scripts/smoke-test.sh --help`
