### PR TITLE
feat: evidence mode for interact before/after artifacts

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -1131,6 +1131,15 @@
           "description": "Upload escalation timeout in ms",
           "type": "number"
         },
+        "evidence": {
+          "description": "Optional visual evidence capture mode: off (default), on_mutation, always.",
+          "enum": [
+            "off",
+            "on_mutation",
+            "always"
+          ],
+          "type": "string"
+        },
         "fields": {
           "description": "Form fields to fill (fill_form, fill_form_and_submit)",
           "items": {

--- a/cmd/dev-console/tools_async.go
+++ b/cmd/dev-console/tools_async.go
@@ -275,6 +275,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		if strings.Contains(cmd.Error, "No active recording") {
 			responseData["retry"] = "No recording is active. Start one first: interact({what: 'record_start', name: 'my-recording'}) or configure({what: 'recording_start', name: 'my-recording'})"
 		}
+		h.attachEvidencePayload(corrID, responseData)
 		summary := fmt.Sprintf("FAILED — Command %s error: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "expired":
@@ -283,6 +284,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		responseData["message"] = fmt.Sprintf("Command %s expired before the extension could execute it. Error: %s", corrID, cmd.Error)
 		responseData["retry"] = "The browser extension may be disconnected or the page is not active. Check observe with what='pilot' to verify extension status, then retry the command."
 		responseData["hint"] = h.DiagnosticHintString()
+		h.attachEvidencePayload(corrID, responseData)
 		summary := fmt.Sprintf("FAILED — Command %s expired: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "timeout":
@@ -295,6 +297,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		}
 		responseData["retry"] = retryMsg
 		responseData["hint"] = h.DiagnosticHintString()
+		h.attachEvidencePayload(corrID, responseData)
 		summary := fmt.Sprintf("FAILED — Command %s timed out: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	case "cancelled":
@@ -304,6 +307,7 @@ func (h *ToolHandler) formatCommandResult(req JSONRPCRequest, cmd queries.Comman
 		if cmd.Error != "" {
 			responseData["detail"] = cmd.Error
 		}
+		h.attachEvidencePayload(corrID, responseData)
 		summary := fmt.Sprintf("FAILED — Command %s cancelled", corrID)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	default:
@@ -353,10 +357,12 @@ func (h *ToolHandler) formatCompleteCommand(req JSONRPCRequest, cmd queries.Comm
 		responseData["error"] = cmd.Error
 		annotateCSPFailure(responseData, cmd.Error, normalizedResult)
 		annotateInteractFailureRecovery(responseData, cmd.Error, normalizedResult)
+		h.attachEvidencePayload(corrID, responseData)
 		summary := fmt.Sprintf("FAILED — Command %s completed with error: %s", corrID, cmd.Error)
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONErrorResponse(summary, responseData)}
 	}
 
+	h.attachEvidencePayload(corrID, responseData)
 	summary := fmt.Sprintf("Command %s: complete", corrID)
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse(summary, responseData)}
 }

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -187,6 +187,11 @@ type ToolHandler struct {
 	recordInteractMu sync.Mutex
 	recordInteract   interactRecordingState
 
+	// Optional evidence capture state keyed by correlation_id.
+	// Tracks before/after screenshots for interact actions when evidence mode is enabled.
+	evidenceMu        sync.Mutex
+	evidenceByCommand map[string]*commandEvidenceState
+
 	// Module registry for plugin-style tool dispatch (incremental migration).
 	toolModules *toolModuleRegistry
 }
@@ -239,9 +244,10 @@ func newPlaybackSessionsMap() map[string]*capture.PlaybackSession {
 // NewToolHandler creates an MCP handler with composite tool capabilities
 func NewToolHandler(server *Server, capture *capture.Capture) *MCPHandler {
 	handler := &ToolHandler{
-		MCPHandler:       NewMCPHandler(server, version),
-		capture:          capture,
-		playbackSessions: newPlaybackSessionsMap(),
+		MCPHandler:        NewMCPHandler(server, version),
+		capture:           capture,
+		playbackSessions:  newPlaybackSessionsMap(),
+		evidenceByCommand: make(map[string]*commandEvidenceState),
 	}
 
 	// Initialize health metrics

--- a/cmd/dev-console/tools_interact_content.go
+++ b/cmd/dev-console/tools_interact_content.go
@@ -193,6 +193,7 @@ func (h *ToolHandler) handleGetReadable(req JSONRPCRequest, args json.RawMessage
 	}
 
 	correlationID := newCorrelationID("readable")
+	h.armEvidenceForCommand(correlationID, "get_readable", args, req.ClientID)
 	execParams, _ := json.Marshal(map[string]any{
 		"script":     getReadableScript,
 		"timeout_ms": params.TimeoutMs,
@@ -230,6 +231,7 @@ func (h *ToolHandler) handleGetMarkdown(req JSONRPCRequest, args json.RawMessage
 	}
 
 	correlationID := newCorrelationID("markdown")
+	h.armEvidenceForCommand(correlationID, "get_markdown", args, req.ClientID)
 	execParams, _ := json.Marshal(map[string]any{
 		"script":     getMarkdownScript,
 		"timeout_ms": params.TimeoutMs,

--- a/cmd/dev-console/tools_interact_elements.go
+++ b/cmd/dev-console/tools_interact_elements.go
@@ -26,6 +26,7 @@ func (h *ToolHandler) handleListInteractive(req JSONRPCRequest, args json.RawMes
 	args = normalizeDOMActionArgs(args, "list_interactive")
 
 	correlationID := newCorrelationID("dom_list")
+	h.armEvidenceForCommand(correlationID, "list_interactive", args, req.ClientID)
 
 	query := queries.PendingQuery{
 		Type:          "dom_action",

--- a/cmd/dev-console/tools_interact_evidence.go
+++ b/cmd/dev-console/tools_interact_evidence.go
@@ -1,0 +1,371 @@
+// tools_interact_evidence.go — Evidence capture state machine for interact actions.
+//
+// Evidence mode is opt-in per interact call via:
+//
+//	evidence: "off" | "on_mutation" | "always"
+//
+// When enabled, the server captures screenshot artifacts before and after actions
+// and surfaces them in command results as evidence.before/evidence.after.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/queries"
+)
+
+type evidenceMode string
+
+const (
+	evidenceModeOff        evidenceMode = "off"
+	evidenceModeOnMutation evidenceMode = "on_mutation"
+	evidenceModeAlways     evidenceMode = "always"
+)
+
+const (
+	evidenceRetryEnv       = "GASOLINE_EVIDENCE_RETRY_COUNT"
+	evidenceMaxCapturesEnv = "GASOLINE_EVIDENCE_MAX_CAPTURES_PER_COMMAND"
+)
+
+type evidenceShot struct {
+	Path     string
+	Filename string
+	Error    string
+	Attempts int
+}
+
+type commandEvidenceState struct {
+	mode          evidenceMode
+	action        string
+	shouldCapture bool
+	maxCaptures   int
+	clientID      string
+	skipped       string
+
+	before evidenceShot
+	after  evidenceShot
+
+	finalized bool
+	cached    map[string]any
+}
+
+var evidenceCaptureFn = defaultEvidenceCapture
+
+func parseEvidenceMode(args json.RawMessage) (evidenceMode, error) {
+	var params struct {
+		Evidence string `json:"evidence"`
+	}
+	lenientUnmarshal(args, &params)
+	raw := strings.TrimSpace(params.Evidence)
+	if raw == "" {
+		return evidenceModeOff, nil
+	}
+
+	mode := evidenceMode(strings.ToLower(raw))
+	switch mode {
+	case evidenceModeOff, evidenceModeOnMutation, evidenceModeAlways:
+		return mode, nil
+	default:
+		return evidenceModeOff, fmt.Errorf("invalid evidence mode: %s", raw)
+	}
+}
+
+func evidenceMaxCapturesPerCommand() int {
+	return parseBoundedEnvInt(evidenceMaxCapturesEnv, 2, 0, 2)
+}
+
+func evidenceRetryCount() int {
+	return parseBoundedEnvInt(evidenceRetryEnv, 1, 0, 3)
+}
+
+func parseBoundedEnvInt(name string, def, min, max int) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return def
+	}
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
+
+func defaultEvidenceCapture(h *ToolHandler, clientID string) evidenceShot {
+	if h == nil || h.capture == nil {
+		return evidenceShot{Error: "capture_not_initialized"}
+	}
+	enabled, _, _ := h.capture.GetTrackingStatus()
+	if !enabled {
+		return evidenceShot{Error: "no_tracked_tab"}
+	}
+
+	queryID := h.capture.CreatePendingQueryWithTimeout(
+		queries.PendingQuery{
+			Type:   "screenshot",
+			Params: json.RawMessage(`{}`),
+		},
+		12*time.Second,
+		clientID,
+	)
+
+	raw, err := h.capture.WaitForResult(queryID, 12*time.Second)
+	if err != nil {
+		return evidenceShot{Error: "screenshot_timeout: " + err.Error()}
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return evidenceShot{Error: "screenshot_parse_error: " + err.Error()}
+	}
+
+	if errMsg, ok := payload["error"].(string); ok && strings.TrimSpace(errMsg) != "" {
+		return evidenceShot{Error: strings.TrimSpace(errMsg)}
+	}
+
+	path, _ := payload["path"].(string)
+	filename, _ := payload["filename"].(string)
+	path = strings.TrimSpace(path)
+	filename = strings.TrimSpace(filename)
+	if path == "" {
+		return evidenceShot{
+			Filename: filename,
+			Error:    "screenshot_missing_path",
+		}
+	}
+
+	return evidenceShot{
+		Path:     path,
+		Filename: filename,
+	}
+}
+
+func canonicalActionFromInteractArgs(args json.RawMessage) string {
+	var params struct {
+		What   string `json:"what"`
+		Action string `json:"action"`
+	}
+	lenientUnmarshal(args, &params)
+	action := strings.TrimSpace(params.What)
+	if action == "" {
+		action = strings.TrimSpace(params.Action)
+	}
+	return strings.ToLower(action)
+}
+
+func isMutationAction(action string) bool {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case
+		"highlight",
+		"execute_js",
+		"navigate", "refresh", "back", "forward", "new_tab",
+		"click", "type", "select", "check", "paste", "key_press",
+		"set_attribute", "scroll_to", "focus",
+		"open_composer", "submit_active_composer", "confirm_top_dialog", "dismiss_top_overlay",
+		"set_storage", "delete_storage", "clear_storage",
+		"set_cookie", "delete_cookie",
+		"fill_form", "fill_form_and_submit",
+		"upload":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *ToolHandler) captureEvidenceWithRetry(clientID string) evidenceShot {
+	retries := evidenceRetryCount()
+	attempts := retries + 1
+	last := evidenceShot{Error: "evidence_capture_not_attempted"}
+
+	for i := 0; i < attempts; i++ {
+		shot := evidenceCaptureFn(h, clientID)
+		shot.Attempts = i + 1
+		if strings.TrimSpace(shot.Path) != "" {
+			return shot
+		}
+		if strings.TrimSpace(shot.Error) == "" {
+			shot.Error = "evidence_capture_failed"
+		}
+		last = shot
+		if i < attempts-1 {
+			time.Sleep(150 * time.Millisecond)
+		}
+	}
+
+	return last
+}
+
+func (h *ToolHandler) armEvidenceForCommand(correlationID, action string, args json.RawMessage, clientID string) {
+	if h == nil || correlationID == "" {
+		return
+	}
+
+	mode, err := parseEvidenceMode(args)
+	if err != nil {
+		return
+	}
+
+	if mode == evidenceModeOff {
+		h.evidenceMu.Lock()
+		delete(h.evidenceByCommand, correlationID)
+		h.evidenceMu.Unlock()
+		return
+	}
+
+	if action == "" {
+		action = canonicalActionFromInteractArgs(args)
+	}
+
+	maxCaptures := evidenceMaxCapturesPerCommand()
+	state := &commandEvidenceState{
+		mode:        mode,
+		action:      strings.ToLower(strings.TrimSpace(action)),
+		maxCaptures: maxCaptures,
+		clientID:    clientID,
+	}
+
+	switch mode {
+	case evidenceModeAlways:
+		state.shouldCapture = true
+	case evidenceModeOnMutation:
+		state.shouldCapture = isMutationAction(state.action)
+		if !state.shouldCapture {
+			state.skipped = "non_mutating_action"
+		}
+	}
+
+	if state.shouldCapture && state.maxCaptures <= 0 {
+		state.shouldCapture = false
+		state.skipped = "capture_budget_zero"
+	}
+
+	if state.shouldCapture {
+		state.before = h.captureEvidenceWithRetry(clientID)
+	}
+
+	h.evidenceMu.Lock()
+	if h.evidenceByCommand == nil {
+		h.evidenceByCommand = make(map[string]*commandEvidenceState)
+	}
+	h.evidenceByCommand[correlationID] = state
+	h.evidenceMu.Unlock()
+}
+
+func (h *ToolHandler) attachEvidencePayload(correlationID string, responseData map[string]any) {
+	if h == nil || correlationID == "" || responseData == nil {
+		return
+	}
+
+	h.evidenceMu.Lock()
+	state, ok := h.evidenceByCommand[correlationID]
+	if !ok {
+		h.evidenceMu.Unlock()
+		return
+	}
+	if state.finalized {
+		responseData["evidence"] = cloneAnyMap(state.cached)
+		h.evidenceMu.Unlock()
+		return
+	}
+	needsAfter := state.shouldCapture && state.maxCaptures > 1
+	clientID := state.clientID
+	h.evidenceMu.Unlock()
+
+	var after evidenceShot
+	if needsAfter {
+		after = h.captureEvidenceWithRetry(clientID)
+	}
+
+	h.evidenceMu.Lock()
+	state, ok = h.evidenceByCommand[correlationID]
+	if !ok {
+		h.evidenceMu.Unlock()
+		return
+	}
+	if !state.finalized {
+		if needsAfter {
+			state.after = after
+		}
+		state.cached = buildEvidencePayload(state)
+		state.finalized = true
+	}
+	payload := cloneAnyMap(state.cached)
+	h.evidenceMu.Unlock()
+
+	responseData["evidence"] = payload
+}
+
+func buildEvidencePayload(state *commandEvidenceState) map[string]any {
+	if state == nil {
+		return map[string]any{}
+	}
+
+	payload := map[string]any{
+		"mode":   string(state.mode),
+		"action": state.action,
+	}
+
+	if state.before.Path != "" {
+		payload["before"] = state.before.Path
+	}
+	if state.after.Path != "" {
+		payload["after"] = state.after.Path
+	}
+
+	files := map[string]any{}
+	if state.before.Filename != "" {
+		files["before"] = state.before.Filename
+	}
+	if state.after.Filename != "" {
+		files["after"] = state.after.Filename
+	}
+	if len(files) > 0 {
+		payload["filenames"] = files
+	}
+
+	errors := map[string]any{}
+	if state.before.Error != "" {
+		errors["before"] = state.before.Error
+	}
+	if state.after.Error != "" {
+		errors["after"] = state.after.Error
+	}
+	if len(errors) > 0 {
+		payload["errors"] = errors
+	}
+
+	if state.skipped != "" {
+		payload["skipped"] = state.skipped
+	}
+
+	if len(errors) > 0 && (state.before.Path != "" || state.after.Path != "") {
+		payload["partial"] = true
+	}
+
+	return payload
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = cloneAnyMap(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/cmd/dev-console/tools_interact_evidence_test.go
+++ b/cmd/dev-console/tools_interact_evidence_test.go
@@ -1,0 +1,215 @@
+// tools_interact_evidence_test.go — TDD tests for interact evidence capture mode.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCommandResult_EvidenceAlwaysIncludesBeforeAfterPaths(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	calls := 0
+	shots := []evidenceShot{
+		{Path: "/tmp/evidence-before.png"},
+		{Path: "/tmp/evidence-after.png"},
+	}
+	idx := 0
+	orig := evidenceCaptureFn
+	evidenceCaptureFn = func(_ *ToolHandler, _ string) evidenceShot {
+		calls++
+		if idx >= len(shots) {
+			return evidenceShot{Error: "unexpected_extra_capture"}
+		}
+		shot := shots[idx]
+		idx++
+		return shot
+	}
+	t.Cleanup(func() {
+		evidenceCaptureFn = orig
+	})
+
+	result, ok := env.callInteract(t, `{"what":"click","selector":"#btn","background":true,"evidence":"always"}`)
+	if !ok || result.IsError {
+		t.Fatalf("click should queue successfully, got: %s", firstText(result))
+	}
+
+	queued := extractResultJSON(t, result)
+	corrID, _ := queued["correlation_id"].(string)
+	if corrID == "" {
+		t.Fatalf("correlation_id missing in queued response: %v", queued)
+	}
+
+	env.capture.CompleteCommand(corrID, json.RawMessage(`{"success":true}`), "")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 2}
+	args := json.RawMessage(`{"correlation_id":"` + corrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if observe.IsError {
+		t.Fatalf("observe command_result should be success, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	evidence, ok := data["evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("evidence payload missing: %v", data["evidence"])
+	}
+	if evidence["before"] != "/tmp/evidence-before.png" {
+		t.Fatalf("evidence.before = %v, want /tmp/evidence-before.png", evidence["before"])
+	}
+	if evidence["after"] != "/tmp/evidence-after.png" {
+		t.Fatalf("evidence.after = %v, want /tmp/evidence-after.png", evidence["after"])
+	}
+	if partial, _ := evidence["partial"].(bool); partial {
+		t.Fatalf("evidence.partial should be false for successful before+after captures, got %v", evidence["partial"])
+	}
+	if calls != 2 {
+		t.Fatalf("capture calls = %d, want 2 (before+after)", calls)
+	}
+}
+
+func TestCommandResult_EvidenceOnMutationSkipsReadOnlyAction(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	calls := 0
+	orig := evidenceCaptureFn
+	evidenceCaptureFn = func(_ *ToolHandler, _ string) evidenceShot {
+		calls++
+		return evidenceShot{Path: "/tmp/should-not-capture.png"}
+	}
+	t.Cleanup(func() {
+		evidenceCaptureFn = orig
+	})
+
+	result, ok := env.callInteract(t, `{"what":"get_text","selector":"h1","background":true,"evidence":"on_mutation"}`)
+	if !ok || result.IsError {
+		t.Fatalf("get_text should queue successfully, got: %s", firstText(result))
+	}
+
+	queued := extractResultJSON(t, result)
+	corrID, _ := queued["correlation_id"].(string)
+	if corrID == "" {
+		t.Fatalf("correlation_id missing in queued response: %v", queued)
+	}
+
+	env.capture.CompleteCommand(corrID, json.RawMessage(`{"success":true,"value":"headline"}`), "")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 2}
+	args := json.RawMessage(`{"correlation_id":"` + corrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if observe.IsError {
+		t.Fatalf("observe command_result should be success, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	evidenceRaw, hasEvidence := data["evidence"]
+	if !hasEvidence {
+		t.Fatal("evidence should be included when caller explicitly sets evidence mode")
+	}
+	evidence, ok := evidenceRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("evidence payload should be an object, got %T", evidenceRaw)
+	}
+	if _, exists := evidence["before"]; exists {
+		t.Fatalf("evidence.before should not be present for read-only action in on_mutation mode: %v", evidence["before"])
+	}
+	if _, exists := evidence["after"]; exists {
+		t.Fatalf("evidence.after should not be present for read-only action in on_mutation mode: %v", evidence["after"])
+	}
+	if calls != 0 {
+		t.Fatalf("capture calls = %d, want 0 for read-only action in on_mutation mode", calls)
+	}
+}
+
+func TestCommandResult_EvidencePartialWhenAfterCaptureFails(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	calls := 0
+	shots := []evidenceShot{
+		{Path: "/tmp/evidence-before.png"},
+		{Error: "screenshot_timeout"},
+		{Error: "screenshot_timeout"},
+	}
+	idx := 0
+	orig := evidenceCaptureFn
+	evidenceCaptureFn = func(_ *ToolHandler, _ string) evidenceShot {
+		calls++
+		if idx >= len(shots) {
+			return evidenceShot{Error: "unexpected_extra_capture"}
+		}
+		shot := shots[idx]
+		idx++
+		return shot
+	}
+	t.Cleanup(func() {
+		evidenceCaptureFn = orig
+	})
+
+	result, ok := env.callInteract(t, `{"what":"click","selector":"#btn","background":true,"evidence":"always"}`)
+	if !ok || result.IsError {
+		t.Fatalf("click should queue successfully, got: %s", firstText(result))
+	}
+
+	queued := extractResultJSON(t, result)
+	corrID, _ := queued["correlation_id"].(string)
+	if corrID == "" {
+		t.Fatalf("correlation_id missing in queued response: %v", queued)
+	}
+
+	env.capture.ApplyCommandResult(corrID, "error", json.RawMessage(`{"success":false,"error":"element_not_found"}`), "element_not_found")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 2}
+	args := json.RawMessage(`{"correlation_id":"` + corrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if !observe.IsError {
+		t.Fatalf("observe command_result should be error for failed action, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	evidence, ok := data["evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("evidence payload missing: %v", data["evidence"])
+	}
+	if evidence["before"] != "/tmp/evidence-before.png" {
+		t.Fatalf("evidence.before = %v, want /tmp/evidence-before.png", evidence["before"])
+	}
+	if _, exists := evidence["after"]; exists {
+		t.Fatalf("evidence.after should be absent when after-capture fails, got %v", evidence["after"])
+	}
+	if partial, _ := evidence["partial"].(bool); !partial {
+		t.Fatalf("evidence.partial should be true when one capture fails, got %v", evidence["partial"])
+	}
+	errorsMap, ok := evidence["errors"].(map[string]any)
+	if !ok {
+		t.Fatalf("evidence.errors missing for partial capture: %v", evidence["errors"])
+	}
+	if afterErr, _ := errorsMap["after"].(string); afterErr == "" {
+		t.Fatalf("evidence.errors.after missing: %v", errorsMap)
+	}
+	if calls < 3 {
+		t.Fatalf("capture calls = %d, want >=3 (before + deterministic retry for failed after capture)", calls)
+	}
+}
+
+func TestInteractEvidence_InvalidModeReturnsError(t *testing.T) {
+	env := newInteractTestEnv(t)
+
+	result, ok := env.callInteract(t, `{"what":"click","selector":"#btn","evidence":"sometimes"}`)
+	if !ok {
+		t.Fatal("interact should return a structured error result")
+	}
+	if !result.IsError {
+		t.Fatalf("invalid evidence mode should return isError=true, got: %s", firstText(result))
+	}
+	text := strings.ToLower(firstText(result))
+	if !strings.Contains(text, "evidence") || !strings.Contains(text, "invalid") {
+		t.Fatalf("expected invalid evidence error details, got: %s", firstText(result))
+	}
+}

--- a/cmd/dev-console/tools_interact_storage.go
+++ b/cmd/dev-console/tools_interact_storage.go
@@ -176,6 +176,7 @@ func (h *ToolHandler) queueExecuteScript(
 	}
 
 	correlationID := newCorrelationID(correlationPrefix)
+	h.armEvidenceForCommand(correlationID, reason, waitArgs, req.ClientID)
 	execParams, _ := json.Marshal(map[string]any{
 		"script":     script,
 		"timeout_ms": timeoutMs,

--- a/cmd/dev-console/tools_interact_upload.go
+++ b/cmd/dev-console/tools_interact_upload.go
@@ -42,7 +42,7 @@ func (h *ToolHandler) handleUpload(req JSONRPCRequest, args json.RawMessage) JSO
 		return *errResp
 	}
 
-	return h.queueUpload(req, params, info)
+	return h.queueUpload(req, args, params, info)
 }
 
 // validateUploadParams checks required parameters for the upload action.
@@ -87,7 +87,7 @@ func uploadFileStatError(req JSONRPCRequest, filePath string, err error) JSONRPC
 }
 
 // queueUpload builds the upload payload and queues it for the extension.
-func (h *ToolHandler) queueUpload(req JSONRPCRequest, params uploadParams, info os.FileInfo) JSONRPCResponse {
+func (h *ToolHandler) queueUpload(req JSONRPCRequest, args json.RawMessage, params uploadParams, info os.FileInfo) JSONRPCResponse {
 	if params.EscalationTimeoutMs <= 0 {
 		params.EscalationTimeoutMs = defaultEscalationTimeoutMs
 	}
@@ -97,6 +97,7 @@ func (h *ToolHandler) queueUpload(req JSONRPCRequest, params uploadParams, info 
 	fileSize := info.Size()
 	progressTier := getProgressTier(fileSize)
 	correlationID := newCorrelationID("upload")
+	h.armEvidenceForCommand(correlationID, "upload", args, req.ClientID)
 
 	uploadPayload := map[string]any{
 		"action": "upload", "selector": params.Selector,

--- a/docs/testing/proof-first-smoke-nightly.md
+++ b/docs/testing/proof-first-smoke-nightly.md
@@ -10,6 +10,7 @@ The proof-first module checks:
 2. CSP flow: `execute_js` fails on CSP-restricted page, DOM primitive fallback succeeds.
 3. Optional LinkedIn composer flow: open, type, submit, verify close cue.
 4. Optional Facebook composer flow: open, type, submit, verify close cue.
+5. Evidence mode flow: mutating action with `evidence:"always"` returns `evidence.before` and `evidence.after` artifact paths.
 
 Each test captures reproducible evidence:
 

--- a/internal/schema/interact.go
+++ b/internal/schema/interact.go
@@ -186,6 +186,11 @@ func InteractToolSchema() mcp.MCPTool {
 					"type":        "boolean",
 					"description": "Enable perf profiling (captures perf_diff)",
 				},
+				"evidence": map[string]any{
+					"type":        "string",
+					"description": "Optional visual evidence capture mode: off (default), on_mutation, always.",
+					"enum":        []string{"off", "on_mutation", "always"},
+				},
 				"observe_mutations": map[string]any{
 					"type":        "boolean",
 					"description": "Track element-level DOM mutations during action execution",


### PR DESCRIPTION
## Summary
- add opt-in interact evidence mode: `evidence: off | on_mutation | always`
- capture screenshot artifacts before/after actions and return them in command results as `evidence.before` / `evidence.after`
- include partial evidence on failures with deterministic retry metadata (`evidence.errors`, `evidence.partial`)
- wire evidence payload into both sync returns and polled `observe(command_result)` final states
- add smoke proof test 28.5 to validate real artifact paths are emitted

## Implementation
- introduced `tools_interact_evidence.go` evidence state machine
- validate `evidence` parameter in `toolInteract`
- arm evidence capture on interact command queue paths (DOM/browser/execute/storage/upload/content/list)
- attach finalized evidence payload in `formatCommandResult` for complete/error/timeout/expired/cancelled
- update interact schema + tools-list golden

## Tests
- `go test ./cmd/dev-console -run 'TestCommandResult_Evidence|TestInteractEvidence_InvalidModeReturnsError|TestRichAction_SchemaHasEvidence' -count=1`
- `go test ./cmd/dev-console -run 'TestRichAction_|TestCommandResult_|TestInteractEvidence_|TestToolsConfigureTutorial_|TestQuickstartContent_' -count=1`
- `go test ./cmd/dev-console -run 'TestInteract|TestToolCallWarnsOnUnknownInteractArgs' -count=1`
- `go test ./cmd/dev-console -run 'TestGoldenToolsList|TestFastStart_ToolsListSchemaStability|TestToolsSchemaParity_InteractWhatMatchesDispatcher' -count=1`
- `go test ./... -run '^$' -count=1`
- `bash -n scripts/smoke-tests/28-proof-first.sh`

Closes #227
