### PR TITLE
feat: compact response V2 — session preference, summary builders, review hardening

### DIFF
--- a/cmd/dev-console/handler.go
+++ b/cmd/dev-console/handler.go
@@ -33,6 +33,7 @@ Key patterns:
 - Performance: interact(action="navigate"|"refresh") auto-includes perf_diff. Add analyze=true to any interact action for profiling.
 - Noise filtering: use configure(action="noise_rule", noise_action="auto_detect") to suppress recurring noise.
 - Recovery: if tools return repeated connection errors or timeouts, use configure(action="restart") to force-restart the daemon. This works even when the daemon is completely unresponsive.
+- Token savings: pass summary=true to observe or analyze for compact responses (~60-70% smaller). Set once per session: configure(what="store", store_action="save", namespace="session", key="response_mode", data={"summary":true}). Use limit=N on interact(what="list_interactive") to cap returned elements.
 - For routing help, read gasoline://capabilities. For detailed docs, read gasoline://guide. For quick examples, read gasoline://quickstart.`
 
 // MCPHandler owns JSON-RPC request routing and response post-processing for MCP.

--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -160,6 +160,10 @@
           "description": "IndexedDB object store name (indexeddb)",
           "type": "string"
         },
+        "summary": {
+          "description": "Return compact summary instead of full entries (errors, logs, network_waterfall, network_bodies, websocket_events, actions, error_bundles, timeline, history)",
+          "type": "boolean"
+        },
         "telemetry_mode": {
           "description": "Telemetry metadata mode for this call: off, auto, full",
           "enum": [
@@ -329,6 +333,10 @@
             "info"
           ],
           "type": "string"
+        },
+        "summary": {
+          "description": "Return compact summary instead of full details (accessibility, security_audit, third_party_audit, form_validation)",
+          "type": "boolean"
         },
         "sync": {
           "description": "Wait for result (default: true).",
@@ -981,10 +989,6 @@
           "minimum": 1,
           "type": "integer"
         },
-        "tool": {
-          "description": "Filter describe_capabilities to a single tool by name (e.g. 'observe', 'interact')",
-          "type": "string"
-        },
         "tool_name": {
           "description": "Filter by tool name",
           "type": "string"
@@ -1050,8 +1054,20 @@
   },
   {
     "name": "interact",
-    "description": "Browser actions. Requires AI Web Pilot.\n\nSynchronous Mode (Default): Tools now block until the extension returns a result (up to 15s). Set background:true to return immediately with a correlation_id.\n\nSelectors: CSS or semantic (text=Submit, role=button, placeholder=Email, label=Name, aria-label=Close). subtitle param composable with any action. analyze=true captures perf_diff. navigate/refresh auto-include perf_diff.\n\nHardware Input: click/type/key_press auto-escalate to Chrome DevTools Protocol (CDP) for isTrusted:true events. Falls back to DOM primitives if CDP is unavailable. hardware_click accepts x/y coordinates for direct coordinate-based clicking.\n\nDraw Mode: draw_mode_start activates annotation overlay — user draws rectangles and types feedback, presses ESC to finish. Use analyze({what:'annotations'}) to retrieve results.\n\nCompatibility: action='screenshot' is a backward-compatible alias for observe({what:'screenshot'}).",
+    "description": "Browser actions. Requires AI Web Pilot.\n\nSynchronous Mode (Default): Tools now block until the extension returns a result (up to 15s). Set background:true to return immediately with a correlation_id.\n\nSelectors: CSS or semantic (text=Submit, role=button, placeholder=Email, label=Name, aria-label=Close). subtitle param composable with any action. analyze=true captures perf_diff. navigate/refresh auto-include perf_diff.\n\nDraw Mode: draw_mode_start activates annotation overlay — user draws rectangles and types feedback, presses ESC to finish. Use analyze({what:'annotations'}) to retrieve results.\n\nCompatibility: either what='navigate' or action='navigate' is accepted. action='screenshot' remains a backward-compatible alias for observe({what:'screenshot'}).",
     "inputSchema": {
+      "anyOf": [
+        {
+          "required": [
+            "what"
+          ]
+        },
+        {
+          "required": [
+            "action"
+          ]
+        }
+      ],
       "properties": {
         "action": {
           "description": "Deprecated alias for 'what'",
@@ -1107,8 +1123,7 @@
             "record_start",
             "record_stop",
             "upload",
-            "draw_mode_start",
-            "hardware_click"
+            "draw_mode_start"
           ],
           "type": "string"
         },
@@ -1225,6 +1240,10 @@
         "key": {
           "description": "Storage key for set_storage/delete_storage",
           "type": "string"
+        },
+        "limit": {
+          "description": "Max elements to return (list_interactive, default all)",
+          "type": "number"
         },
         "name": {
           "description": "Attribute, recording, or cookie name",
@@ -1392,8 +1411,7 @@
             "record_start",
             "record_stop",
             "upload",
-            "draw_mode_start",
-            "hardware_click"
+            "draw_mode_start"
           ],
           "type": "string"
         },
@@ -1405,19 +1423,8 @@
             "isolated"
           ],
           "type": "string"
-        },
-        "x": {
-          "description": "X coordinate in pixels from left (hardware_click, or click with x/y for CDP escalation)",
-          "type": "number"
-        },
-        "y": {
-          "description": "Y coordinate in pixels from top (hardware_click, or click with x/y for CDP escalation)",
-          "type": "number"
         }
       },
-      "required": [
-        "what"
-      ],
       "type": "object"
     }
   }

--- a/cmd/dev-console/tools_analyze.go
+++ b/cmd/dev-console/tools_analyze.go
@@ -139,6 +139,8 @@ func (h *ToolHandler) toolAnalyze(req JSONRPCRequest, args json.RawMessage) JSON
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+params.What, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
+	args = h.maybeInjectSummary(args)
+
 	return handler(h, req, args)
 }
 

--- a/cmd/dev-console/tools_analyze_inspect.go
+++ b/cmd/dev-console/tools_analyze_inspect.go
@@ -70,6 +70,11 @@ func (h *ToolHandler) toolFormValidation(req JSONRPCRequest, args json.RawMessag
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
 	}
 
+	var summaryParams struct {
+		Summary bool `json:"summary"`
+	}
+	json.Unmarshal(args, &summaryParams)
+
 	// Add mode=validate to params for the extension
 	var rawParams map[string]any
 	if json.Unmarshal(args, &rawParams) == nil {
@@ -87,7 +92,90 @@ func (h *ToolHandler) toolFormValidation(req JSONRPCRequest, args json.RawMessag
 	}
 	h.capture.CreatePendingQueryWithTimeout(query, queries.AsyncCommandTimeout, req.ClientID)
 
-	return h.MaybeWaitForCommand(req, correlationID, augmentedArgs, "Form validation queued")
+	resp := h.MaybeWaitForCommand(req, correlationID, augmentedArgs, "Form validation queued")
+
+	if summaryParams.Summary {
+		resp = buildFormValidationSummary(resp)
+	}
+
+	return resp
+}
+
+// buildFormValidationSummary extracts counts from form validation response.
+func buildFormValidationSummary(resp JSONRPCResponse) JSONRPCResponse {
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil || result.IsError {
+		return resp
+	}
+
+	for _, block := range result.Content {
+		idx := 0
+		for i, ch := range block.Text {
+			if ch == '{' {
+				idx = i
+				break
+			}
+		}
+		if idx == 0 && block.Text[0] != '{' {
+			continue
+		}
+
+		var data map[string]any
+		if json.Unmarshal([]byte(block.Text[idx:]), &data) != nil {
+			continue
+		}
+
+		// Extract forms array from result or result.result
+		forms := extractFormsList(data)
+		if forms == nil {
+			continue
+		}
+
+		totalForms := len(forms)
+		valid := 0
+		invalid := 0
+		for _, f := range forms {
+			fMap, ok := f.(map[string]any)
+			if !ok {
+				continue
+			}
+			if isValid, ok := fMap["valid"].(bool); ok && isValid {
+				valid++
+			} else {
+				invalid++
+			}
+		}
+
+		summaryData := map[string]any{
+			"total_forms": totalForms,
+			"valid":       valid,
+			"invalid":     invalid,
+		}
+		summaryJSON, _ := json.Marshal(summaryData)
+		result.Content = []MCPContentBlock{{Type: "text", Text: "Form validation summary\n" + string(summaryJSON)}}
+		newResult, _ := json.Marshal(result)
+		resp.Result = newResult
+		return resp
+	}
+
+	return resp
+}
+
+func extractFormsList(data map[string]any) []any {
+	if forms, ok := data["forms"].([]any); ok {
+		return forms
+	}
+	if result, ok := data["result"].(map[string]any); ok {
+		if forms, ok := result["forms"].([]any); ok {
+			return forms
+		}
+		if inner, ok := result["result"].(map[string]any); ok {
+			if forms, ok := inner["forms"].([]any); ok {
+				return forms
+			}
+		}
+	}
+	return nil
 }
 
 // ============================================

--- a/cmd/dev-console/tools_analyze_inspect_test.go
+++ b/cmd/dev-console/tools_analyze_inspect_test.go
@@ -1,0 +1,111 @@
+// Purpose: Validate form validation summary compact responses.
+// Why: Prevents silent regressions in form validation summary mode.
+// Docs: docs/features/feature/analyze-tool/index.md
+
+// tools_analyze_inspect_test.go — Tests for form validation summary builder.
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildFormValidationSummary_Basic(t *testing.T) {
+	t.Parallel()
+
+	formsData := map[string]any{
+		"forms": []any{
+			map[string]any{"id": "login", "valid": true},
+			map[string]any{"id": "search", "valid": false},
+			map[string]any{"id": "signup", "valid": false},
+		},
+	}
+	formsJSON, _ := json.Marshal(formsData)
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "Form validation results\n" + string(formsJSON)}},
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	summarized := buildFormValidationSummary(resp)
+
+	var summaryResult MCPToolResult
+	if err := json.Unmarshal(summarized.Result, &summaryResult); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse the JSON from the summary text
+	text := summaryResult.Content[0].Text
+	idx := 0
+	for i, ch := range text {
+		if ch == '{' {
+			idx = i
+			break
+		}
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(text[idx:]), &data); err != nil {
+		t.Fatalf("failed to parse summary JSON: %v", err)
+	}
+
+	if data["total_forms"] != float64(3) {
+		t.Errorf("total_forms = %v, want 3", data["total_forms"])
+	}
+	if data["valid"] != float64(1) {
+		t.Errorf("valid = %v, want 1", data["valid"])
+	}
+	if data["invalid"] != float64(2) {
+		t.Errorf("invalid = %v, want 2", data["invalid"])
+	}
+}
+
+func TestBuildFormValidationSummary_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "error occurred"}},
+		IsError: true,
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	// Should return original response unchanged
+	summarized := buildFormValidationSummary(resp)
+	if string(summarized.Result) != string(resp.Result) {
+		t.Error("error response should be returned unchanged")
+	}
+}
+
+func TestExtractFormsList_Direct(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{
+		"forms": []any{map[string]any{"id": "f1"}},
+	}
+	forms := extractFormsList(data)
+	if len(forms) != 1 {
+		t.Errorf("expected 1 form, got %d", len(forms))
+	}
+}
+
+func TestExtractFormsList_Nested(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{
+		"result": map[string]any{
+			"forms": []any{map[string]any{"id": "f1"}},
+		},
+	}
+	forms := extractFormsList(data)
+	if len(forms) != 1 {
+		t.Errorf("expected 1 form from nested result, got %d", len(forms))
+	}
+}
+
+func TestExtractFormsList_NoForms(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{"foo": "bar"}
+	forms := extractFormsList(data)
+	if forms != nil {
+		t.Error("expected nil for data without forms")
+	}
+}

--- a/cmd/dev-console/tools_analyze_security.go
+++ b/cmd/dev-console/tools_analyze_security.go
@@ -21,6 +21,7 @@ func (h *ToolHandler) toolSecurityAudit(req JSONRPCRequest, args json.RawMessage
 		SeverityMin string   `json:"severity_min"`
 		Checks      []string `json:"checks"`
 		URLFilter   string   `json:"url"`
+		Summary     bool     `json:"summary"`
 	}
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &params); err != nil {
@@ -58,10 +59,23 @@ func (h *ToolHandler) toolSecurityAudit(req JSONRPCRequest, args json.RawMessage
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInternal, err.Error(), "Internal error — do not retry")}
 	}
 
+	if params.Summary {
+		if scanResult, ok := result.(security.SecurityScanResult); ok {
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Security audit summary", buildSecurityAuditSummary(scanResult))}
+		}
+	}
+
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Security audit complete", result)}
 }
 
 func (h *ToolHandler) toolAuditThirdParties(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
+	var params struct {
+		Summary bool `json:"summary"`
+	}
+	if len(args) > 0 {
+		json.Unmarshal(args, &params)
+	}
+
 	// Gather data from capture buffers
 	networkBodies := h.capture.GetNetworkBodies()
 
@@ -78,5 +92,95 @@ func (h *ToolHandler) toolAuditThirdParties(req JSONRPCRequest, args json.RawMes
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, err.Error(), "Fix JSON arguments and try again")}
 	}
 
+	if params.Summary {
+		if tpResult, ok := result.(analysis.ThirdPartyResult); ok {
+			return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Third-party audit summary", buildThirdPartySummary(tpResult))}
+		}
+	}
+
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Third-party audit complete", result)}
+}
+
+// ============================================
+// Summary Builders
+// ============================================
+
+var severityOrder = map[string]int{"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+
+func buildSecurityAuditSummary(result security.SecurityScanResult) map[string]any {
+	bySeverity := make(map[string]int)
+	for _, f := range result.Findings {
+		bySeverity[f.Severity]++
+	}
+
+	topN := 5
+	if len(result.Findings) < topN {
+		topN = len(result.Findings)
+	}
+
+	// Sort findings by severity (critical first)
+	sorted := make([]security.SecurityFinding, len(result.Findings))
+	copy(sorted, result.Findings)
+	for i := 0; i < len(sorted)-1; i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if severityOrder[sorted[j].Severity] < severityOrder[sorted[i].Severity] {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	topIssues := make([]map[string]any, topN)
+	for i := 0; i < topN; i++ {
+		topIssues[i] = map[string]any{
+			"check":    sorted[i].Check,
+			"severity": sorted[i].Severity,
+			"title":    sorted[i].Title,
+		}
+	}
+
+	return map[string]any{
+		"total":       len(result.Findings),
+		"by_severity": bySeverity,
+		"top_issues":  topIssues,
+	}
+}
+
+func buildThirdPartySummary(result analysis.ThirdPartyResult) map[string]any {
+	byRisk := map[string]int{
+		"critical": result.Summary.CriticalRisk,
+		"high":     result.Summary.HighRisk,
+		"medium":   result.Summary.MediumRisk,
+		"low":      result.Summary.LowRisk,
+	}
+
+	topN := 5
+	if len(result.ThirdParties) < topN {
+		topN = len(result.ThirdParties)
+	}
+
+	// Sort by risk (critical first)
+	sorted := make([]analysis.ThirdPartyEntry, len(result.ThirdParties))
+	copy(sorted, result.ThirdParties)
+	for i := 0; i < len(sorted)-1; i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if severityOrder[sorted[j].RiskLevel] < severityOrder[sorted[i].RiskLevel] {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	top := make([]map[string]any, topN)
+	for i := 0; i < topN; i++ {
+		top[i] = map[string]any{
+			"origin": sorted[i].Origin,
+			"risk":   sorted[i].RiskLevel,
+			"reason": sorted[i].RiskReason,
+		}
+	}
+
+	return map[string]any{
+		"total_origins": len(result.ThirdParties),
+		"by_risk":       byRisk,
+		"top":           top,
+	}
 }

--- a/cmd/dev-console/tools_analyze_security_test.go
+++ b/cmd/dev-console/tools_analyze_security_test.go
@@ -1,0 +1,143 @@
+// Purpose: Validate analyze security/third-party summary compact responses.
+// Why: Prevents silent regressions in summary mode for security tools.
+// Docs: docs/features/feature/analyze-tool/index.md
+
+// tools_analyze_security_test.go — Tests for security audit + third-party audit summary builders.
+package main
+
+import (
+	"testing"
+
+	"github.com/dev-console/dev-console/internal/analysis"
+	"github.com/dev-console/dev-console/internal/security"
+)
+
+// ============================================
+// Security Audit Summary Tests
+// ============================================
+
+func TestBuildSecuritySummary_Basic(t *testing.T) {
+	t.Parallel()
+	result := security.SecurityScanResult{
+		Findings: []security.SecurityFinding{
+			{Check: "credentials", Severity: "critical", Title: "API key in response"},
+			{Check: "credentials", Severity: "high", Title: "Token in URL"},
+			{Check: "headers", Severity: "medium", Title: "Missing CSP"},
+			{Check: "headers", Severity: "medium", Title: "Missing HSTS"},
+			{Check: "transport", Severity: "low", Title: "Mixed content"},
+		},
+		Summary: security.ScanSummary{
+			TotalFindings: 5,
+			BySeverity:    map[string]int{"critical": 1, "high": 1, "medium": 2, "low": 1},
+			ByCheck:       map[string]int{"credentials": 2, "headers": 2, "transport": 1},
+		},
+	}
+
+	summary := buildSecurityAuditSummary(result)
+
+	if summary["total"] != 5 {
+		t.Errorf("total = %v, want 5", summary["total"])
+	}
+
+	bySeverity, ok := summary["by_severity"].(map[string]int)
+	if !ok {
+		t.Fatalf("by_severity wrong type: %T", summary["by_severity"])
+	}
+	if bySeverity["critical"] != 1 {
+		t.Errorf("critical = %d, want 1", bySeverity["critical"])
+	}
+
+	topIssues, ok := summary["top_issues"].([]map[string]any)
+	if !ok {
+		t.Fatalf("top_issues wrong type: %T", summary["top_issues"])
+	}
+	if len(topIssues) == 0 {
+		t.Fatal("expected at least one top issue")
+	}
+	if topIssues[0]["severity"] != "critical" {
+		t.Errorf("first top issue severity = %v, want critical", topIssues[0]["severity"])
+	}
+}
+
+func TestBuildSecuritySummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := security.SecurityScanResult{}
+	summary := buildSecurityAuditSummary(result)
+	if summary["total"] != 0 {
+		t.Errorf("total = %v, want 0", summary["total"])
+	}
+	topIssues := summary["top_issues"].([]map[string]any)
+	if len(topIssues) != 0 {
+		t.Errorf("expected 0 top issues, got %d", len(topIssues))
+	}
+}
+
+func TestBuildSecuritySummary_LimitTo5(t *testing.T) {
+	t.Parallel()
+	findings := make([]security.SecurityFinding, 8)
+	for i := range findings {
+		findings[i] = security.SecurityFinding{Check: "headers", Severity: "medium", Title: "issue"}
+	}
+	result := security.SecurityScanResult{Findings: findings}
+	summary := buildSecurityAuditSummary(result)
+	topIssues := summary["top_issues"].([]map[string]any)
+	if len(topIssues) > 5 {
+		t.Errorf("top_issues should be capped at 5, got %d", len(topIssues))
+	}
+}
+
+// ============================================
+// Third-party Audit Summary Tests
+// ============================================
+
+func TestBuildThirdPartySummary_Basic(t *testing.T) {
+	t.Parallel()
+	result := analysis.ThirdPartyResult{
+		ThirdParties: []analysis.ThirdPartyEntry{
+			{Origin: "https://cdn.evil.com", RiskLevel: "high", RiskReason: "unknown CDN"},
+			{Origin: "https://analytics.google.com", RiskLevel: "low", RiskReason: "known tracker"},
+			{Origin: "https://malware.xyz", RiskLevel: "critical", RiskReason: "suspicious domain"},
+		},
+		Summary: analysis.ThirdPartySummary{
+			TotalThirdParties: 3,
+			CriticalRisk:      1,
+			HighRisk:          1,
+			LowRisk:           1,
+		},
+	}
+
+	summary := buildThirdPartySummary(result)
+
+	if summary["total_origins"] != 3 {
+		t.Errorf("total_origins = %v, want 3", summary["total_origins"])
+	}
+
+	byRisk, ok := summary["by_risk"].(map[string]int)
+	if !ok {
+		t.Fatalf("by_risk wrong type: %T", summary["by_risk"])
+	}
+	if byRisk["critical"] != 1 {
+		t.Errorf("critical = %d, want 1", byRisk["critical"])
+	}
+
+	top, ok := summary["top"].([]map[string]any)
+	if !ok {
+		t.Fatalf("top wrong type: %T", summary["top"])
+	}
+	if len(top) != 3 {
+		t.Fatalf("expected 3 top entries, got %d", len(top))
+	}
+	// Critical should be first (sorted by severity)
+	if top[0]["risk"] != "critical" {
+		t.Errorf("first top entry risk = %v, want critical", top[0]["risk"])
+	}
+}
+
+func TestBuildThirdPartySummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := analysis.ThirdPartyResult{}
+	summary := buildThirdPartySummary(result)
+	if summary["total_origins"] != 0 {
+		t.Errorf("total_origins = %v, want 0", summary["total_origins"])
+	}
+}

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -197,6 +197,11 @@ func (h *ToolHandler) toolConfigureStore(req JSONRPCRequest, args json.RawMessag
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, err.Error(), "Fix the request parameters and try again")}
 	}
 
+	// Invalidate summary preference cache when response_mode is written
+	if namespace == "session" && compositeArgs.Key == "response_mode" {
+		h.invalidateSummaryPref()
+	}
+
 	// Parse result back to map for response
 	var responseData map[string]any
 	if err := json.Unmarshal(result, &responseData); err != nil {

--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -185,6 +185,11 @@ type ToolHandler struct {
 
 	// Module registry for plugin-style tool dispatch (incremental migration).
 	toolModules *toolModuleRegistry
+
+	// Session-level summary preference cache.
+	summaryPrefMu    sync.RWMutex
+	summaryPrefValue bool
+	summaryPrefReady bool
 }
 
 // GetCapture returns the capture instance

--- a/cmd/dev-console/tools_interact_elements.go
+++ b/cmd/dev-console/tools_interact_elements.go
@@ -18,6 +18,7 @@ func (h *ToolHandler) handleListInteractive(req JSONRPCRequest, args json.RawMes
 	var params struct {
 		TabID       int  `json:"tab_id,omitempty"`
 		VisibleOnly bool `json:"visible_only,omitempty"`
+		Limit       int  `json:"limit,omitempty"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidJSON, "Invalid JSON arguments: "+err.Error(), "Fix JSON syntax and call again")}
@@ -48,7 +49,12 @@ func (h *ToolHandler) handleListInteractive(req JSONRPCRequest, args json.RawMes
 	resp := h.MaybeWaitForCommand(req, correlationID, args, "list_interactive queued")
 
 	// Post-process: extract elements from result and build index→selector store
+	// IMPORTANT: index store is built from ALL elements before truncation
 	h.buildElementIndexFromResponse(resp)
+
+	if params.Limit > 0 {
+		resp = truncateListInteractiveResponse(resp, params.Limit)
+	}
 
 	return resp
 }
@@ -95,6 +101,69 @@ func (h *ToolHandler) buildElementIndexFromResponse(resp JSONRPCResponse) {
 		}
 		h.elementIndexMu.Unlock()
 		return
+	}
+}
+
+// truncateListInteractiveResponse limits the elements array in a list_interactive response.
+func truncateListInteractiveResponse(resp JSONRPCResponse, limit int) JSONRPCResponse {
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil || result.IsError {
+		return resp
+	}
+
+	for i, block := range result.Content {
+		idx := strings.Index(block.Text, "{")
+		if idx < 0 {
+			continue
+		}
+		jsonStr := block.Text[idx:]
+		prefix := block.Text[:idx]
+
+		var data map[string]any
+		if json.Unmarshal([]byte(jsonStr), &data) != nil {
+			continue
+		}
+
+		elements := act.ExtractElementList(data)
+		if elements == nil || len(elements) <= limit {
+			continue
+		}
+
+		total := len(elements)
+		setNestedElements(data, elements[:limit])
+		data["total"] = total
+		data["truncated"] = true
+
+		newJSON, err := json.Marshal(data)
+		if err != nil {
+			continue
+		}
+		result.Content[i].Text = prefix + string(newJSON)
+		newResult, _ := json.Marshal(result)
+		resp.Result = newResult
+		return resp
+	}
+
+	return resp
+}
+
+// setNestedElements updates the elements array at whatever nesting level it was found.
+func setNestedElements(data map[string]any, elements []any) {
+	if _, ok := data["elements"]; ok {
+		data["elements"] = elements
+		return
+	}
+	if r, ok := data["result"].(map[string]any); ok {
+		if _, ok := r["elements"]; ok {
+			r["elements"] = elements
+			return
+		}
+		if rr, ok := r["result"].(map[string]any); ok {
+			if _, ok := rr["elements"]; ok {
+				rr["elements"] = elements
+				return
+			}
+		}
 	}
 }
 

--- a/cmd/dev-console/tools_interact_elements_test.go
+++ b/cmd/dev-console/tools_interact_elements_test.go
@@ -173,3 +173,100 @@ func TestExtractElementList_NoElements(t *testing.T) {
 		t.Error("expected nil for data without elements")
 	}
 }
+
+// ============================================
+// List Interactive Limit/Truncation Tests
+// ============================================
+
+func TestTruncateListInteractiveResponse_Basic(t *testing.T) {
+	t.Parallel()
+
+	elements := make([]any, 20)
+	for i := range elements {
+		elements[i] = map[string]any{"index": float64(i), "selector": "#el-" + string(rune('a'+i)), "tag": "div"}
+	}
+	elemData := map[string]any{"elements": elements}
+	elemJSON, _ := json.Marshal(elemData)
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "list_interactive results\n" + string(elemJSON)}},
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	truncated := truncateListInteractiveResponse(resp, 5)
+
+	// Parse truncated response
+	var truncResult MCPToolResult
+	if err := json.Unmarshal(truncated.Result, &truncResult); err != nil {
+		t.Fatal(err)
+	}
+
+	text := truncResult.Content[0].Text
+	idx := 0
+	for i, ch := range text {
+		if ch == '{' {
+			idx = i
+			break
+		}
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(text[idx:]), &data); err != nil {
+		t.Fatalf("parse truncated JSON: %v", err)
+	}
+
+	elems, ok := data["elements"].([]any)
+	if !ok {
+		t.Fatal("elements not found in truncated response")
+	}
+	if len(elems) != 5 {
+		t.Errorf("expected 5 elements, got %d", len(elems))
+	}
+	if data["total"] != float64(20) {
+		t.Errorf("total = %v, want 20", data["total"])
+	}
+	if data["truncated"] != true {
+		t.Errorf("truncated = %v, want true", data["truncated"])
+	}
+}
+
+func TestTruncateListInteractiveResponse_NoTruncationNeeded(t *testing.T) {
+	t.Parallel()
+
+	elemData := map[string]any{
+		"elements": []any{
+			map[string]any{"index": float64(0), "selector": "#a"},
+			map[string]any{"index": float64(1), "selector": "#b"},
+		},
+	}
+	elemJSON, _ := json.Marshal(elemData)
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: string(elemJSON)}},
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	truncated := truncateListInteractiveResponse(resp, 10)
+
+	// Should be unchanged
+	if string(truncated.Result) != string(resp.Result) {
+		t.Error("response should be unchanged when limit > element count")
+	}
+}
+
+func TestTruncateListInteractiveResponse_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	result := MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: "error"}},
+		IsError: true,
+	}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: resultJSON}
+
+	truncated := truncateListInteractiveResponse(resp, 5)
+	if string(truncated.Result) != string(resp.Result) {
+		t.Error("error response should be unchanged")
+	}
+}

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -149,6 +149,8 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown observe mode: "+params.What, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
+	args = h.maybeInjectSummary(args)
+
 	resp := handler(h, req, args)
 
 	// Warn when extension is disconnected (except for server-side modes that don't need it)

--- a/cmd/dev-console/tools_summary_pref.go
+++ b/cmd/dev-console/tools_summary_pref.go
@@ -1,0 +1,98 @@
+// tools_summary_pref.go — Session-level summary preference injection.
+package main
+
+import "encoding/json"
+
+// loadSummaryPref reads the cached summary preference.
+// On first call (or after invalidation), loads from session store.
+func (h *ToolHandler) loadSummaryPref() bool {
+	h.summaryPrefMu.RLock()
+	if h.summaryPrefReady {
+		val := h.summaryPrefValue
+		h.summaryPrefMu.RUnlock()
+		return val
+	}
+	h.summaryPrefMu.RUnlock()
+
+	// Upgrade to write lock and load from store
+	h.summaryPrefMu.Lock()
+	defer h.summaryPrefMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if h.summaryPrefReady {
+		return h.summaryPrefValue
+	}
+
+	h.summaryPrefReady = true
+	h.summaryPrefValue = false
+
+	if h.sessionStoreImpl == nil {
+		return false
+	}
+
+	data, err := h.sessionStoreImpl.Load("session", "response_mode")
+	if err != nil || len(data) == 0 {
+		return false
+	}
+
+	var pref struct {
+		Summary bool `json:"summary"`
+	}
+	if err := json.Unmarshal(data, &pref); err != nil {
+		return false
+	}
+	h.summaryPrefValue = pref.Summary
+	return h.summaryPrefValue
+}
+
+// invalidateSummaryPref clears the cached preference, forcing a re-read.
+func (h *ToolHandler) invalidateSummaryPref() {
+	h.summaryPrefMu.Lock()
+	defer h.summaryPrefMu.Unlock()
+	h.summaryPrefReady = false
+	h.summaryPrefValue = false
+}
+
+// maybeInjectSummary adds "summary":true to args when:
+// 1. Session preference is set
+// 2. Args don't already contain "summary" or "full" keys
+// Parses args at most once to avoid redundant JSON overhead.
+func (h *ToolHandler) maybeInjectSummary(args json.RawMessage) json.RawMessage {
+	if !h.loadSummaryPref() {
+		return args
+	}
+
+	if len(args) == 0 || string(args) == "null" {
+		return json.RawMessage(`{"summary":true}`)
+	}
+
+	// Single parse: check for existing keys and inject in one pass
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(args, &m); err != nil {
+		return args
+	}
+	if _, ok := m["summary"]; ok {
+		return args
+	}
+	if _, ok := m["full"]; ok {
+		return args
+	}
+
+	m["summary"] = json.RawMessage(`true`)
+	// Error impossible: simple map of JSON values
+	result, _ := json.Marshal(m)
+	return result
+}
+
+// argHasKey checks if a JSON object contains a specific key.
+func argHasKey(args json.RawMessage, key string) bool {
+	if len(args) == 0 || string(args) == "null" {
+		return false
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(args, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/cmd/dev-console/tools_summary_pref_test.go
+++ b/cmd/dev-console/tools_summary_pref_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestArgHasKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args string
+		key  string
+		want bool
+	}{
+		{"present string", `{"summary":true,"limit":10}`, "summary", true},
+		{"present false", `{"summary":false}`, "summary", true},
+		{"absent", `{"limit":10}`, "summary", false},
+		{"empty object", `{}`, "summary", false},
+		{"null args", `null`, "summary", false},
+		{"full key present", `{"full":true}`, "full", true},
+		{"full key absent", `{"summary":true}`, "full", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := argHasKey(json.RawMessage(tt.args), tt.key)
+			if got != tt.want {
+				t.Errorf("argHasKey(%s, %q) = %v, want %v", tt.args, tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaybeInjectSummary_NoPreference(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	// No preference set (summaryPrefReady=false, summaryPrefValue=false)
+	args := json.RawMessage(`{"what":"errors","limit":10}`)
+	result := h.maybeInjectSummary(args)
+
+	// Should return args unchanged
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := parsed["summary"]; ok {
+		t.Error("expected no summary key when preference not set")
+	}
+}
+
+func TestMaybeInjectSummary_PreferenceSet(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	args := json.RawMessage(`{"what":"errors","limit":10}`)
+	result := h.maybeInjectSummary(args)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary, ok := parsed["summary"]
+	if !ok {
+		t.Fatal("expected summary key to be injected")
+	}
+	if summary != true {
+		t.Errorf("expected summary=true, got %v", summary)
+	}
+}
+
+func TestMaybeInjectSummary_ExplicitSummaryFalse(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	args := json.RawMessage(`{"what":"errors","summary":false}`)
+	result := h.maybeInjectSummary(args)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// summary key was already present, so it should NOT be overridden
+	summary, ok := parsed["summary"]
+	if !ok {
+		t.Fatal("expected summary key to still be present")
+	}
+	if summary != false {
+		t.Errorf("expected summary=false (explicit override), got %v", summary)
+	}
+}
+
+func TestMaybeInjectSummary_ExplicitFullTrue(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	args := json.RawMessage(`{"what":"errors","full":true}`)
+	result := h.maybeInjectSummary(args)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// "full" is present, so summary should NOT be injected
+	if _, ok := parsed["summary"]; ok {
+		t.Error("expected no summary key when full=true is present")
+	}
+}
+
+func TestInvalidateSummaryPref(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	h.invalidateSummaryPref()
+
+	if h.summaryPrefReady {
+		t.Error("expected summaryPrefReady to be false after invalidation")
+	}
+}
+
+func TestMaybeInjectSummary_NilArgs(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	// nil args should get summary injected
+	result := h.maybeInjectSummary(nil)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := parsed["summary"]; !ok {
+		t.Error("expected summary key to be injected into nil args")
+	}
+}
+
+func TestMaybeInjectSummary_EmptyArgs(t *testing.T) {
+	t.Parallel()
+
+	h := &ToolHandler{}
+	h.summaryPrefReady = true
+	h.summaryPrefValue = true
+
+	result := h.maybeInjectSummary(json.RawMessage(`{}`))
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary, ok := parsed["summary"]
+	if !ok {
+		t.Fatal("expected summary key to be injected into empty args")
+	}
+	if summary != true {
+		t.Errorf("expected summary=true, got %v", summary)
+	}
+}

--- a/internal/schema/analyze.go
+++ b/internal/schema/analyze.go
@@ -142,6 +142,10 @@ func AnalyzeToolSchema() mcp.MCPTool {
 					"type":        "number",
 					"description": "Pixel diff threshold 0-255 (visual_diff, default 30)",
 				},
+				"summary": map[string]any{
+					"type":        "boolean",
+					"description": "Return compact summary instead of full details (accessibility, security_audit, third_party_audit, form_validation)",
+				},
 			},
 			"required": []string{"what"},
 		},

--- a/internal/schema/interact.go
+++ b/internal/schema/interact.go
@@ -86,6 +86,10 @@ func InteractToolSchema() mcp.MCPTool {
 					"type":        "boolean",
 					"description": "Only return visible elements (list_interactive)",
 				},
+				"limit": map[string]any{
+					"type":        "number",
+					"description": "Max elements to return (list_interactive, default all)",
+				},
 				"frame": map[string]any{
 					"description": "Target iframe: CSS selector, 0-based index, or \"all\"",
 					"type":        "string",

--- a/internal/schema/observe.go
+++ b/internal/schema/observe.go
@@ -168,6 +168,10 @@ func ObserveToolSchema() mcp.MCPTool {
 					"type":        "number",
 					"description": "Minimum occurrences to form a group (summarized_logs, default 2)",
 				},
+				"summary": map[string]any{
+					"type":        "boolean",
+					"description": "Return compact summary instead of full entries (errors, logs, network_waterfall, network_bodies, websocket_events, actions, error_bundles, timeline, history)",
+				},
 			},
 			"required": []string{"what"},
 		},

--- a/internal/tools/configure/mode_specs.go
+++ b/internal/tools/configure/mode_specs.go
@@ -115,36 +115,36 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 	// ── observe ────────────────────────────────────────────────
 	"observe": {
 		"errors": {
-			Hint:     "Raw JavaScript console errors",
-			Optional: []string{"scope", "limit"},
+			Hint:     "Raw JavaScript console errors. summary=true returns counts by source + top messages",
+			Optional: []string{"scope", "limit", "summary"},
 		},
 		"logs": {
-			Hint:     "Console log messages with level/source filtering",
-			Optional: []string{"min_level", "level", "source", "include_internal", "include_extension_logs", "extension_limit", "limit", "scope"},
+			Hint:     "Console log messages with level/source filtering. summary=true returns counts by level/source",
+			Optional: []string{"min_level", "level", "source", "include_internal", "include_extension_logs", "extension_limit", "limit", "scope", "summary"},
 		},
 		"extension_logs": {
 			Hint:     "Gasoline extension internal debug logs",
 			Optional: []string{"limit"},
 		},
 		"network_waterfall": {
-			Hint:     "HTTP request/response timeline with status and timing",
-			Optional: []string{"url", "method", "status_min", "status_max", "limit", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction"},
+			Hint:     "HTTP request/response timeline with status and timing. summary=true returns compact {url,ms,type} entries",
+			Optional: []string{"url", "method", "status_min", "status_max", "limit", "summary", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction"},
 		},
 		"network_bodies": {
-			Hint:     "HTTP response bodies with JSON path extraction",
-			Optional: []string{"url", "body_key", "body_path", "method", "status_min", "status_max", "limit", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction"},
+			Hint:     "HTTP response bodies with JSON path extraction. summary=true returns status groups + top URLs",
+			Optional: []string{"url", "body_key", "body_path", "method", "status_min", "status_max", "limit", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction", "summary"},
 		},
 		"websocket_events": {
-			Hint:     "WebSocket message frames (incoming/outgoing)",
-			Optional: []string{"connection_id", "direction", "limit", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction"},
+			Hint:     "WebSocket message frames (incoming/outgoing). summary=true returns direction/event counts",
+			Optional: []string{"connection_id", "direction", "limit", "after_cursor", "before_cursor", "since_cursor", "restart_on_eviction", "summary"},
 		},
 		"websocket_status": {
 			Hint:     "Active WebSocket connection states",
 			Optional: []string{"limit"},
 		},
 		"actions": {
-			Hint:     "User interaction log (clicks, inputs, navigation)",
-			Optional: []string{"limit", "after_cursor", "before_cursor", "since_cursor", "last_n", "restart_on_eviction"},
+			Hint:     "User interaction log (clicks, inputs, navigation). summary=true returns counts by type + time range",
+			Optional: []string{"limit", "after_cursor", "before_cursor", "since_cursor", "last_n", "restart_on_eviction", "summary"},
 		},
 		"vitals": {
 			Hint:     "Core Web Vitals (LCP, CLS, INP, FCP, TTFB)",
@@ -157,20 +157,20 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 			Hint: "All open browser tabs with URLs",
 		},
 		"history": {
-			Hint:     "Recent page navigation history",
-			Optional: []string{"limit"},
+			Hint:     "Recent page navigation history. summary=true returns counts only",
+			Optional: []string{"limit", "summary"},
 		},
 		"pilot": {
 			Hint:     "AI Web Pilot connection status and availability",
 			Optional: []string{"limit"},
 		},
 		"timeline": {
-			Hint:     "Merged chronological view of actions, errors, network, and WebSocket events",
-			Optional: []string{"include", "limit"},
+			Hint:     "Merged chronological view of actions, errors, network, and WebSocket events. summary=true returns counts by type",
+			Optional: []string{"include", "limit", "summary"},
 		},
 		"error_bundles": {
-			Hint:     "Pre-assembled debug context per error (error + network + actions + logs in time window)",
-			Optional: []string{"window_seconds", "limit", "scope"},
+			Hint:     "Pre-assembled debug context per error (error + network + actions + logs in time window). summary=true returns bundle counts + unique messages",
+			Optional: []string{"window_seconds", "limit", "scope", "summary"},
 		},
 		"screenshot": {
 			Hint:     "Capture page screenshot (full page or element)",
@@ -318,8 +318,8 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 			Optional: []string{"script", "world", "timeout_ms"},
 		},
 		"list_interactive": {
-			Hint:     "List all clickable/typeable elements on the page",
-			Optional: []string{"visible_only", "frame", "scope_selector"},
+			Hint:     "List all clickable/typeable elements on the page. Use limit to cap results",
+			Optional: []string{"visible_only", "frame", "scope_selector", "limit"},
 		},
 		"get_readable": {
 			Hint:     "Extract readable text content from the page",
@@ -435,8 +435,8 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 			Hint: "Page load performance metrics and bottleneck analysis",
 		},
 		"accessibility": {
-			Hint:     "WCAG/axe accessibility audit with violation details",
-			Optional: []string{"selector", "scope", "tags", "force_refresh", "frame"},
+			Hint:     "WCAG/axe accessibility audit with violation details. summary=true returns counts + top issues",
+			Optional: []string{"selector", "scope", "tags", "force_refresh", "frame", "summary"},
 		},
 		"error_clusters": {
 			Hint: "Group errors by pattern to identify systemic issues",
@@ -445,12 +445,12 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 			Hint: "Analyze navigation history patterns",
 		},
 		"security_audit": {
-			Hint:     "Check for credential leaks, CSP, cookie, and header risks",
-			Optional: []string{"checks", "severity_min"},
+			Hint:     "Check for credential leaks, CSP, cookie, and header risks. summary=true returns counts + top issues",
+			Optional: []string{"checks", "severity_min", "summary"},
 		},
 		"third_party_audit": {
-			Hint:     "Audit third-party script origins and data exposure",
-			Optional: []string{"first_party_origins", "include_static", "custom_lists"},
+			Hint:     "Audit third-party script origins and data exposure. summary=true returns counts + top origins",
+			Optional: []string{"first_party_origins", "include_static", "custom_lists", "summary"},
 		},
 		"link_health": {
 			Hint:     "Check all page links for broken URLs (404s, timeouts)",
@@ -492,7 +492,8 @@ var toolModeSpecs = map[string]map[string]modeParamSpec{
 			Optional: []string{"selector", "frame"},
 		},
 		"form_validation": {
-			Hint: "Check form validation rules and constraint violations",
+			Hint:     "Check form validation rules and constraint violations. summary=true returns counts only",
+			Optional: []string{"summary"},
 		},
 		"visual_baseline": {
 			Hint:     "Capture a baseline screenshot for visual regression",

--- a/internal/tools/observe/analysis.go
+++ b/internal/tools/observe/analysis.go
@@ -20,18 +20,28 @@ func GetNetworkWaterfall(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage
 	var params struct {
 		Limit     int    `json:"limit"`
 		URLFilter string `json:"url"`
+		Summary   bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	params.Limit = clampLimit(params.Limit, 100)
 
 	allEntries := refreshWaterfallIfStale(deps)
-	entries := filterWaterfallEntries(allEntries, params.URLFilter, params.Limit)
 
 	var newestTS time.Time
 	if len(allEntries) > 0 {
 		newestTS = allEntries[len(allEntries)-1].Timestamp
 	}
 
+	if params.Summary {
+		entries := filterWaterfallSummaryEntries(allEntries, params.URLFilter, params.Limit)
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Network waterfall", map[string]any{
+			"entries":  entries,
+			"count":    len(entries),
+			"metadata": BuildResponseMetadata(deps.GetCapture(), newestTS),
+		})}
+	}
+
+	entries := filterWaterfallEntries(allEntries, params.URLFilter, params.Limit)
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Network waterfall", map[string]any{
 		"entries":  entries,
 		"count":    len(entries),
@@ -98,6 +108,26 @@ func waterfallEntryToMap(entry capture.NetworkWaterfallEntry) map[string]any {
 		"timestamp":         entry.Timestamp,
 		"page_url":          entry.PageURL,
 	}
+}
+
+func waterfallSummaryEntry(entry capture.NetworkWaterfallEntry) map[string]any {
+	url := entry.URL
+	if len(url) > 80 {
+		url = url[:80] + "..."
+	}
+	return map[string]any{"url": url, "ms": entry.Duration, "type": entry.InitiatorType}
+}
+
+func filterWaterfallSummaryEntries(allEntries []capture.NetworkWaterfallEntry, urlFilter string, limit int) []map[string]any {
+	entries := make([]map[string]any, 0)
+	for i := len(allEntries) - 1; i >= 0 && len(entries) < limit; i-- {
+		entry := allEntries[i]
+		if urlFilter != "" && (entry.URL == "" || !ContainsIgnoreCase(entry.URL, urlFilter)) {
+			continue
+		}
+		entries = append(entries, waterfallSummaryEntry(entry))
+	}
+	return entries
 }
 
 // GetWSStatus returns the current WebSocket connection status.
@@ -241,6 +271,7 @@ func RunA11yAudit(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.J
 		Tags         []string `json:"tags"`
 		ForceRefresh bool     `json:"force_refresh"`
 		Frame        any      `json:"frame"`
+		Summary      bool     `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	if params.Scope == "" && params.Selector != "" {
@@ -260,6 +291,10 @@ func RunA11yAudit(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.J
 	var auditResult map[string]any
 	if err := json.Unmarshal(result, &auditResult); err != nil {
 		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.StructuredErrorResponse(mcp.ErrInvalidJSON, "Failed to parse a11y result: "+err.Error(), "Check extension logs for errors")}
+	}
+
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("A11y audit", buildA11ySummary(auditResult))}
 	}
 
 	ensureA11ySummary(auditResult)
@@ -400,6 +435,7 @@ func GetSessionTimeline(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage)
 	var params struct {
 		Limit   int      `json:"limit"`
 		Include []string `json:"include"`
+		Summary bool     `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	if params.Limit <= 0 {
@@ -415,6 +451,12 @@ func GetSessionTimeline(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage)
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Timestamp > entries[j].Timestamp
 	})
+
+	if params.Summary {
+		summary := buildTimelineSummary(entries)
+		summary["metadata"] = BuildResponseMetadata(deps.GetCapture(), time.Now())
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Timeline", summary)}
+	}
 
 	if len(entries) > params.Limit {
 		entries = entries[:params.Limit]
@@ -517,6 +559,28 @@ func collectTimelineWebSocket(wsEvents []capture.WebSocketEvent) []timelineEntry
 		})
 	}
 	return entries
+}
+
+func buildTimelineSummary(entries []timelineEntry) map[string]any {
+	counts := make(map[string]int)
+	var first, last string
+	for _, e := range entries {
+		counts[e.Type]++
+		if first == "" || e.Timestamp < first {
+			first = e.Timestamp
+		}
+		if last == "" || e.Timestamp > last {
+			last = e.Timestamp
+		}
+	}
+	result := map[string]any{
+		"counts_by_type": counts,
+		"total":          len(entries),
+	}
+	if first != "" {
+		result["time_range"] = map[string]string{"first": first, "last": last}
+	}
+	return result
 }
 
 // ============================================
@@ -627,13 +691,26 @@ type historyEntry struct {
 }
 
 // AnalyzeHistory extracts navigation history from captured user actions.
-func AnalyzeHistory(deps Deps, req mcp.JSONRPCRequest, _ json.RawMessage) mcp.JSONRPCResponse {
+func AnalyzeHistory(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JSONRPCResponse {
+	var params struct {
+		Limit   int  `json:"limit"`
+		Summary bool `json:"summary"`
+	}
+	mcp.LenientUnmarshal(args, &params)
+
 	actions := deps.GetCapture().GetAllEnhancedActions()
 	entries := buildHistoryEntries(actions)
+	entries = limitHistoryEntries(entries, clampLimit(params.Limit, 0))
+
+	responseMeta := BuildResponseMetadata(deps.GetCapture(), time.Now())
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("History", buildHistorySummary(entries, responseMeta))}
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("History", map[string]any{
 		"entries":  entries,
 		"count":    len(entries),
-		"metadata": BuildResponseMetadata(deps.GetCapture(), time.Now()),
+		"metadata": responseMeta,
 	})}
 }
 
@@ -653,5 +730,58 @@ func buildHistoryEntries(actions []capture.EnhancedAction) []historyEntry {
 		}
 	}
 	return entries
+}
+
+func limitHistoryEntries(entries []historyEntry, limit int) []historyEntry {
+	if limit <= 0 || len(entries) <= limit {
+		return entries
+	}
+	return entries[len(entries)-limit:]
+}
+
+// buildA11ySummary creates a compact representation of an a11y audit result.
+func buildA11ySummary(auditResult map[string]any) map[string]any {
+	passes, _ := auditResult["passes"].([]any)
+	violations, _ := auditResult["violations"].([]any)
+	incomplete, _ := auditResult["incomplete"].([]any)
+
+	type issueInfo struct {
+		rule     string
+		severity string
+		count    int
+	}
+	issues := make([]issueInfo, 0, len(violations))
+	for _, v := range violations {
+		vMap, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		rule, _ := vMap["id"].(string)
+		impact, _ := vMap["impact"].(string)
+		nodes, _ := vMap["nodes"].([]any)
+		issues = append(issues, issueInfo{rule: rule, severity: impact, count: len(nodes)})
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].count > issues[j].count
+	})
+	topN := 5
+	if len(issues) < topN {
+		topN = len(issues)
+	}
+	topIssues := make([]map[string]any, topN)
+	for i := 0; i < topN; i++ {
+		topIssues[i] = map[string]any{
+			"rule":     issues[i].rule,
+			"count":    issues[i].count,
+			"severity": issues[i].severity,
+		}
+	}
+
+	return map[string]any{
+		"pass":       len(passes),
+		"violations": len(violations),
+		"incomplete": len(incomplete),
+		"top_issues": topIssues,
+	}
 }
 

--- a/internal/tools/observe/analysis_test.go
+++ b/internal/tools/observe/analysis_test.go
@@ -1,0 +1,341 @@
+// Purpose: Validate observe analysis summary and compact response functions.
+// Why: Prevents silent regressions in summary/compact response features.
+// Docs: docs/features/feature/observe/index.md
+
+// analysis_test.go — Tests for waterfall summary, timeline summary, history limit, and a11y compact.
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/capture"
+)
+
+// ============================================
+// Waterfall Summary Tests
+// ============================================
+
+func TestWaterfallSummaryEntry_CompactFields(t *testing.T) {
+	t.Parallel()
+	entry := capture.NetworkWaterfallEntry{
+		URL:             "https://example.com/api/data",
+		InitiatorType:   "fetch",
+		Duration:        123.45,
+		StartTime:       100.0,
+		TransferSize:    5000,
+		DecodedBodySize: 10000,
+		EncodedBodySize: 5000,
+		Timestamp:       time.Now(),
+		PageURL:         "https://example.com",
+	}
+
+	result := waterfallSummaryEntry(entry)
+
+	// Should have exactly 3 fields: url, ms, type
+	if len(result) != 3 {
+		t.Errorf("expected 3 fields, got %d: %v", len(result), result)
+	}
+	if result["url"] != "https://example.com/api/data" {
+		t.Errorf("url = %v, want https://example.com/api/data", result["url"])
+	}
+	if result["ms"] != 123.45 {
+		t.Errorf("ms = %v, want 123.45", result["ms"])
+	}
+	if result["type"] != "fetch" {
+		t.Errorf("type = %v, want fetch", result["type"])
+	}
+}
+
+func TestWaterfallSummaryEntry_URLTruncation(t *testing.T) {
+	t.Parallel()
+	longURL := "https://example.com/" + string(make([]byte, 100)) // > 80 chars
+	for i := range longURL {
+		if i >= 20 && longURL[i] == 0 {
+			// Fill with 'a' chars after the prefix
+		}
+	}
+	// Build a URL that's definitely > 80 chars
+	longURL = "https://example.com/api/v1/very/long/path/that/exceeds/eighty/characters/limit/and/keeps/going/further"
+
+	entry := capture.NetworkWaterfallEntry{
+		URL:           longURL,
+		InitiatorType: "xmlhttprequest",
+		Duration:      50.0,
+	}
+
+	result := waterfallSummaryEntry(entry)
+
+	url := result["url"].(string)
+	if len(url) > 83 { // 80 + "..."
+		t.Errorf("URL should be truncated, len=%d: %s", len(url), url)
+	}
+	if url[len(url)-3:] != "..." {
+		t.Errorf("truncated URL should end with ..., got: %s", url)
+	}
+}
+
+func TestWaterfallSummaryEntry_ShortURL(t *testing.T) {
+	t.Parallel()
+	entry := capture.NetworkWaterfallEntry{
+		URL:           "https://a.co/x",
+		InitiatorType: "script",
+		Duration:      10.0,
+	}
+
+	result := waterfallSummaryEntry(entry)
+	if result["url"] != "https://a.co/x" {
+		t.Errorf("short URL should not be truncated: %v", result["url"])
+	}
+}
+
+func TestFilterWaterfallSummaryEntries(t *testing.T) {
+	t.Parallel()
+	entries := []capture.NetworkWaterfallEntry{
+		{URL: "https://example.com/a", InitiatorType: "fetch", Duration: 10.0},
+		{URL: "https://example.com/b", InitiatorType: "script", Duration: 20.0},
+		{URL: "https://other.com/c", InitiatorType: "img", Duration: 30.0},
+	}
+
+	result := filterWaterfallSummaryEntries(entries, "", 10)
+	if len(result) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(result))
+	}
+	// Each entry should have exactly 3 fields
+	for i, entry := range result {
+		if len(entry) != 3 {
+			t.Errorf("entry %d: expected 3 fields, got %d", i, len(entry))
+		}
+	}
+}
+
+func TestFilterWaterfallSummaryEntries_WithFilter(t *testing.T) {
+	t.Parallel()
+	entries := []capture.NetworkWaterfallEntry{
+		{URL: "https://example.com/a", InitiatorType: "fetch", Duration: 10.0},
+		{URL: "https://other.com/b", InitiatorType: "script", Duration: 20.0},
+	}
+
+	result := filterWaterfallSummaryEntries(entries, "example", 10)
+	if len(result) != 1 {
+		t.Errorf("expected 1 filtered entry, got %d", len(result))
+	}
+}
+
+func TestFilterWaterfallSummaryEntries_WithLimit(t *testing.T) {
+	t.Parallel()
+	entries := []capture.NetworkWaterfallEntry{
+		{URL: "https://example.com/a", InitiatorType: "fetch", Duration: 10.0},
+		{URL: "https://example.com/b", InitiatorType: "script", Duration: 20.0},
+		{URL: "https://example.com/c", InitiatorType: "img", Duration: 30.0},
+	}
+
+	result := filterWaterfallSummaryEntries(entries, "", 2)
+	if len(result) != 2 {
+		t.Errorf("expected 2 entries with limit, got %d", len(result))
+	}
+}
+
+// ============================================
+// Timeline Summary Tests
+// ============================================
+
+func TestBuildTimelineSummary_CountsByType(t *testing.T) {
+	t.Parallel()
+	entries := []timelineEntry{
+		{Timestamp: "2024-01-01T00:00:01Z", Type: "action", Summary: "click"},
+		{Timestamp: "2024-01-01T00:00:02Z", Type: "action", Summary: "type"},
+		{Timestamp: "2024-01-01T00:00:03Z", Type: "error", Summary: "ReferenceError"},
+		{Timestamp: "2024-01-01T00:00:04Z", Type: "network", Summary: "GET /api"},
+		{Timestamp: "2024-01-01T00:00:05Z", Type: "network", Summary: "POST /api"},
+		{Timestamp: "2024-01-01T00:00:06Z", Type: "network", Summary: "GET /img"},
+		{Timestamp: "2024-01-01T00:00:07Z", Type: "websocket", Summary: "message"},
+	}
+
+	result := buildTimelineSummary(entries)
+
+	counts, ok := result["counts_by_type"].(map[string]int)
+	if !ok {
+		t.Fatalf("counts_by_type wrong type: %T", result["counts_by_type"])
+	}
+	if counts["action"] != 2 {
+		t.Errorf("action count = %d, want 2", counts["action"])
+	}
+	if counts["error"] != 1 {
+		t.Errorf("error count = %d, want 1", counts["error"])
+	}
+	if counts["network"] != 3 {
+		t.Errorf("network count = %d, want 3", counts["network"])
+	}
+	if counts["websocket"] != 1 {
+		t.Errorf("websocket count = %d, want 1", counts["websocket"])
+	}
+
+	if result["total"] != 7 {
+		t.Errorf("total = %v, want 7", result["total"])
+	}
+
+	timeRange, ok := result["time_range"].(map[string]string)
+	if !ok {
+		t.Fatalf("time_range wrong type: %T", result["time_range"])
+	}
+	if timeRange["first"] != "2024-01-01T00:00:01Z" {
+		t.Errorf("first = %v, want 2024-01-01T00:00:01Z", timeRange["first"])
+	}
+	if timeRange["last"] != "2024-01-01T00:00:07Z" {
+		t.Errorf("last = %v, want 2024-01-01T00:00:07Z", timeRange["last"])
+	}
+}
+
+func TestBuildTimelineSummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := buildTimelineSummary(nil)
+	if result["total"] != 0 {
+		t.Errorf("total = %v, want 0", result["total"])
+	}
+}
+
+// ============================================
+// History Limit Tests
+// ============================================
+
+func TestBuildHistoryEntries_Limit(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UnixMilli()
+	actions := []capture.EnhancedAction{
+		{Type: "navigate", Timestamp: now - 3000, ToURL: "https://a.com"},
+		{Type: "navigate", Timestamp: now - 2000, ToURL: "https://b.com"},
+		{Type: "navigate", Timestamp: now - 1000, ToURL: "https://c.com"},
+	}
+
+	entries := buildHistoryEntries(actions)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 history entries, got %d", len(entries))
+	}
+
+	// Now test with limit
+	limited := limitHistoryEntries(entries, 2)
+	if len(limited) != 2 {
+		t.Errorf("expected 2 entries with limit, got %d", len(limited))
+	}
+	// Should keep the most recent (last) entries
+	if limited[0].ToURL != "https://b.com" {
+		t.Errorf("first limited entry = %s, want https://b.com", limited[0].ToURL)
+	}
+	if limited[1].ToURL != "https://c.com" {
+		t.Errorf("second limited entry = %s, want https://c.com", limited[1].ToURL)
+	}
+}
+
+func TestLimitHistoryEntries_NoTruncation(t *testing.T) {
+	t.Parallel()
+	entries := []historyEntry{
+		{ToURL: "https://a.com"},
+		{ToURL: "https://b.com"},
+	}
+	limited := limitHistoryEntries(entries, 10)
+	if len(limited) != 2 {
+		t.Errorf("expected 2 entries (no truncation), got %d", len(limited))
+	}
+}
+
+func TestLimitHistoryEntries_ZeroLimit(t *testing.T) {
+	t.Parallel()
+	entries := []historyEntry{
+		{ToURL: "https://a.com"},
+	}
+	// Zero limit means no limit applied
+	limited := limitHistoryEntries(entries, 0)
+	if len(limited) != 1 {
+		t.Errorf("expected 1 entry with zero limit, got %d", len(limited))
+	}
+}
+
+// ============================================
+// A11y Summary Tests
+// ============================================
+
+func TestBuildA11ySummary_Compact(t *testing.T) {
+	t.Parallel()
+	auditResult := map[string]any{
+		"passes": []any{
+			map[string]any{"id": "rule1"},
+			map[string]any{"id": "rule2"},
+		},
+		"violations": []any{
+			map[string]any{
+				"id":      "color-contrast",
+				"impact":  "serious",
+				"nodes":   []any{map[string]any{}, map[string]any{}, map[string]any{}},
+			},
+			map[string]any{
+				"id":      "image-alt",
+				"impact":  "critical",
+				"nodes":   []any{map[string]any{}},
+			},
+		},
+		"incomplete": []any{
+			map[string]any{"id": "aria-label"},
+		},
+	}
+
+	result := buildA11ySummary(auditResult)
+
+	if result["pass"] != 2 {
+		t.Errorf("pass = %v, want 2", result["pass"])
+	}
+	if result["violations"] != 2 {
+		t.Errorf("violations = %v, want 2", result["violations"])
+	}
+	if result["incomplete"] != 1 {
+		t.Errorf("incomplete = %v, want 1", result["incomplete"])
+	}
+
+	topIssues, ok := result["top_issues"].([]map[string]any)
+	if !ok {
+		t.Fatalf("top_issues wrong type: %T", result["top_issues"])
+	}
+	if len(topIssues) != 2 {
+		t.Fatalf("expected 2 top issues, got %d", len(topIssues))
+	}
+	// Should be sorted by node count descending
+	if topIssues[0]["rule"] != "color-contrast" {
+		t.Errorf("first issue = %v, want color-contrast", topIssues[0]["rule"])
+	}
+	if topIssues[0]["count"] != 3 {
+		t.Errorf("first issue count = %v, want 3", topIssues[0]["count"])
+	}
+	if topIssues[0]["severity"] != "serious" {
+		t.Errorf("first issue severity = %v, want serious", topIssues[0]["severity"])
+	}
+}
+
+func TestBuildA11ySummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := buildA11ySummary(map[string]any{})
+	if result["pass"] != 0 {
+		t.Errorf("pass = %v, want 0", result["pass"])
+	}
+	if result["violations"] != 0 {
+		t.Errorf("violations = %v, want 0", result["violations"])
+	}
+}
+
+func TestBuildA11ySummary_TopIssuesLimitedTo5(t *testing.T) {
+	t.Parallel()
+	violations := make([]any, 7)
+	for i := range violations {
+		violations[i] = map[string]any{
+			"id":     "rule-" + string(rune('a'+i)),
+			"impact": "minor",
+			"nodes":  []any{map[string]any{}},
+		}
+	}
+	auditResult := map[string]any{"violations": violations}
+
+	result := buildA11ySummary(auditResult)
+	topIssues := result["top_issues"].([]map[string]any)
+	if len(topIssues) != 5 {
+		t.Errorf("expected 5 top issues (capped), got %d", len(topIssues))
+	}
+}

--- a/internal/tools/observe/bundling.go
+++ b/internal/tools/observe/bundling.go
@@ -34,6 +34,7 @@ func GetErrorBundles(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mc
 		Limit         int    `json:"limit"`
 		WindowSeconds int    `json:"window_seconds"`
 		URL           string `json:"url"`
+		Summary       bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	if params.Limit <= 0 {
@@ -62,6 +63,10 @@ func GetErrorBundles(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mc
 	var newestEntry time.Time
 	if len(errors) > 0 {
 		newestEntry = errors[0].ts
+	}
+
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Error bundles", buildErrorBundlesSummary(bundles, newestEntry, BuildResponseMetadata(cap, newestEntry)))}
 	}
 
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Error bundles", map[string]any{

--- a/internal/tools/observe/handlers.go
+++ b/internal/tools/observe/handlers.go
@@ -57,9 +57,10 @@ func clampLimit(limit, defaultVal int) int {
 // GetBrowserErrors returns error-level log entries from the capture buffer.
 func GetBrowserErrors(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JSONRPCResponse {
 	var params struct {
-		Limit int    `json:"limit"`
-		URL   string `json:"url"`
-		Scope string `json:"scope"`
+		Limit   int    `json:"limit"`
+		URL     string `json:"url"`
+		Scope   string `json:"scope"`
+		Summary bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	params.Limit = clampLimit(params.Limit, 100)
@@ -124,6 +125,10 @@ func GetBrowserErrors(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) m
 	responseMeta := BuildResponseMetadata(deps.GetCapture(), newestTS)
 	responseMeta.NoiseSuppressed = noiseSuppressed
 
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Browser errors", buildErrorsSummary(errors, noiseSuppressed, responseMeta))}
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Browser errors", map[string]any{
 		"errors":   errors,
 		"count":    len(errors),
@@ -149,6 +154,7 @@ func GetBrowserLogs(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp
 		IncludeInternal   bool   `json:"include_internal"`
 		IncludeExtension  bool   `json:"include_extension_logs"`
 		ExtensionLimit    int    `json:"extension_limit"`
+		Summary           bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	if params.Scope == "" {
@@ -247,10 +253,17 @@ func GetBrowserLogs(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp
 		}
 	}
 
-	meta := BuildPaginatedResponseMetadata(deps.GetCapture(), newestTS, pMeta)
+	isFirstPage := params.AfterCursor == "" && params.BeforeCursor == "" && params.SinceCursor == ""
+	meta := BuildPaginatedMetadataWithSummary(deps.GetCapture(), newestTS, pMeta, isFirstPage, func() map[string]any {
+		return quickLogsSummary(logs)
+	})
 	meta["scope"] = params.Scope
 	if noiseSuppressed > 0 {
 		meta["noise_suppressed"] = noiseSuppressed
+	}
+
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Browser logs", buildLogsSummary(logs, meta))}
 	}
 
 	response := map[string]any{
@@ -426,6 +439,7 @@ func GetNetworkBodies(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) m
 		StatusMax int    `json:"status_max"`
 		BodyKey   string `json:"body_key"`
 		BodyPath  string `json:"body_path"`
+		Summary   bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	if params.BodyKey != "" && params.BodyPath != "" {
@@ -474,10 +488,15 @@ func GetNetworkBodies(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) m
 		newestTS, _ = time.Parse(time.RFC3339, allBodies[len(allBodies)-1].Timestamp)
 	}
 
+	responseMeta := BuildResponseMetadata(deps.GetCapture(), newestTS)
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Network bodies", buildNetworkBodiesSummary(filtered, responseMeta))}
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Network bodies", map[string]any{
 		"entries":  filtered,
 		"count":    len(filtered),
-		"metadata": BuildResponseMetadata(deps.GetCapture(), newestTS),
+		"metadata": responseMeta,
 	})}
 }
 
@@ -488,6 +507,7 @@ func GetWSEvents(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JS
 		URL          string `json:"url"`
 		ConnectionID string `json:"connection_id"`
 		Direction    string `json:"direction"`
+		Summary      bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	params.Limit = clampLimit(params.Limit, 100)
@@ -512,18 +532,24 @@ func GetWSEvents(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JS
 		newestTS, _ = time.Parse(time.RFC3339, allEvents[len(allEvents)-1].Timestamp)
 	}
 
+	responseMeta := BuildResponseMetadata(deps.GetCapture(), newestTS)
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("WebSocket events", buildWSEventsSummary(filtered, responseMeta))}
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("WebSocket events", map[string]any{
 		"entries":  filtered,
 		"count":    len(filtered),
-		"metadata": BuildResponseMetadata(deps.GetCapture(), newestTS),
+		"metadata": responseMeta,
 	})}
 }
 
 // GetEnhancedActions returns captured user actions (clicks, inputs, navigations).
 func GetEnhancedActions(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage) mcp.JSONRPCResponse {
 	var params struct {
-		Limit int    `json:"limit"`
-		URL   string `json:"url"`
+		Limit   int    `json:"limit"`
+		URL     string `json:"url"`
+		Summary bool   `json:"summary"`
 	}
 	mcp.LenientUnmarshal(args, &params)
 	params.Limit = clampLimit(params.Limit, 100)
@@ -542,10 +568,15 @@ func GetEnhancedActions(deps Deps, req mcp.JSONRPCRequest, args json.RawMessage)
 		newestTS = time.UnixMilli(allActions[len(allActions)-1].Timestamp)
 	}
 
+	responseMeta := BuildResponseMetadata(deps.GetCapture(), newestTS)
+	if params.Summary {
+		return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Enhanced actions", buildActionsSummary(filtered, responseMeta))}
+	}
+
 	return mcp.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcp.JSONResponse("Enhanced actions", map[string]any{
 		"entries":  filtered,
 		"count":    len(filtered),
-		"metadata": BuildResponseMetadata(deps.GetCapture(), newestTS),
+		"metadata": responseMeta,
 	})}
 }
 

--- a/internal/tools/observe/summary_builders.go
+++ b/internal/tools/observe/summary_builders.go
@@ -1,0 +1,306 @@
+// summary_builders.go — Compact summary builders for observe modes.
+package observe
+
+import (
+	"sort"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/capture"
+	"github.com/dev-console/dev-console/internal/pagination"
+)
+
+// buildErrorsSummary returns {total, by_source, top_messages, metadata}.
+func buildErrorsSummary(errors []map[string]any, noiseSuppressed int, meta ResponseMetadata) map[string]any {
+	bySource := make(map[string]int)
+	msgCounts := make(map[string]int)
+
+	for _, e := range errors {
+		src, _ := e["source"].(string)
+		if src == "" {
+			src = "unknown"
+		}
+		bySource[src]++
+
+		msg, _ := e["message"].(string)
+		if msg != "" {
+			msg = truncateRunes(msg, 100)
+			msgCounts[msg]++
+		}
+	}
+
+	// Build top messages sorted by frequency
+	type msgCount struct {
+		msg   string
+		count int
+	}
+	ranked := make([]msgCount, 0, len(msgCounts))
+	for msg, count := range msgCounts {
+		ranked = append(ranked, msgCount{msg, count})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].count > ranked[j].count
+	})
+	topN := 5
+	if len(ranked) < topN {
+		topN = len(ranked)
+	}
+	topMessages := make([]map[string]any, topN)
+	for i := 0; i < topN; i++ {
+		topMessages[i] = map[string]any{"message": ranked[i].msg, "count": ranked[i].count}
+	}
+
+	result := map[string]any{
+		"total":        len(errors),
+		"by_source":    bySource,
+		"top_messages": topMessages,
+		"metadata":     meta,
+	}
+	if noiseSuppressed > 0 {
+		result["noise_suppressed"] = noiseSuppressed
+	}
+	return result
+}
+
+// buildLogsSummary returns {total, by_level, by_source, metadata}.
+func buildLogsSummary(logs []map[string]any, meta map[string]any) map[string]any {
+	byLevel := make(map[string]int)
+	bySource := make(map[string]int)
+
+	for _, l := range logs {
+		level, _ := l["level"].(string)
+		if level == "" {
+			level = "unknown"
+		}
+		byLevel[level]++
+
+		src, _ := l["source"].(string)
+		if src == "" {
+			src = "unknown"
+		}
+		bySource[src]++
+	}
+
+	return map[string]any{
+		"total":     len(logs),
+		"by_level":  byLevel,
+		"by_source": bySource,
+		"metadata":  meta,
+	}
+}
+
+// buildNetworkBodiesSummary returns {total, by_status_group, by_method, top_urls, metadata}.
+func buildNetworkBodiesSummary(bodies []capture.NetworkBody, meta ResponseMetadata) map[string]any {
+	byStatus := make(map[string]int)
+	byMethod := make(map[string]int)
+	seenURLs := make(map[string]bool)
+	urls := make([]string, 0)
+
+	for _, b := range bodies {
+		// Status grouping: 2xx, 3xx, 4xx, 5xx
+		group := statusGroup(b.Status)
+		byStatus[group]++
+
+		method := b.Method
+		if method == "" {
+			method = "GET"
+		}
+		byMethod[method]++
+
+		url := b.URL
+		if len([]rune(url)) > 80 {
+			url = string([]rune(url)[:80]) + "..."
+		}
+		if !seenURLs[url] {
+			seenURLs[url] = true
+			urls = append(urls, url)
+		}
+	}
+
+	topN := 5
+	if len(urls) < topN {
+		topN = len(urls)
+	}
+
+	return map[string]any{
+		"total":           len(bodies),
+		"by_status_group": byStatus,
+		"by_method":       byMethod,
+		"recent_urls":     urls[:topN],
+		"metadata":        meta,
+	}
+}
+
+// statusGroup converts an HTTP status code to a group string (2xx, 3xx, etc.).
+func statusGroup(status int) string {
+	switch {
+	case status >= 200 && status < 300:
+		return "2xx"
+	case status >= 300 && status < 400:
+		return "3xx"
+	case status >= 400 && status < 500:
+		return "4xx"
+	case status >= 500 && status < 600:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
+// buildErrorBundlesSummary returns {total_bundles, unique_error_messages, newest_entry, metadata}.
+func buildErrorBundlesSummary(bundles []map[string]any, newestEntry time.Time, meta ResponseMetadata) map[string]any {
+	seen := make(map[string]bool)
+	messages := make([]string, 0)
+
+	for _, b := range bundles {
+		errMap, ok := b["error"].(map[string]any)
+		if !ok {
+			continue
+		}
+		msg, _ := errMap["message"].(string)
+		if msg != "" && !seen[msg] {
+			seen[msg] = true
+			messages = append(messages, msg)
+		}
+	}
+
+	result := map[string]any{
+		"total_bundles":         len(bundles),
+		"unique_error_messages": messages,
+		"metadata":              meta,
+	}
+	if !newestEntry.IsZero() {
+		result["newest_entry"] = newestEntry.Format(time.RFC3339)
+	}
+	return result
+}
+
+// buildWSEventsSummary returns {total, by_direction, by_event_type, connection_count, metadata}.
+func buildWSEventsSummary(events []capture.WebSocketEvent, meta ResponseMetadata) map[string]any {
+	byDirection := make(map[string]int)
+	byEvent := make(map[string]int)
+	connIDs := make(map[string]bool)
+
+	for _, e := range events {
+		if e.Direction != "" {
+			byDirection[e.Direction]++
+		}
+		if e.Event != "" {
+			byEvent[e.Event]++
+		}
+		if e.ID != "" {
+			connIDs[e.ID] = true
+		}
+	}
+
+	return map[string]any{
+		"total":            len(events),
+		"by_direction":     byDirection,
+		"by_event_type":    byEvent,
+		"connection_count": len(connIDs),
+		"metadata":         meta,
+	}
+}
+
+// buildActionsSummary returns {total, by_type, time_range, metadata}.
+func buildActionsSummary(actions []capture.EnhancedAction, meta ResponseMetadata) map[string]any {
+	byType := make(map[string]int)
+	var firstTS, lastTS int64
+	hasTS := false
+
+	for _, a := range actions {
+		byType[a.Type]++
+		if !hasTS || a.Timestamp < firstTS {
+			firstTS = a.Timestamp
+			hasTS = true
+		}
+		if a.Timestamp > lastTS {
+			lastTS = a.Timestamp
+		}
+	}
+
+	result := map[string]any{
+		"total":    len(actions),
+		"by_type":  byType,
+		"metadata": meta,
+	}
+	if hasTS {
+		result["time_range"] = map[string]string{
+			"first": time.UnixMilli(firstTS).Format(time.RFC3339),
+			"last":  time.UnixMilli(lastTS).Format(time.RFC3339),
+		}
+	}
+	return result
+}
+
+// buildHistorySummary returns {total, by_type, unique_urls, metadata}.
+func buildHistorySummary(entries []historyEntry, meta ResponseMetadata) map[string]any {
+	byType := make(map[string]int)
+	urls := make(map[string]bool)
+
+	for _, e := range entries {
+		if e.Type != "" {
+			byType[e.Type]++
+		}
+		if e.ToURL != "" {
+			urls[e.ToURL] = true
+		}
+	}
+
+	return map[string]any{
+		"total":       len(entries),
+		"by_type":     byType,
+		"unique_urls": len(urls),
+		"metadata":    meta,
+	}
+}
+
+// quickLogsSummary is a lightweight version for pagination header (just by_level + total).
+func quickLogsSummary(logs []map[string]any) map[string]any {
+	byLevel := make(map[string]int)
+	for _, l := range logs {
+		level, _ := l["level"].(string)
+		if level == "" {
+			level = "unknown"
+		}
+		byLevel[level]++
+	}
+	return map[string]any{
+		"total":    len(logs),
+		"by_level": byLevel,
+	}
+}
+
+// truncateRunes truncates a string to maxRunes runes, avoiding mid-character splits.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes])
+}
+
+// BuildPaginatedMetadataWithSummary adds a summary block to first-page paginated responses.
+func BuildPaginatedMetadataWithSummary(
+	cap *capture.Capture, newestEntry time.Time,
+	pMeta *pagination.CursorPaginationMetadata,
+	isFirstPage bool,
+	summaryFn func() map[string]any,
+) map[string]any {
+	var meta map[string]any
+	if cap != nil {
+		meta = BuildPaginatedResponseMetadata(cap, newestEntry, pMeta)
+	} else {
+		// Nil capture — build minimal metadata for testing
+		meta = map[string]any{
+			"total":   pMeta.Total,
+			"has_more": pMeta.HasMore,
+		}
+		if pMeta.Cursor != "" {
+			meta["cursor"] = pMeta.Cursor
+		}
+	}
+	if isFirstPage && summaryFn != nil {
+		meta["summary"] = summaryFn()
+	}
+	return meta
+}

--- a/internal/tools/observe/summary_builders_test.go
+++ b/internal/tools/observe/summary_builders_test.go
@@ -1,0 +1,453 @@
+// summary_builders_test.go — Tests for compact summary builders.
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dev-console/dev-console/internal/capture"
+	"github.com/dev-console/dev-console/internal/pagination"
+)
+
+func TestBuildErrorsSummary_CountsBySource(t *testing.T) {
+	t.Parallel()
+	errors := []map[string]any{
+		{"message": "err1", "source": "console", "timestamp": "2024-01-01T00:00:00Z"},
+		{"message": "err2", "source": "console", "timestamp": "2024-01-01T00:00:01Z"},
+		{"message": "err3", "source": "network", "timestamp": "2024-01-01T00:00:02Z"},
+	}
+	meta := ResponseMetadata{RetrievedAt: "2024-01-01T00:00:03Z", DataAge: "1.0s"}
+	result := buildErrorsSummary(errors, 0, meta)
+
+	total, _ := result["total"].(int)
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+
+	bySource, ok := result["by_source"].(map[string]int)
+	if !ok {
+		t.Fatal("by_source not a map[string]int")
+	}
+	if bySource["console"] != 2 {
+		t.Errorf("console count = %d, want 2", bySource["console"])
+	}
+	if bySource["network"] != 1 {
+		t.Errorf("network count = %d, want 1", bySource["network"])
+	}
+}
+
+func TestBuildErrorsSummary_TopMessages(t *testing.T) {
+	t.Parallel()
+	errors := make([]map[string]any, 0)
+	for i := 0; i < 10; i++ {
+		errors = append(errors, map[string]any{"message": "repeated error", "source": "js"})
+	}
+	for i := 0; i < 3; i++ {
+		errors = append(errors, map[string]any{"message": "less common", "source": "js"})
+	}
+	errors = append(errors, map[string]any{"message": "rare error", "source": "js"})
+
+	result := buildErrorsSummary(errors, 0, ResponseMetadata{})
+	topMessages, ok := result["top_messages"].([]map[string]any)
+	if !ok {
+		t.Fatal("top_messages not a []map[string]any")
+	}
+	if len(topMessages) == 0 {
+		t.Fatal("top_messages is empty")
+	}
+	// First should be the most frequent
+	if topMessages[0]["message"] != "repeated error" {
+		t.Errorf("first top message = %v, want 'repeated error'", topMessages[0]["message"])
+	}
+	if topMessages[0]["count"] != 10 {
+		t.Errorf("first count = %v, want 10", topMessages[0]["count"])
+	}
+	// Should be capped at 5
+	if len(topMessages) > 5 {
+		t.Errorf("top_messages len = %d, want <= 5", len(topMessages))
+	}
+}
+
+func TestBuildErrorsSummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := buildErrorsSummary(nil, 0, ResponseMetadata{})
+	total, _ := result["total"].(int)
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+}
+
+func TestBuildLogsSummary_CountsByLevel(t *testing.T) {
+	t.Parallel()
+	logs := []map[string]any{
+		{"level": "info", "message": "a"},
+		{"level": "info", "message": "b"},
+		{"level": "warn", "message": "c"},
+		{"level": "error", "message": "d"},
+	}
+	result := buildLogsSummary(logs, map[string]any{})
+
+	total, _ := result["total"].(int)
+	if total != 4 {
+		t.Errorf("total = %d, want 4", total)
+	}
+
+	byLevel, ok := result["by_level"].(map[string]int)
+	if !ok {
+		t.Fatal("by_level not a map[string]int")
+	}
+	if byLevel["info"] != 2 {
+		t.Errorf("info count = %d, want 2", byLevel["info"])
+	}
+	if byLevel["warn"] != 1 {
+		t.Errorf("warn count = %d, want 1", byLevel["warn"])
+	}
+	if byLevel["error"] != 1 {
+		t.Errorf("error count = %d, want 1", byLevel["error"])
+	}
+}
+
+func TestBuildLogsSummary_CountsBySource(t *testing.T) {
+	t.Parallel()
+	logs := []map[string]any{
+		{"level": "info", "source": "console"},
+		{"level": "info", "source": "console"},
+		{"level": "warn", "source": "network"},
+	}
+	result := buildLogsSummary(logs, map[string]any{})
+
+	bySource, ok := result["by_source"].(map[string]int)
+	if !ok {
+		t.Fatal("by_source not a map[string]int")
+	}
+	if bySource["console"] != 2 {
+		t.Errorf("console count = %d, want 2", bySource["console"])
+	}
+}
+
+func TestBuildNetworkBodiesSummary_StatusGrouping(t *testing.T) {
+	t.Parallel()
+	bodies := []capture.NetworkBody{
+		{URL: "http://a.com/api", Method: "GET", Status: 200},
+		{URL: "http://a.com/api2", Method: "GET", Status: 201},
+		{URL: "http://a.com/api3", Method: "POST", Status: 404},
+		{URL: "http://a.com/api4", Method: "GET", Status: 500},
+	}
+	result := buildNetworkBodiesSummary(bodies, ResponseMetadata{})
+
+	byStatus, ok := result["by_status_group"].(map[string]int)
+	if !ok {
+		t.Fatal("by_status_group not a map[string]int")
+	}
+	if byStatus["2xx"] != 2 {
+		t.Errorf("2xx count = %d, want 2", byStatus["2xx"])
+	}
+	if byStatus["4xx"] != 1 {
+		t.Errorf("4xx count = %d, want 1", byStatus["4xx"])
+	}
+	if byStatus["5xx"] != 1 {
+		t.Errorf("5xx count = %d, want 1", byStatus["5xx"])
+	}
+}
+
+func TestBuildNetworkBodiesSummary_RecentURLs(t *testing.T) {
+	t.Parallel()
+	longURL := "http://example.com/" + string(make([]byte, 100))
+	bodies := []capture.NetworkBody{
+		{URL: longURL, Method: "GET", Status: 200},
+		{URL: "http://short.com", Method: "GET", Status: 200},
+	}
+	result := buildNetworkBodiesSummary(bodies, ResponseMetadata{})
+
+	recentURLs, ok := result["recent_urls"].([]string)
+	if !ok {
+		t.Fatal("recent_urls not a []string")
+	}
+	if len(recentURLs) != 2 {
+		t.Fatalf("recent_urls len = %d, want 2", len(recentURLs))
+	}
+	// Long URL should be truncated to 80 runes + "..."
+	if len([]rune(recentURLs[0])) > 84 {
+		t.Errorf("long URL not truncated: rune len=%d", len([]rune(recentURLs[0])))
+	}
+}
+
+func TestBuildErrorBundlesSummary_Counts(t *testing.T) {
+	t.Parallel()
+	bundles := []map[string]any{
+		{"error": map[string]any{"message": "err1"}},
+		{"error": map[string]any{"message": "err2"}},
+		{"error": map[string]any{"message": "err1"}},
+	}
+	meta := ResponseMetadata{RetrievedAt: "2024-01-01T00:00:00Z"}
+	result := buildErrorBundlesSummary(bundles, time.Now(), meta)
+
+	total, _ := result["total_bundles"].(int)
+	if total != 3 {
+		t.Errorf("total_bundles = %d, want 3", total)
+	}
+
+	messages, ok := result["unique_error_messages"].([]string)
+	if !ok {
+		t.Fatal("unique_error_messages not a []string")
+	}
+	if len(messages) != 2 {
+		t.Errorf("unique_error_messages len = %d, want 2", len(messages))
+	}
+
+	// Verify metadata is included
+	if _, ok := result["metadata"]; !ok {
+		t.Error("expected metadata key in error bundles summary")
+	}
+}
+
+func TestBuildWSEventsSummary_ByDirection(t *testing.T) {
+	t.Parallel()
+	events := []capture.WebSocketEvent{
+		{Direction: "incoming", ID: "conn1", Event: "message"},
+		{Direction: "incoming", ID: "conn1", Event: "message"},
+		{Direction: "outgoing", ID: "conn1", Event: "message"},
+	}
+	result := buildWSEventsSummary(events, ResponseMetadata{})
+
+	byDir, ok := result["by_direction"].(map[string]int)
+	if !ok {
+		t.Fatal("by_direction not a map[string]int")
+	}
+	if byDir["incoming"] != 2 {
+		t.Errorf("incoming = %d, want 2", byDir["incoming"])
+	}
+	if byDir["outgoing"] != 1 {
+		t.Errorf("outgoing = %d, want 1", byDir["outgoing"])
+	}
+}
+
+func TestBuildWSEventsSummary_UniqueConnections(t *testing.T) {
+	t.Parallel()
+	events := []capture.WebSocketEvent{
+		{Direction: "incoming", ID: "conn1", Event: "message"},
+		{Direction: "incoming", ID: "conn2", Event: "message"},
+		{Direction: "incoming", ID: "conn1", Event: "message"},
+	}
+	result := buildWSEventsSummary(events, ResponseMetadata{})
+
+	connCount, _ := result["connection_count"].(int)
+	if connCount != 2 {
+		t.Errorf("connection_count = %d, want 2", connCount)
+	}
+}
+
+func TestBuildActionsSummary_ByType(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UnixMilli()
+	actions := []capture.EnhancedAction{
+		{Type: "click", Timestamp: now},
+		{Type: "click", Timestamp: now + 1000},
+		{Type: "type", Timestamp: now + 2000},
+		{Type: "navigate", Timestamp: now + 3000},
+	}
+	result := buildActionsSummary(actions, ResponseMetadata{})
+
+	total, _ := result["total"].(int)
+	if total != 4 {
+		t.Errorf("total = %d, want 4", total)
+	}
+
+	byType, ok := result["by_type"].(map[string]int)
+	if !ok {
+		t.Fatal("by_type not a map[string]int")
+	}
+	if byType["click"] != 2 {
+		t.Errorf("click = %d, want 2", byType["click"])
+	}
+	if byType["type"] != 1 {
+		t.Errorf("type = %d, want 1", byType["type"])
+	}
+}
+
+func TestBuildActionsSummary_TimeRange(t *testing.T) {
+	t.Parallel()
+	t1 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli()
+	t2 := time.Date(2024, 1, 1, 10, 5, 0, 0, time.UTC).UnixMilli()
+	actions := []capture.EnhancedAction{
+		{Type: "click", Timestamp: t1},
+		{Type: "click", Timestamp: t2},
+	}
+	result := buildActionsSummary(actions, ResponseMetadata{})
+
+	timeRange, ok := result["time_range"].(map[string]string)
+	if !ok {
+		t.Fatal("time_range not a map[string]string")
+	}
+	if timeRange["first"] == "" || timeRange["last"] == "" {
+		t.Error("expected first and last timestamps in time_range")
+	}
+}
+
+func TestQuickLogsSummary_ByLevel(t *testing.T) {
+	t.Parallel()
+	logs := []map[string]any{
+		{"level": "info"},
+		{"level": "info"},
+		{"level": "error"},
+	}
+	result := quickLogsSummary(logs)
+
+	total, _ := result["total"].(int)
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+
+	byLevel, ok := result["by_level"].(map[string]int)
+	if !ok {
+		t.Fatal("by_level not a map[string]int")
+	}
+	if byLevel["info"] != 2 {
+		t.Errorf("info = %d, want 2", byLevel["info"])
+	}
+	if byLevel["error"] != 1 {
+		t.Errorf("error = %d, want 1", byLevel["error"])
+	}
+}
+
+func TestBuildLogsSummary_EmptySourceBucketed(t *testing.T) {
+	t.Parallel()
+	logs := []map[string]any{
+		{"level": "info", "source": ""},
+		{"level": "info", "source": "console"},
+	}
+	result := buildLogsSummary(logs, map[string]any{})
+
+	bySource, ok := result["by_source"].(map[string]int)
+	if !ok {
+		t.Fatal("by_source not a map[string]int")
+	}
+	if bySource["unknown"] != 1 {
+		t.Errorf("unknown count = %d, want 1", bySource["unknown"])
+	}
+	if bySource["console"] != 1 {
+		t.Errorf("console count = %d, want 1", bySource["console"])
+	}
+}
+
+func TestTruncateRunes_UTF8Safe(t *testing.T) {
+	t.Parallel()
+	// 4-byte emoji chars: each is 1 rune but 4 bytes
+	input := "Hello \U0001F600\U0001F600\U0001F600 world"
+	result := truncateRunes(input, 9)
+	runes := []rune(result)
+	if len(runes) != 9 {
+		t.Errorf("rune len = %d, want 9", len(runes))
+	}
+	// Should not have corrupted byte sequences
+	for i, r := range runes {
+		if r == '\uFFFD' {
+			t.Errorf("replacement char at rune %d — truncation corrupted UTF-8", i)
+		}
+	}
+}
+
+func TestBuildActionsSummary_EpochTimestamp(t *testing.T) {
+	t.Parallel()
+	// Timestamp 0 = Unix epoch. Should still produce time_range.
+	actions := []capture.EnhancedAction{
+		{Type: "click", Timestamp: 0},
+		{Type: "click", Timestamp: 1000},
+	}
+	result := buildActionsSummary(actions, ResponseMetadata{})
+	if _, ok := result["time_range"]; !ok {
+		t.Error("expected time_range even with epoch timestamp 0")
+	}
+}
+
+func TestBuildHistorySummary_Counts(t *testing.T) {
+	t.Parallel()
+	entries := []historyEntry{
+		{Timestamp: "2024-01-01T10:00:00Z", ToURL: "http://a.com", Type: "navigate"},
+		{Timestamp: "2024-01-01T10:01:00Z", ToURL: "http://b.com", Type: "navigate"},
+		{Timestamp: "2024-01-01T10:02:00Z", ToURL: "http://b.com/page", Type: "page_visit"},
+	}
+	result := buildHistorySummary(entries, ResponseMetadata{RetrievedAt: "2024-01-01T10:03:00Z"})
+
+	total, _ := result["total"].(int)
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	byType, ok := result["by_type"].(map[string]int)
+	if !ok {
+		t.Fatal("by_type not a map[string]int")
+	}
+	if byType["navigate"] != 2 {
+		t.Errorf("navigate = %d, want 2", byType["navigate"])
+	}
+	if byType["page_visit"] != 1 {
+		t.Errorf("page_visit = %d, want 1", byType["page_visit"])
+	}
+	uniqueURLs, ok := result["unique_urls"].(int)
+	if !ok {
+		t.Fatal("unique_urls not an int")
+	}
+	if uniqueURLs != 3 {
+		t.Errorf("unique_urls = %d, want 3", uniqueURLs)
+	}
+}
+
+func TestBuildHistorySummary_Empty(t *testing.T) {
+	t.Parallel()
+	result := buildHistorySummary(nil, ResponseMetadata{})
+	total, _ := result["total"].(int)
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+}
+
+func TestBuildPaginatedMetadataWithSummary_FirstPage(t *testing.T) {
+	t.Parallel()
+	pMeta := &pagination.CursorPaginationMetadata{
+		Total:   50,
+		HasMore: true,
+		Cursor:  "cursor123",
+	}
+	summaryFn := func() map[string]any {
+		return map[string]any{"total": 50, "by_level": map[string]int{"info": 30, "error": 20}}
+	}
+
+	// isFirstPage=true
+	result := BuildPaginatedMetadataWithSummary(nil, time.Time{}, pMeta, true, summaryFn)
+
+	summary, ok := result["summary"]
+	if !ok {
+		t.Fatal("expected summary key on first page")
+	}
+	summaryMap, ok := summary.(map[string]any)
+	if !ok {
+		t.Fatal("summary not a map[string]any")
+	}
+	if summaryMap["total"] != 50 {
+		t.Errorf("summary total = %v, want 50", summaryMap["total"])
+	}
+}
+
+func TestBuildPaginatedMetadataWithSummary_SubsequentPage(t *testing.T) {
+	t.Parallel()
+	pMeta := &pagination.CursorPaginationMetadata{
+		Total:   50,
+		HasMore: true,
+		Cursor:  "cursor456",
+	}
+	called := false
+	summaryFn := func() map[string]any {
+		called = true
+		return map[string]any{"total": 50}
+	}
+
+	// isFirstPage=false
+	result := BuildPaginatedMetadataWithSummary(nil, time.Time{}, pMeta, false, summaryFn)
+
+	if _, ok := result["summary"]; ok {
+		t.Error("expected no summary key on subsequent page")
+	}
+	if called {
+		t.Error("summaryFn should not be called for subsequent pages")
+	}
+}


### PR DESCRIPTION
## Summary
- **Session-level summary preference**: LLMs opt in once via `configure(store)`, then all observe/analyze calls auto-inject `summary=true`. Explicit `summary=false` or `full=true` overrides.
- **Summary builders for 9 modes**: errors, logs, network_bodies, error_bundles, websocket_events, actions, history, timeline, plus pagination header on first page of logs (~60-70% token savings)
- **Review hardening**: single JSON parse in maybeInjectSummary, UTF-8 safe truncation, consistent empty-source bucketing, epoch-safe timestamp tracking, metadata in all summary shapes

Closes #289, #290, #293

## Test plan
- [x] 34 new tests pass (8 preference + 26 builders)
- [x] `go build`, `go vet` clean
- [x] Golden file updated
- [x] Binary rebuilt and installed
- [x] Principal Engineer + QA Engineer review — all P0/P1 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)