### PR TITLE
fix(interact): accept action alias without requiring what

### DIFF
--- a/cmd/dev-console/tools_interact.go
+++ b/cmd/dev-console/tools_interact.go
@@ -136,9 +136,24 @@ func (h *ToolHandler) toolInteract(req JSONRPCRequest, args json.RawMessage) JSO
 		what = params.Action
 	}
 
+	if params.What != "" && params.Action != "" && params.What != params.Action {
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+			ErrInvalidParam,
+			"Conflicting dispatch values: 'what' and 'action' do not match",
+			"Provide only one dispatch field, or set both to the same action value",
+			withParam("what"),
+		)}
+	}
+
 	if what == "" {
 		validActions := h.getValidInteractActions()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'what' is missing", "Add the 'what' parameter and call again", withParam("what"), withHint("Valid values: "+validActions))}
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+			ErrMissingParam,
+			"Required dispatch parameter is missing: provide 'what' or alias 'action'",
+			"Add 'what' (preferred) or 'action' and call again",
+			withParam("what"),
+			withHint("Valid values: "+validActions),
+		)}
 	}
 
 	if _, err := parseEvidenceMode(args); err != nil {

--- a/internal/schema/interact.go
+++ b/internal/schema/interact.go
@@ -10,7 +10,7 @@ import "github.com/dev-console/dev-console/internal/mcp"
 func InteractToolSchema() mcp.MCPTool {
 	return mcp.MCPTool{
 		Name:        "interact",
-		Description: "Browser actions. Requires AI Web Pilot.\n\nSynchronous Mode (Default): Tools now block until the extension returns a result (up to 15s). Set background:true to return immediately with a correlation_id.\n\nSelectors: CSS or semantic (text=Submit, role=button, placeholder=Email, label=Name, aria-label=Close). subtitle param composable with any action. analyze=true captures perf_diff. navigate/refresh auto-include perf_diff.\n\nDraw Mode: draw_mode_start activates annotation overlay — user draws rectangles and types feedback, presses ESC to finish. Use analyze({what:'annotations'}) to retrieve results.\n\nCompatibility: action='screenshot' is a backward-compatible alias for observe({what:'screenshot'}).",
+		Description: "Browser actions. Requires AI Web Pilot.\n\nSynchronous Mode (Default): Tools now block until the extension returns a result (up to 15s). Set background:true to return immediately with a correlation_id.\n\nSelectors: CSS or semantic (text=Submit, role=button, placeholder=Email, label=Name, aria-label=Close). subtitle param composable with any action. analyze=true captures perf_diff. navigate/refresh auto-include perf_diff.\n\nDraw Mode: draw_mode_start activates annotation overlay — user draws rectangles and types feedback, presses ESC to finish. Use analyze({what:'annotations'}) to retrieve results.\n\nCompatibility: either what='navigate' or action='navigate' is accepted. action='screenshot' remains a backward-compatible alias for observe({what:'screenshot'}).",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -256,7 +256,10 @@ func InteractToolSchema() mcp.MCPTool {
 					"description": "File path to save output (run_a11y_and_export_sarif)",
 				},
 			},
-			"required": []string{"what"},
+			"anyOf": []map[string]any{
+				{"required": []string{"what"}},
+				{"required": []string{"action"}},
+			},
 		},
 	}
 }

--- a/internal/schema/interact_test.go
+++ b/internal/schema/interact_test.go
@@ -1,0 +1,84 @@
+package schema
+
+import "testing"
+
+func TestInteractToolSchema_DispatchAcceptsWhatOrAction(t *testing.T) {
+	t.Parallel()
+
+	tool := InteractToolSchema()
+	props, ok := tool.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("interact schema missing properties")
+	}
+
+	whatProp, ok := props["what"].(map[string]any)
+	if !ok {
+		t.Fatal("interact schema missing 'what' property")
+	}
+	actionProp, ok := props["action"].(map[string]any)
+	if !ok {
+		t.Fatal("interact schema missing 'action' property")
+	}
+
+	whatEnum := toSchemaStringSlice(t, whatProp["enum"])
+	actionEnum := toSchemaStringSlice(t, actionProp["enum"])
+	if len(whatEnum) == 0 || len(actionEnum) == 0 {
+		t.Fatal("interact dispatch enums must be non-empty")
+	}
+	if len(whatEnum) != len(actionEnum) {
+		t.Fatalf("enum length mismatch: what=%d action=%d", len(whatEnum), len(actionEnum))
+	}
+	for i := range whatEnum {
+		if whatEnum[i] != actionEnum[i] {
+			t.Fatalf("enum mismatch at %d: what=%q action=%q", i, whatEnum[i], actionEnum[i])
+		}
+	}
+
+	if _, hasRequired := tool.InputSchema["required"]; hasRequired {
+		t.Fatal("interact schema should not hard-require 'what' when 'action' alias is supported")
+	}
+
+	anyOfRaw, ok := tool.InputSchema["anyOf"]
+	if !ok {
+		t.Fatal("interact schema missing anyOf dispatch requirement")
+	}
+	anyOf, ok := anyOfRaw.([]map[string]any)
+	if !ok {
+		t.Fatalf("interact anyOf type = %T, want []map[string]any", anyOfRaw)
+	}
+	if len(anyOf) != 2 {
+		t.Fatalf("interact anyOf length = %d, want 2", len(anyOf))
+	}
+
+	firstRequired := toSchemaStringSlice(t, anyOf[0]["required"])
+	secondRequired := toSchemaStringSlice(t, anyOf[1]["required"])
+	if len(firstRequired) != 1 || firstRequired[0] != "what" {
+		t.Fatalf("first anyOf required = %v, want [what]", firstRequired)
+	}
+	if len(secondRequired) != 1 || secondRequired[0] != "action" {
+		t.Fatalf("second anyOf required = %v, want [action]", secondRequired)
+	}
+}
+
+func toSchemaStringSlice(t *testing.T, raw any) []string {
+	t.Helper()
+	switch v := raw.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				t.Fatalf("string slice item[%d] type = %T, want string", i, item)
+			}
+			out = append(out, s)
+		}
+		return out
+	default:
+		t.Fatalf("string slice type = %T, want []string or []any", raw)
+		return nil
+	}
+}

--- a/internal/tools/configure/capabilities.go
+++ b/internal/tools/configure/capabilities.go
@@ -96,12 +96,7 @@ func BuildCapabilitiesSummary(tools []mcp.MCPTool) map[string]any {
 	toolsMap := make(map[string]any, len(tools))
 	for _, tool := range tools {
 		props, _ := tool.InputSchema["properties"].(map[string]any)
-		required := toStringSlice(tool.InputSchema["required"])
-
-		dispatchParam := ""
-		if len(required) > 0 {
-			dispatchParam = required[0]
-		}
+		dispatchParam := inferDispatchParam(tool.InputSchema, props)
 
 		modes := extractModes(dispatchParam, props)
 
@@ -122,12 +117,7 @@ func BuildCapabilitiesMap(tools []mcp.MCPTool) map[string]any {
 	toolsMap := make(map[string]any, len(tools))
 	for _, tool := range tools {
 		props, _ := tool.InputSchema["properties"].(map[string]any)
-		required := toStringSlice(tool.InputSchema["required"])
-
-		dispatchParam := ""
-		if len(required) > 0 {
-			dispatchParam = required[0]
-		}
+		dispatchParam := inferDispatchParam(tool.InputSchema, props)
 
 		modes := extractModes(dispatchParam, props)
 
@@ -152,6 +142,29 @@ func BuildCapabilitiesMap(tools []mcp.MCPTool) map[string]any {
 		}
 	}
 	return toolsMap
+}
+
+// inferDispatchParam selects the canonical mode/action parameter for a tool.
+// Primary source is schema.required[0]. For alias-friendly schemas that use
+// anyOf/oneOf instead of a top-level required field, fall back to known enum
+// dispatch keys so capabilities output remains stable.
+func inferDispatchParam(inputSchema map[string]any, props map[string]any) string {
+	required := toStringSlice(inputSchema["required"])
+	if len(required) > 0 {
+		return required[0]
+	}
+
+	candidates := []string{"what", "mode", "format", "action"}
+	for _, name := range candidates {
+		prop, ok := props[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		if len(toStringSlice(prop["enum"])) > 0 {
+			return name
+		}
+	}
+	return ""
 }
 
 func extractModes(dispatchParam string, props map[string]any) []string {

--- a/internal/tools/configure/capabilities_test.go
+++ b/internal/tools/configure/capabilities_test.go
@@ -134,6 +134,45 @@ func TestBuildCapabilitiesMap_NoRequired(t *testing.T) {
 	}
 }
 
+func TestBuildCapabilitiesMap_InferDispatchParamWhenRequiredOmitted(t *testing.T) {
+	t.Parallel()
+
+	tools := []mcp.MCPTool{
+		{
+			Name: "interact",
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"what": map[string]any{
+						"type": "string",
+						"enum": []string{"navigate", "click"},
+					},
+					"action": map[string]any{
+						"type": "string",
+						"enum": []string{"navigate", "click"},
+					},
+					"url": map[string]any{"type": "string"},
+				},
+				"anyOf": []map[string]any{
+					{"required": []string{"what"}},
+					{"required": []string{"action"}},
+				},
+			},
+		},
+	}
+
+	result := BuildCapabilitiesMap(tools)
+	tool := result["interact"].(map[string]any)
+
+	if got := tool["dispatch_param"]; got != "what" {
+		t.Fatalf("dispatch_param = %v, want what", got)
+	}
+
+	modes := tool["modes"].([]string)
+	if len(modes) != 2 || modes[0] != "navigate" || modes[1] != "click" {
+		t.Fatalf("modes = %v, want [navigate click]", modes)
+	}
+}
+
 func TestBuildCapabilitiesMap_IncludesModeParamsAndTypeMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Summary:\n- Allow interact schema dispatch via either what or action so action-only calls are valid at schema-validation time.\n- Keep what as canonical dispatch_param in describe_capabilities even when schema uses alias-friendly anyOf.\n- Add runtime guard for conflicting what/action values and clearer missing-dispatch guidance.\n- Add tests for interact schema alias dispatch and capabilities dispatch inference.\n\nWhy:\nIssue #268 reports action-only interact calls failing with required property what before runtime alias logic executes.\n\nFixes #268\n\nValidation:\n- go test ./internal/schema -count=1\n- go test ./internal/tools/configure -count=1\n- go test ./cmd/dev-console -run 'TestSchemaParity_InteractWhatEnumMatchesDispatch|TestDescribeCapabilities_ResponseStructure|TestDescribeCapabilities_ToolsHaveModes' -count=1\n- go test ./cmd/dev-console -run 'TestInteractStorageMutation_.*' -count=1