### PR TITLE
feat: end-to-end command traceability across async command lifecycle

### DIFF
--- a/internal/capture/query_dispatcher.go
+++ b/internal/capture/query_dispatcher.go
@@ -163,6 +163,11 @@ func (c *Capture) GetFailedCommands() []*queries.CommandResult {
 	return c.qd.GetFailedCommands()
 }
 
+// GetRecentCommandTraces returns the latest command traces for diagnostics.
+func (c *Capture) GetRecentCommandTraces(limit int) []*queries.CommandResult {
+	return c.qd.GetRecentCommandTraces(limit)
+}
+
 // QueuePosition delegates to QueryDispatcher.
 func (c *Capture) QueuePosition(correlationID string) int {
 	return c.qd.QueuePosition(correlationID)

--- a/internal/capture/sync.go
+++ b/internal/capture/sync.go
@@ -94,6 +94,7 @@ type SyncCommand struct {
 	Params        json.RawMessage `json:"params"`
 	TabID         int             `json:"tab_id,omitempty"`
 	CorrelationID string          `json:"correlation_id,omitempty"`
+	TraceID       string          `json:"trace_id,omitempty"`
 }
 
 // =============================================================================
@@ -212,6 +213,7 @@ func buildSyncCommands(pending []queries.PendingQueryResponse) []SyncCommand {
 			Params:        q.Params,
 			TabID:         q.TabID,
 			CorrelationID: q.CorrelationID,
+			TraceID:       q.TraceID,
 		}
 	}
 	return commands

--- a/internal/capture/sync_test.go
+++ b/internal/capture/sync_test.go
@@ -354,6 +354,9 @@ func TestHandleSync_CommandsIncludeTabID(t *testing.T) {
 	if resp.Commands[0].CorrelationID != "corr-tab-42" {
 		t.Fatalf("Expected correlation_id corr-tab-42, got %q", resp.Commands[0].CorrelationID)
 	}
+	if resp.Commands[0].TraceID != "corr-tab-42" {
+		t.Fatalf("Expected trace_id corr-tab-42, got %q", resp.Commands[0].TraceID)
+	}
 }
 
 func TestHandleSync_AdaptivePoll_SlowWhenNoCommands(t *testing.T) {
@@ -612,7 +615,7 @@ func TestHandleSync_CommandResultLifecycleMatrix(t *testing.T) {
 			}
 
 			req := SyncRequest{
-				ExtSessionID:    "test_session",
+				ExtSessionID:   "test_session",
 				CommandResults: []SyncCommandResult{result},
 			}
 			body, _ := json.Marshal(req)

--- a/internal/queries/command_trace_test.go
+++ b/internal/queries/command_trace_test.go
@@ -1,0 +1,154 @@
+package queries
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func traceStages(events []CommandTraceEvent) []string {
+	stages := make([]string, 0, len(events))
+	for _, evt := range events {
+		stages = append(stages, evt.Stage)
+	}
+	return stages
+}
+
+func requireStage(t *testing.T, events []CommandTraceEvent, want string) {
+	t.Helper()
+	for _, evt := range events {
+		if evt.Stage == want {
+			return
+		}
+	}
+	t.Fatalf("trace missing stage %q; got=%v", want, traceStages(events))
+}
+
+func indexOfStage(events []CommandTraceEvent, stage string) int {
+	for i, evt := range events {
+		if evt.Stage == stage {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestCommandTraceLifecycle_CompleteFlow(t *testing.T) {
+	t.Parallel()
+
+	qd := NewQueryDispatcher()
+	defer qd.Close()
+
+	queryID := qd.CreatePendingQueryWithTimeout(PendingQuery{
+		Type:          "browser_action",
+		CorrelationID: "corr-trace-flow",
+	}, 30*time.Second, "test-client")
+	if queryID == "" {
+		t.Fatal("CreatePendingQueryWithTimeout returned empty query ID")
+	}
+
+	cmd, found := qd.GetCommandResult("corr-trace-flow")
+	if !found {
+		t.Fatal("expected pending command result after queueing")
+	}
+	if cmd.TraceID != "corr-trace-flow" {
+		t.Fatalf("trace_id = %q, want corr-trace-flow", cmd.TraceID)
+	}
+	if cmd.QueryID != queryID {
+		t.Fatalf("query_id = %q, want %q", cmd.QueryID, queryID)
+	}
+	requireStage(t, cmd.TraceEvents, "queued")
+
+	pending := qd.GetPendingQueries()
+	if len(pending) != 1 {
+		t.Fatalf("pending len=%d, want 1", len(pending))
+	}
+	if pending[0].TraceID != "corr-trace-flow" {
+		t.Fatalf("pending trace_id = %q, want corr-trace-flow", pending[0].TraceID)
+	}
+
+	cmd, found = qd.GetCommandResult("corr-trace-flow")
+	if !found {
+		t.Fatal("expected command result after dispatch")
+	}
+	requireStage(t, cmd.TraceEvents, "sent")
+
+	qd.AcknowledgePendingQuery(queryID)
+	cmd, found = qd.GetCommandResult("corr-trace-flow")
+	if !found {
+		t.Fatal("expected command result after ack")
+	}
+	requireStage(t, cmd.TraceEvents, "started")
+
+	qd.ApplyCommandResult("corr-trace-flow", "complete", json.RawMessage(`{"ok":true}`), "")
+	cmd, found = qd.GetCommandResult("corr-trace-flow")
+	if !found {
+		t.Fatal("expected command result after completion")
+	}
+	requireStage(t, cmd.TraceEvents, "resolved")
+
+	queuedIdx := indexOfStage(cmd.TraceEvents, "queued")
+	sentIdx := indexOfStage(cmd.TraceEvents, "sent")
+	startedIdx := indexOfStage(cmd.TraceEvents, "started")
+	resolvedIdx := indexOfStage(cmd.TraceEvents, "resolved")
+	if queuedIdx < 0 || sentIdx < 0 || startedIdx < 0 || resolvedIdx < 0 {
+		t.Fatalf("expected full lifecycle order, got=%v", traceStages(cmd.TraceEvents))
+	}
+	if !(queuedIdx < sentIdx && sentIdx < startedIdx && startedIdx < resolvedIdx) {
+		t.Fatalf("trace order invalid: %v", traceStages(cmd.TraceEvents))
+	}
+}
+
+func TestCommandTraceLifecycle_ErrorAndTimeout(t *testing.T) {
+	t.Parallel()
+
+	qd := NewQueryDispatcher()
+	defer qd.Close()
+
+	qd.RegisterCommand("corr-trace-error", "q-err", 30*time.Second)
+	qd.ApplyCommandResult("corr-trace-error", "error", nil, "forced failure")
+	errCmd, found := qd.GetCommandResult("corr-trace-error")
+	if !found {
+		t.Fatal("expected errored command result")
+	}
+	requireStage(t, errCmd.TraceEvents, "errored")
+
+	qd.RegisterCommand("corr-trace-timeout", "q-timeout", 30*time.Second)
+	qd.ExpireCommand("corr-trace-timeout")
+	timeoutCmd, found := qd.GetCommandResult("corr-trace-timeout")
+	if !found {
+		t.Fatal("expected timed_out command result")
+	}
+	requireStage(t, timeoutCmd.TraceEvents, "timed_out")
+}
+
+func TestGetRecentCommandTraces_RespectsLimitAndIncludesTimeline(t *testing.T) {
+	t.Parallel()
+
+	qd := NewQueryDispatcher()
+	defer qd.Close()
+
+	qd.RegisterCommand("corr-trace-a", "q-a", 30*time.Second)
+	qd.ApplyCommandResult("corr-trace-a", "error", nil, "boom")
+
+	qd.RegisterCommand("corr-trace-b", "q-b", 30*time.Second)
+	qd.ApplyCommandResult("corr-trace-b", "complete", json.RawMessage(`{"ok":true}`), "")
+
+	traces := qd.GetRecentCommandTraces(1)
+	if len(traces) != 1 {
+		t.Fatalf("trace count=%d, want 1", len(traces))
+	}
+	if traces[0].TraceID == "" {
+		t.Fatal("trace_id should not be empty")
+	}
+	if len(traces[0].TraceEvents) == 0 {
+		t.Fatal("trace events should not be empty")
+	}
+	if traces[0].TraceTimeline == "" {
+		t.Fatal("trace_timeline should not be empty")
+	}
+	if !strings.Contains(traces[0].TraceTimeline, "queued") {
+		t.Fatalf("trace_timeline = %q, expected queued stage", traces[0].TraceTimeline)
+	}
+}

--- a/internal/queries/commands_test.go
+++ b/internal/queries/commands_test.go
@@ -97,8 +97,8 @@ func TestNewQueryDispatcher_CompleteCommand_WithError(t *testing.T) {
 	if !found {
 		t.Fatal("GetCommandResult returned false")
 	}
-	if cmd.Status != "complete" {
-		t.Errorf("Status = %q, want complete", cmd.Status)
+	if cmd.Status != "error" {
+		t.Errorf("Status = %q, want error", cmd.Status)
 	}
 	if cmd.Error != "element not found" {
 		t.Errorf("Error = %q, want 'element not found'", cmd.Error)

--- a/internal/queries/dispatcher_trace.go
+++ b/internal/queries/dispatcher_trace.go
@@ -1,0 +1,197 @@
+package queries
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	traceStageQueued   = "queued"
+	traceStageSent     = "sent"
+	traceStageStarted  = "started"
+	traceStageResolved = "resolved"
+	traceStageTimedOut = "timed_out"
+	traceStageErrored  = "errored"
+)
+
+func deriveTraceID(explicit string, correlationID string, queryID string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if correlationID != "" {
+		return correlationID
+	}
+	if queryID != "" {
+		return "trace_" + queryID
+	}
+	return ""
+}
+
+func buildTraceTimeline(events []CommandTraceEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+	stages := make([]string, 0, len(events))
+	for _, evt := range events {
+		if evt.Stage == "" {
+			continue
+		}
+		stages = append(stages, evt.Stage)
+	}
+	return strings.Join(stages, " -> ")
+}
+
+func traceStageFromStatus(status string) string {
+	switch NormalizeCommandStatus(status) {
+	case "pending":
+		return traceStageStarted
+	case "complete":
+		return traceStageResolved
+	case "error", "cancelled":
+		return traceStageErrored
+	case "timeout", "expired":
+		return traceStageTimedOut
+	default:
+		return ""
+	}
+}
+
+func (qd *QueryDispatcher) ensureTraceContextLocked(cmd *CommandResult, correlationID string, queryID string, traceID string, now time.Time) {
+	if cmd == nil {
+		return
+	}
+	if cmd.CorrelationID == "" {
+		cmd.CorrelationID = correlationID
+	}
+	if cmd.TraceID == "" {
+		cmd.TraceID = deriveTraceID(traceID, correlationID, queryID)
+	}
+	if cmd.QueryID == "" && queryID != "" {
+		cmd.QueryID = queryID
+	}
+	if cmd.UpdatedAt.IsZero() {
+		cmd.UpdatedAt = now
+	}
+}
+
+func (qd *QueryDispatcher) hasTraceStageLocked(cmd *CommandResult, stage string) bool {
+	if cmd == nil || stage == "" {
+		return false
+	}
+	for _, evt := range cmd.TraceEvents {
+		if evt.Stage == stage {
+			return true
+		}
+	}
+	return false
+}
+
+func (qd *QueryDispatcher) appendTraceEventLocked(cmd *CommandResult, stage string, source string, status string, message string, at time.Time) {
+	if cmd == nil || stage == "" {
+		return
+	}
+	if qd.hasTraceStageLocked(cmd, stage) {
+		if at.After(cmd.UpdatedAt) {
+			cmd.UpdatedAt = at
+		}
+		return
+	}
+
+	cmd.TraceEvents = append(cmd.TraceEvents, CommandTraceEvent{
+		Stage:   stage,
+		At:      at,
+		Source:  source,
+		Status:  status,
+		Message: message,
+	})
+	cmd.TraceTimeline = buildTraceTimeline(cmd.TraceEvents)
+	cmd.UpdatedAt = at
+}
+
+func (qd *QueryDispatcher) recordTraceEvent(correlationID string, stage string, source string, status string, message string, at time.Time) {
+	if correlationID == "" || stage == "" {
+		return
+	}
+
+	qd.resultsMu.Lock()
+	defer qd.resultsMu.Unlock()
+
+	if cmd, exists := qd.completedResults[correlationID]; exists {
+		qd.ensureTraceContextLocked(cmd, correlationID, "", "", at)
+		qd.appendTraceEventLocked(cmd, stage, source, status, message, at)
+		return
+	}
+	for _, cmd := range qd.failedCommands {
+		if cmd == nil || cmd.CorrelationID != correlationID {
+			continue
+		}
+		qd.ensureTraceContextLocked(cmd, correlationID, "", "", at)
+		qd.appendTraceEventLocked(cmd, stage, source, status, message, at)
+		return
+	}
+}
+
+func copyCommandResultWithTrace(src *CommandResult) *CommandResult {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	if len(src.TraceEvents) > 0 {
+		cp.TraceEvents = make([]CommandTraceEvent, len(src.TraceEvents))
+		copy(cp.TraceEvents, src.TraceEvents)
+	}
+	return &cp
+}
+
+// GetRecentCommandTraces returns the latest command traces across active and failed commands.
+// Sorted by UpdatedAt descending and bounded by limit (if > 0).
+func (qd *QueryDispatcher) GetRecentCommandTraces(limit int) []*CommandResult {
+	qd.cleanExpiredCommands()
+
+	qd.resultsMu.RLock()
+	defer qd.resultsMu.RUnlock()
+
+	combined := make([]*CommandResult, 0, len(qd.completedResults)+len(qd.failedCommands))
+	seen := make(map[string]struct{}, len(qd.completedResults)+len(qd.failedCommands))
+	add := func(cmd *CommandResult) {
+		if cmd == nil {
+			return
+		}
+		key := cmd.CorrelationID
+		if key == "" {
+			key = cmd.TraceID
+		}
+		if key != "" {
+			if _, exists := seen[key]; exists {
+				return
+			}
+			seen[key] = struct{}{}
+		}
+		combined = append(combined, copyCommandResultWithTrace(cmd))
+	}
+
+	for _, cmd := range qd.failedCommands {
+		add(cmd)
+	}
+	for _, cmd := range qd.completedResults {
+		add(cmd)
+	}
+
+	sort.Slice(combined, func(i, j int) bool {
+		left := combined[i].UpdatedAt
+		right := combined[j].UpdatedAt
+		if left.IsZero() {
+			left = combined[i].CreatedAt
+		}
+		if right.IsZero() {
+			right = combined[j].CreatedAt
+		}
+		return left.After(right)
+	})
+
+	if limit > 0 && len(combined) > limit {
+		combined = combined[:limit]
+	}
+	return combined
+}


### PR DESCRIPTION
## Summary
- implement end-to-end trace lifecycle for async commands with a single trace_id
- record structured lifecycle stages: queued, sent, started, resolved, timed_out, errored
- surface trace timeline in observe(command_result) responses and queued/still_processing responses
- expose recent trace report in /diagnostics as command_traces entries

## Implementation details
- extended pending query and command models with trace_id, query linkage, and trace events/timeline
- added dispatcher trace helpers for lifecycle event recording, deduping stages, and recent trace retrieval
- trace propagation now includes sync command payloads (trace_id) so extension execution remains correlated
- ensured failed and active command snapshots return safe copies including trace slices

## Tests
- go test ./internal/queries ./internal/capture -count=1
- go test ./cmd/dev-console -run 'TestSetupHTTPRoutesBasicEndpoints|TestMaybeWaitForCommand_BackgroundOverride|TestToolObserveCommandResult_IncludesTraceTimeline|TestFormatCommandResult_' -count=1
- go test ./cmd/dev-console -count=1

Closes #228