### PR TITLE
feat(reliability): deterministic retry contract with terminal stop

### DIFF
--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -192,6 +192,10 @@ type ToolHandler struct {
 	evidenceMu        sync.Mutex
 	evidenceByCommand map[string]*commandEvidenceState
 
+	// Deterministic retry contract metadata keyed by correlation_id.
+	retryContractMu sync.Mutex
+	retryByCommand  map[string]*commandRetryState
+
 	// Module registry for plugin-style tool dispatch (incremental migration).
 	toolModules *toolModuleRegistry
 }
@@ -248,6 +252,7 @@ func NewToolHandler(server *Server, capture *capture.Capture) *MCPHandler {
 		capture:           capture,
 		playbackSessions:  newPlaybackSessionsMap(),
 		evidenceByCommand: make(map[string]*commandEvidenceState),
+		retryByCommand:    make(map[string]*commandRetryState),
 	}
 
 	// Initialize health metrics

--- a/cmd/dev-console/tools_interact_evidence.go
+++ b/cmd/dev-console/tools_interact_evidence.go
@@ -210,6 +210,8 @@ func (h *ToolHandler) armEvidenceForCommand(correlationID, action string, args j
 		return
 	}
 
+	h.armRetryContract(correlationID, action, args)
+
 	mode, err := parseEvidenceMode(args)
 	if err != nil {
 		return

--- a/cmd/dev-console/tools_interact_retry_contract.go
+++ b/cmd/dev-console/tools_interact_retry_contract.go
@@ -1,0 +1,337 @@
+// tools_interact_retry_contract.go — Deterministic retry contract for interact actions.
+//
+// Contract goals:
+// - Max one retry per step (2 attempts total)
+// - Retry attempt must use a changed strategy
+// - Terminal failures include an actionable evidence summary
+// - Retry metadata is exposed via retry_context
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const maxRetryAttemptsPerStep = 2
+
+type commandRetryState struct {
+	Attempt             int
+	MaxAttempts         int
+	Action              string
+	Strategy            string
+	StrategyFingerprint string
+	ChangedStrategy     bool
+	PolicyViolation     string
+	ParentCorrelationID string
+	CreatedAt           time.Time
+}
+
+type retryTerminalDecision struct {
+	Terminal bool
+	Cause    string
+}
+
+func parseRetryParentCorrelationID(args json.RawMessage) string {
+	var params struct {
+		CorrelationID string `json:"correlation_id"`
+	}
+	lenientUnmarshal(args, &params)
+	return strings.TrimSpace(params.CorrelationID)
+}
+
+func deriveRetryStrategy(action string, args json.RawMessage) (strategy string, fingerprint string) {
+	var payload map[string]any
+	lenientUnmarshal(args, &payload)
+
+	f := map[string]any{
+		"action": strings.ToLower(strings.TrimSpace(action)),
+	}
+	for _, key := range []string{
+		"selector",
+		"scope_selector",
+		"scope_rect",
+		"annotation_rect",
+		"element_id",
+		"index",
+		"frame",
+		"world",
+		"text",
+		"value",
+		"wait_for",
+	} {
+		if v, ok := payload[key]; ok {
+			f[key] = v
+		}
+	}
+	fingerprint = stableMarshalForRetry(f)
+
+	switch {
+	case payload["element_id"] != nil:
+		return "element_handle", fingerprint
+	case payload["scope_selector"] != nil || payload["scope_rect"] != nil || payload["annotation_rect"] != nil:
+		return "scoped_selector", fingerprint
+	case payload["frame"] != nil:
+		return "frame_targeted", fingerprint
+	case payload["selector"] != nil:
+		return "selector", fingerprint
+	case payload["index"] != nil:
+		return "indexed", fingerprint
+	case payload["world"] != nil:
+		return "world_switch", fingerprint
+	default:
+		return "default", fingerprint
+	}
+}
+
+func stableMarshalForRetry(v map[string]any) string {
+	if v == nil {
+		return ""
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func (h *ToolHandler) armRetryContract(correlationID, action string, args json.RawMessage) {
+	if h == nil || correlationID == "" {
+		return
+	}
+
+	if action == "" {
+		action = canonicalActionFromInteractArgs(args)
+	}
+	action = strings.ToLower(strings.TrimSpace(action))
+	strategy, fingerprint := deriveRetryStrategy(action, args)
+	parentCorrID := parseRetryParentCorrelationID(args)
+
+	state := &commandRetryState{
+		Attempt:             1,
+		MaxAttempts:         maxRetryAttemptsPerStep,
+		Action:              action,
+		Strategy:            strategy,
+		StrategyFingerprint: fingerprint,
+		ChangedStrategy:     true,
+		ParentCorrelationID: parentCorrID,
+		CreatedAt:           time.Now(),
+	}
+
+	if parentCorrID != "" {
+		if parent, ok := h.getRetryState(parentCorrID); ok {
+			state.Attempt = parent.Attempt + 1
+			if state.Attempt > state.MaxAttempts {
+				state.Attempt = state.MaxAttempts
+				state.PolicyViolation = "attempt_limit_exceeded"
+			}
+			state.ChangedStrategy = state.StrategyFingerprint != parent.StrategyFingerprint
+			if !state.ChangedStrategy {
+				state.PolicyViolation = "strategy_unchanged"
+			}
+		} else {
+			// Treat explicit parent chaining as retry attempt even if parent context has expired.
+			state.Attempt = 2
+			state.PolicyViolation = "parent_context_missing"
+		}
+	}
+
+	h.retryContractMu.Lock()
+	if h.retryByCommand == nil {
+		h.retryByCommand = make(map[string]*commandRetryState)
+	}
+	h.retryByCommand[correlationID] = state
+	h.pruneRetryStatesLocked(2048)
+	h.retryContractMu.Unlock()
+}
+
+func (h *ToolHandler) getRetryState(correlationID string) (*commandRetryState, bool) {
+	h.retryContractMu.Lock()
+	defer h.retryContractMu.Unlock()
+	state, ok := h.retryByCommand[correlationID]
+	return state, ok
+}
+
+func (h *ToolHandler) pruneRetryStatesLocked(maxEntries int) {
+	if len(h.retryByCommand) <= maxEntries {
+		return
+	}
+
+	var oldestKey string
+	var oldestTime time.Time
+	for key, st := range h.retryByCommand {
+		if oldestKey == "" || st.CreatedAt.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = st.CreatedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(h.retryByCommand, oldestKey)
+	}
+}
+
+func deriveRetryReason(responseData map[string]any, fallback string) string {
+	if responseData != nil {
+		if code, ok := responseData["error_code"].(string); ok && strings.TrimSpace(code) != "" {
+			return strings.TrimSpace(code)
+		}
+		if errCode, ok := responseData["error"].(string); ok && strings.TrimSpace(errCode) != "" {
+			return strings.TrimSpace(errCode)
+		}
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
+	}
+	return "unknown"
+}
+
+func (h *ToolHandler) attachRetryContext(correlationID string, responseData map[string]any, status string, fallbackReason string) retryTerminalDecision {
+	if h == nil || correlationID == "" || responseData == nil {
+		return retryTerminalDecision{}
+	}
+
+	h.retryContractMu.Lock()
+	state, ok := h.retryByCommand[correlationID]
+	h.retryContractMu.Unlock()
+	if !ok || state == nil {
+		return retryTerminalDecision{}
+	}
+
+	reason := deriveRetryReason(responseData, fallbackReason)
+	if strings.EqualFold(status, "complete") && reason == "unknown" {
+		reason = "success"
+	}
+
+	retryContext := map[string]any{
+		"attempt":          state.Attempt,
+		"max_attempts":     state.MaxAttempts,
+		"strategy":         state.Strategy,
+		"changed_strategy": state.ChangedStrategy,
+		"reason":           reason,
+	}
+	if state.ParentCorrelationID != "" {
+		retryContext["parent_correlation_id"] = state.ParentCorrelationID
+	}
+	if state.PolicyViolation != "" {
+		retryContext["policy_violation"] = state.PolicyViolation
+	}
+
+	decision := retryTerminalDecision{}
+	failureStatus := status == "error" || status == "timeout" || status == "expired" || status == "cancelled"
+	if failureStatus {
+		if state.Attempt >= state.MaxAttempts {
+			decision.Terminal = true
+			decision.Cause = "max_attempts_reached"
+		}
+		if state.Attempt > 1 && !state.ChangedStrategy {
+			decision.Terminal = true
+			decision.Cause = "strategy_not_changed"
+		}
+	}
+
+	retryContext["terminal_stop"] = decision.Terminal
+	if decision.Cause != "" {
+		retryContext["terminal_cause"] = decision.Cause
+	}
+	responseData["retry_context"] = retryContext
+
+	if !failureStatus {
+		return decision
+	}
+
+	if decision.Terminal {
+		responseData["terminal"] = true
+		responseData["retryable"] = false
+		if _, exists := responseData["retry"]; !exists {
+			responseData["retry"] = "Terminal after two attempts. Stop retrying this step and report evidence_summary."
+		}
+		responseData["evidence_summary"] = buildRetryEvidenceSummary(correlationID, reason, retryContext, responseData)
+		return decision
+	}
+
+	// Non-terminal failure on attempt 1: allow one retry with a changed strategy.
+	if _, exists := responseData["retryable"]; !exists {
+		responseData["retryable"] = true
+	}
+	if _, exists := responseData["retry"]; !exists {
+		responseData["retry"] = "Retry once with a changed strategy (scope_selector/scope_rect/element_id/index/frame/world). If the second attempt fails, stop and report evidence_summary."
+	}
+
+	return decision
+}
+
+func buildRetryEvidenceSummary(correlationID, reason string, retryContext map[string]any, responseData map[string]any) map[string]any {
+	summary := map[string]any{
+		"correlation_id": correlationID,
+		"failure_reason": reason,
+		"next_action":    "Stop retries for this step and report this bundle.",
+		"required": []string{
+			"command_result",
+			"screenshot",
+			"scoped_list_interactive_output",
+		},
+	}
+
+	if retryContext != nil {
+		summary["retry_context"] = retryContext
+	}
+	if responseData != nil {
+		if evidence, ok := responseData["evidence"]; ok {
+			summary["captured_evidence"] = evidence
+		}
+		if u, ok := responseData["effective_url"].(string); ok && strings.TrimSpace(u) != "" {
+			summary["url"] = u
+		} else if u, ok := responseData["resolved_url"].(string); ok && strings.TrimSpace(u) != "" {
+			summary["url"] = u
+		}
+	}
+	return summary
+}
+
+func retryContextAttempt(data map[string]any) (int, bool) {
+	retryContext, ok := data["retry_context"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	v, ok := retryContext["attempt"].(float64)
+	if !ok {
+		return 0, false
+	}
+	return int(v), true
+}
+
+func retryContextChangedStrategy(data map[string]any) (bool, bool) {
+	retryContext, ok := data["retry_context"].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	v, ok := retryContext["changed_strategy"].(bool)
+	return v, ok
+}
+
+func retryContextTerminal(data map[string]any) (bool, bool) {
+	retryContext, ok := data["retry_context"].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	v, ok := retryContext["terminal_stop"].(bool)
+	return v, ok
+}
+
+func retryContextReason(data map[string]any) string {
+	retryContext, ok := data["retry_context"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := retryContext["reason"].(string)
+	return strings.TrimSpace(v)
+}
+
+func retryContextString(data map[string]any) string {
+	retryContext, ok := data["retry_context"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%v", retryContext)
+}

--- a/cmd/dev-console/tools_interact_retry_contract_test.go
+++ b/cmd/dev-console/tools_interact_retry_contract_test.go
@@ -1,0 +1,193 @@
+// tools_interact_retry_contract_test.go — TDD tests for deterministic retry contract.
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRetryContract_FirstFailureIncludesRetryContext(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	result, ok := env.callInteract(t, `{"what":"click","selector":"#retry-btn","background":true}`)
+	if !ok || result.IsError {
+		t.Fatalf("click should queue successfully, got: %s", firstText(result))
+	}
+	queued := extractResultJSON(t, result)
+	corrID, _ := queued["correlation_id"].(string)
+	if corrID == "" {
+		t.Fatalf("missing correlation_id in queued response: %v", queued)
+	}
+
+	env.capture.ApplyCommandResult(corrID, "error", json.RawMessage(`{"success":false,"error":"element_not_found"}`), "element_not_found")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 2}
+	args := json.RawMessage(`{"correlation_id":"` + corrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if !observe.IsError {
+		t.Fatalf("expected failure result, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	attempt, ok := retryContextAttempt(data)
+	if !ok || attempt != 1 {
+		t.Fatalf("retry_context.attempt = %v (ok=%v), want 1. retry_context=%s", attempt, ok, retryContextString(data))
+	}
+	if reason := retryContextReason(data); reason != "element_not_found" {
+		t.Fatalf("retry_context.reason = %q, want element_not_found", reason)
+	}
+	if terminal, ok := retryContextTerminal(data); !ok || terminal {
+		t.Fatalf("retry_context.terminal_stop = %v (ok=%v), want false", terminal, ok)
+	}
+	if retryable, ok := data["retryable"].(bool); !ok || !retryable {
+		t.Fatalf("retryable = %v (ok=%v), want true on first failure", data["retryable"], ok)
+	}
+}
+
+func TestRetryContract_SecondFailureWithoutStrategyChangeIsTerminal(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	first, ok := env.callInteract(t, `{"what":"click","selector":"#retry-btn","background":true}`)
+	if !ok || first.IsError {
+		t.Fatalf("first click should queue successfully, got: %s", firstText(first))
+	}
+	firstData := extractResultJSON(t, first)
+	firstCorrID, _ := firstData["correlation_id"].(string)
+	env.capture.ApplyCommandResult(firstCorrID, "error", json.RawMessage(`{"success":false,"error":"ambiguous_target"}`), "ambiguous_target")
+
+	secondArgs := `{"what":"click","selector":"#retry-btn","background":true,"correlation_id":"` + firstCorrID + `"}`
+	second, ok := env.callInteract(t, secondArgs)
+	if !ok || second.IsError {
+		t.Fatalf("second click should queue successfully, got: %s", firstText(second))
+	}
+	secondData := extractResultJSON(t, second)
+	secondCorrID, _ := secondData["correlation_id"].(string)
+	env.capture.ApplyCommandResult(secondCorrID, "error", json.RawMessage(`{"success":false,"error":"ambiguous_target"}`), "ambiguous_target")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 3}
+	args := json.RawMessage(`{"correlation_id":"` + secondCorrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if !observe.IsError {
+		t.Fatalf("expected terminal failure, got success: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	attempt, ok := retryContextAttempt(data)
+	if !ok || attempt != 2 {
+		t.Fatalf("retry_context.attempt = %v (ok=%v), want 2. retry_context=%s", attempt, ok, retryContextString(data))
+	}
+	changed, ok := retryContextChangedStrategy(data)
+	if !ok || changed {
+		t.Fatalf("retry_context.changed_strategy = %v (ok=%v), want false", changed, ok)
+	}
+	if terminal, ok := retryContextTerminal(data); !ok || !terminal {
+		t.Fatalf("retry_context.terminal_stop = %v (ok=%v), want true", terminal, ok)
+	}
+	if terminal, _ := data["terminal"].(bool); !terminal {
+		t.Fatalf("terminal = %v, want true", data["terminal"])
+	}
+	if retryable, _ := data["retryable"].(bool); retryable {
+		t.Fatalf("retryable = %v, want false on terminal failure", data["retryable"])
+	}
+
+	summary, ok := data["evidence_summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("evidence_summary missing on terminal failure: %v", data["evidence_summary"])
+	}
+	if next, _ := summary["next_action"].(string); next == "" {
+		t.Fatalf("evidence_summary.next_action missing: %v", summary)
+	}
+}
+
+func TestRetryContract_SecondFailureWithChangedStrategyStillTerminal(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	first, ok := env.callInteract(t, `{"what":"click","selector":".submit-btn","background":true}`)
+	if !ok || first.IsError {
+		t.Fatalf("first click should queue successfully, got: %s", firstText(first))
+	}
+	firstData := extractResultJSON(t, first)
+	firstCorrID, _ := firstData["correlation_id"].(string)
+	env.capture.ApplyCommandResult(firstCorrID, "error", json.RawMessage(`{"success":false,"error":"ambiguous_target"}`), "ambiguous_target")
+
+	secondArgs := `{"what":"click","selector":".submit-btn","scope_selector":"#active-composer","background":true,"correlation_id":"` + firstCorrID + `"}`
+	second, ok := env.callInteract(t, secondArgs)
+	if !ok || second.IsError {
+		t.Fatalf("second click should queue successfully, got: %s", firstText(second))
+	}
+	secondData := extractResultJSON(t, second)
+	secondCorrID, _ := secondData["correlation_id"].(string)
+	env.capture.ApplyCommandResult(secondCorrID, "error", json.RawMessage(`{"success":false,"error":"ambiguous_target"}`), "ambiguous_target")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 4}
+	args := json.RawMessage(`{"correlation_id":"` + secondCorrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if !observe.IsError {
+		t.Fatalf("expected terminal failure on second attempt, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	attempt, ok := retryContextAttempt(data)
+	if !ok || attempt != 2 {
+		t.Fatalf("retry_context.attempt = %v (ok=%v), want 2. retry_context=%s", attempt, ok, retryContextString(data))
+	}
+	changed, ok := retryContextChangedStrategy(data)
+	if !ok || !changed {
+		t.Fatalf("retry_context.changed_strategy = %v (ok=%v), want true", changed, ok)
+	}
+	if terminal, ok := retryContextTerminal(data); !ok || !terminal {
+		t.Fatalf("retry_context.terminal_stop = %v (ok=%v), want true", terminal, ok)
+	}
+}
+
+func TestRetryContract_SecondAttemptSuccessIncludesRetryContext(t *testing.T) {
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	first, ok := env.callInteract(t, `{"what":"click","selector":"#retry-btn","background":true}`)
+	if !ok || first.IsError {
+		t.Fatalf("first click should queue successfully, got: %s", firstText(first))
+	}
+	firstData := extractResultJSON(t, first)
+	firstCorrID, _ := firstData["correlation_id"].(string)
+	env.capture.ApplyCommandResult(firstCorrID, "error", json.RawMessage(`{"success":false,"error":"element_not_found"}`), "element_not_found")
+
+	secondArgs := `{"what":"click","selector":"#retry-btn","scope_selector":"#dialog","background":true,"correlation_id":"` + firstCorrID + `"}`
+	second, ok := env.callInteract(t, secondArgs)
+	if !ok || second.IsError {
+		t.Fatalf("second click should queue successfully, got: %s", firstText(second))
+	}
+	secondData := extractResultJSON(t, second)
+	secondCorrID, _ := secondData["correlation_id"].(string)
+	env.capture.CompleteCommand(secondCorrID, json.RawMessage(`{"success":true}`), "")
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 5}
+	args := json.RawMessage(`{"correlation_id":"` + secondCorrID + `"}`)
+	resp := env.handler.toolObserveCommandResult(req, args)
+	observe := parseToolResult(t, resp)
+	if observe.IsError {
+		t.Fatalf("expected success on second attempt, got: %s", firstText(observe))
+	}
+
+	data := extractResultJSON(t, observe)
+	attempt, ok := retryContextAttempt(data)
+	if !ok || attempt != 2 {
+		t.Fatalf("retry_context.attempt = %v (ok=%v), want 2. retry_context=%s", attempt, ok, retryContextString(data))
+	}
+	changed, ok := retryContextChangedStrategy(data)
+	if !ok || !changed {
+		t.Fatalf("retry_context.changed_strategy = %v (ok=%v), want true", changed, ok)
+	}
+	if terminal, ok := retryContextTerminal(data); !ok || terminal {
+		t.Fatalf("retry_context.terminal_stop = %v (ok=%v), want false on success", terminal, ok)
+	}
+	if reason := retryContextReason(data); reason != "success" {
+		t.Fatalf("retry_context.reason = %q, want success", reason)
+	}
+}

--- a/docs/testing/proof-first-smoke-nightly.md
+++ b/docs/testing/proof-first-smoke-nightly.md
@@ -11,6 +11,7 @@ The proof-first module checks:
 3. Optional LinkedIn composer flow: open, type, submit, verify close cue.
 4. Optional Facebook composer flow: open, type, submit, verify close cue.
 5. Evidence mode flow: mutating action with `evidence:"always"` returns `evidence.before` and `evidence.after` artifact paths.
+6. Retry contract flow: chained second failure (`correlation_id`) returns `retry_context.terminal_stop=true` and terminal evidence summary.
 
 Each test captures reproducible evidence:
 


### PR DESCRIPTION
## Summary
- add deterministic retry contract for interact command results
- enforce max two attempts per step (initial + one retry) via per-command retry state
- require strategy change on retry chains; unchanged strategy is flagged as policy violation
- return terminal stop metadata and actionable evidence summary on second failure
- expose structured retry metadata in final command results: `retry_context.attempt`, `strategy`, `changed_strategy`, `reason`, `terminal_stop`

## Implementation
- added retry contract state machine in `cmd/dev-console/tools_interact_retry_contract.go`
- initialized retry metadata store on `ToolHandler` and pruned bounded state
- wired contract arming through existing interact command arm path (`armEvidenceForCommand` now also arms retry metadata)
- attached retry context and terminal decision handling in command result formatting (`cmd/dev-console/tools_async.go`)
- preserved first-failure retryability while making second failures terminal (`retryable=false`, `terminal=true`, `evidence_summary`)
- added smoke test `28.6` for stop-after-two-attempts behavior and updated nightly proof-first docs

## Tests
- `go test ./cmd/dev-console -run 'TestRetryContract_' -count=1`
- `go test ./cmd/dev-console -run 'TestCommandResult_|TestRichAction_|TestInteractEvidence_|TestRetryContract_' -count=1`
- `go test ./... -run '^$' -count=1`
- `bash -n scripts/smoke-tests/28-proof-first.sh`

Closes #230
