### PR TITLE
Implement structured recovery errors and deterministic local smoke harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Browser extension + MCP server for real-time browser telemetry.
 
 ## Git Workflow
 
-- Branch from `next`, PR to `next`
+- Branch from `UNSTABLE`, PR to `UNSTABLE`
 - Never push directly to `main`
 - Squash commits before merge
 

--- a/cmd/dev-console/contract_helpers_test.go
+++ b/cmd/dev-console/contract_helpers_test.go
@@ -271,13 +271,19 @@ func assertStructuredErrorCode(t *testing.T, label string, result MCPToolResult,
 	}
 
 	assertObjectShape(t, label+" (structured_error)", data, []fieldSpec{
+		required("error_code", "string"),
 		required("error", "string"),
 		required("message", "string"),
+		required("recovery_playbook", "string"),
 		required("retry", "string"),
 	})
 
 	if expectedCode != "" {
-		if code, _ := data["error"].(string); code != expectedCode {
+		code, _ := data["error_code"].(string)
+		if code == "" {
+			code, _ = data["error"].(string)
+		}
+		if code != expectedCode {
 			t.Errorf("%s: expected error code %q, got %q", label, expectedCode, code)
 		}
 	}

--- a/cmd/dev-console/contract_helpers_test.go
+++ b/cmd/dev-console/contract_helpers_test.go
@@ -272,17 +272,12 @@ func assertStructuredErrorCode(t *testing.T, label string, result MCPToolResult,
 
 	assertObjectShape(t, label+" (structured_error)", data, []fieldSpec{
 		required("error_code", "string"),
-		required("error", "string"),
 		required("message", "string"),
 		required("recovery_playbook", "string"),
-		required("retry", "string"),
 	})
 
 	if expectedCode != "" {
 		code, _ := data["error_code"].(string)
-		if code == "" {
-			code, _ = data["error"].(string)
-		}
 		if code != expectedCode {
 			t.Errorf("%s: expected error code %q, got %q", label, expectedCode, code)
 		}

--- a/cmd/dev-console/tools_analyze.go
+++ b/cmd/dev-console/tools_analyze.go
@@ -116,7 +116,9 @@ func getValidAnalyzeModes() string {
 // toolAnalyze dispatches analyze requests based on the 'what' parameter.
 func (h *ToolHandler) toolAnalyze(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 	var params struct {
-		What string `json:"what"`
+		What   string `json:"what"`
+		Mode   string `json:"mode"`
+		Action string `json:"action"`
 	}
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &params); err != nil {
@@ -124,22 +126,41 @@ func (h *ToolHandler) toolAnalyze(req JSONRPCRequest, args json.RawMessage) JSON
 		}
 	}
 
-	if params.What == "" {
+	what := params.What
+	usedAliasParam := ""
+	if what != "" && params.Mode != "" && params.Mode != what {
+		return whatAliasConflictResponse(req, "mode", what, params.Mode, getValidAnalyzeModes())
+	}
+	if what != "" && params.Action != "" && params.Action != what {
+		return whatAliasConflictResponse(req, "action", what, params.Action, getValidAnalyzeModes())
+	}
+	if what == "" {
+		if params.Mode != "" {
+			what = params.Mode
+			usedAliasParam = "mode"
+		} else if params.Action != "" {
+			what = params.Action
+			usedAliasParam = "action"
+		}
+	}
+
+	if what == "" {
 		validModes := getValidAnalyzeModes()
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'what' is missing", "Add the 'what' parameter and call again", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
-	if alias, ok := analyzeAliases[params.What]; ok {
-		params.What = alias
+	if alias, ok := analyzeAliases[what]; ok {
+		what = alias
 	}
 
-	handler, ok := analyzeHandlers[params.What]
+	handler, ok := analyzeHandlers[what]
 	if !ok {
 		validModes := getValidAnalyzeModes()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+params.What, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
-	return handler(h, req, args)
+	resp := handler(h, req, args)
+	return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 }
 
 // ============================================

--- a/cmd/dev-console/tools_analyze_handler_test.go
+++ b/cmd/dev-console/tools_analyze_handler_test.go
@@ -83,6 +83,45 @@ func TestToolsAnalyzeDispatch_EmptyArgs(t *testing.T) {
 	}
 }
 
+func TestToolsAnalyzeDispatch_ModeAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callAnalyzeRaw(h, `{"mode":"dom","selector":"body","sync":false}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("mode alias should be accepted, got: %s", result.Content[0].Text)
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
+func TestToolsAnalyzeDispatch_ConflictingWhatAndMode(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callAnalyzeRaw(h, `{"what":"dom","mode":"performance","selector":"body"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("conflicting what/mode should return isError:true")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "invalid_param") {
+		t.Fatalf("expected invalid_param, got: %s", text)
+	}
+	if !strings.Contains(text, "Conflicting parameters") {
+		t.Fatalf("expected conflict explanation, got: %s", text)
+	}
+}
+
 // ============================================
 // getValidAnalyzeModes Tests
 // ============================================

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -128,8 +128,17 @@ func (h *ToolHandler) toolConfigure(req JSONRPCRequest, args json.RawMessage) JS
 	}
 
 	what := params.What
+	usedAliasParam := ""
+	if what != "" && params.Action != "" && params.Action != what {
+		if _, isTopLevelConfigureAction := configureHandlers[params.Action]; isTopLevelConfigureAction {
+			return whatAliasConflictResponse(req, "action", what, params.Action, getValidConfigureActions())
+		}
+	}
 	if what == "" {
 		what = params.Action
+		if what != "" {
+			usedAliasParam = "action"
+		}
 	}
 
 	if what == "" {
@@ -143,7 +152,8 @@ func (h *ToolHandler) toolConfigure(req JSONRPCRequest, args json.RawMessage) JS
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown configure action: "+what, "Use a valid action from the 'what' enum", withParam("what"), withHint("Valid values: "+validActions))}
 	}
 
-	return handler(h, req, args)
+	resp := handler(h, req, args)
+	return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 }
 
 func (h *ToolHandler) toolConfigureStore(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {

--- a/cmd/dev-console/tools_configure_handler_test.go
+++ b/cmd/dev-console/tools_configure_handler_test.go
@@ -83,6 +83,45 @@ func TestToolsConfigureDispatch_EmptyArgs(t *testing.T) {
 	}
 }
 
+func TestToolsConfigureDispatch_ActionAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callConfigureRaw(h, `{"action":"health"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("action alias should be accepted, got: %s", result.Content[0].Text)
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
+func TestToolsConfigureDispatch_ConflictingWhatAndAction(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callConfigureRaw(h, `{"what":"health","action":"clear"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("conflicting what/action should return isError:true")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "invalid_param") {
+		t.Fatalf("expected invalid_param, got: %s", text)
+	}
+	if !strings.Contains(text, "Conflicting parameters") {
+		t.Fatalf("expected conflict explanation, got: %s", text)
+	}
+}
+
 // ============================================
 // getValidConfigureActions Tests
 // ============================================

--- a/cmd/dev-console/tools_contract_enforcement_test.go
+++ b/cmd/dev-console/tools_contract_enforcement_test.go
@@ -150,6 +150,12 @@ func TestContractEnforcement_ErrorsHaveRetryableField(t *testing.T) {
 			if _, exists := data["retryable"]; !exists {
 				t.Errorf("error code %q missing 'retryable' field", tc.code)
 			}
+			if code, _ := data["error_code"].(string); code == "" {
+				t.Errorf("error code %q missing canonical 'error_code' field", tc.code)
+			}
+			if playbook, _ := data["recovery_playbook"].(string); playbook == "" {
+				t.Errorf("error code %q missing canonical 'recovery_playbook' field", tc.code)
+			}
 		})
 	}
 }

--- a/cmd/dev-console/tools_errors.go
+++ b/cmd/dev-console/tools_errors.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/dev-console/dev-console/internal/mcp"
 )
@@ -44,6 +45,32 @@ func withFinal(final bool) func(*StructuredError)    { return mcp.WithFinal(fina
 
 func retryDefaultsForCode(code string) []func(*StructuredError) {
 	return mcp.RetryDefaultsForCode(code)
+}
+
+func appendCanonicalWhatAliasWarning(resp JSONRPCResponse, aliasParam, mode string) JSONRPCResponse {
+	if strings.TrimSpace(aliasParam) == "" || strings.TrimSpace(mode) == "" {
+		return resp
+	}
+	warning := fmt.Sprintf("Accepted alias parameter '%s'; canonical parameter is 'what' (use what=%q).", aliasParam, mode)
+	return appendWarningsToResponse(resp, []string{warning})
+}
+
+func whatAliasConflictResponse(req JSONRPCRequest, aliasParam, whatValue, aliasValue, validValues string) JSONRPCResponse {
+	hint := "Use only 'what' when specifying tool mode/action."
+	if strings.TrimSpace(validValues) != "" {
+		hint += " Valid values: " + validValues
+	}
+	return JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result: mcpStructuredError(
+			ErrInvalidParam,
+			fmt.Sprintf("Conflicting parameters: what=%q and %s=%q", whatValue, aliasParam, aliasValue),
+			"Send only the canonical 'what' parameter and retry.",
+			withParam("what"),
+			withHint(hint),
+		),
+	}
 }
 
 // diagnosticHintString returns a plain-text snapshot of system state.

--- a/cmd/dev-console/tools_errors_test.go
+++ b/cmd/dev-console/tools_errors_test.go
@@ -83,6 +83,28 @@ func TestStructuredError_DefaultRetryable_IsFalse(t *testing.T) {
 	}
 }
 
+func TestStructuredError_CanonicalRecoveryContractFields(t *testing.T) {
+	t.Parallel()
+
+	result := mcpStructuredError(
+		ErrMissingParam, "Missing parameter", "Call interact with what=list_interactive",
+	)
+
+	se := extractStructuredErrorJSON(t, result)
+	if se["error_code"] != ErrMissingParam {
+		t.Fatalf("error_code = %v, want %q", se["error_code"], ErrMissingParam)
+	}
+	if se["error"] != ErrMissingParam {
+		t.Fatalf("error = %v, want %q", se["error"], ErrMissingParam)
+	}
+	if se["recovery_playbook"] != "Call interact with what=list_interactive" {
+		t.Fatalf("recovery_playbook = %v", se["recovery_playbook"])
+	}
+	if se["retry"] != "Call interact with what=list_interactive" {
+		t.Fatalf("retry = %v", se["retry"])
+	}
+}
+
 func TestStructuredError_ErrorCodes_RetryableDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/dev-console/tools_errors_test.go
+++ b/cmd/dev-console/tools_errors_test.go
@@ -94,14 +94,14 @@ func TestStructuredError_CanonicalRecoveryContractFields(t *testing.T) {
 	if se["error_code"] != ErrMissingParam {
 		t.Fatalf("error_code = %v, want %q", se["error_code"], ErrMissingParam)
 	}
-	if se["error"] != ErrMissingParam {
-		t.Fatalf("error = %v, want %q", se["error"], ErrMissingParam)
-	}
 	if se["recovery_playbook"] != "Call interact with what=list_interactive" {
 		t.Fatalf("recovery_playbook = %v", se["recovery_playbook"])
 	}
-	if se["retry"] != "Call interact with what=list_interactive" {
-		t.Fatalf("retry = %v", se["retry"])
+	if _, exists := se["error"]; exists {
+		t.Fatalf("legacy field error should not be present: %v", se["error"])
+	}
+	if _, exists := se["retry"]; exists {
+		t.Fatalf("legacy field retry should not be present: %v", se["retry"])
 	}
 }
 

--- a/cmd/dev-console/tools_generate.go
+++ b/cmd/dev-console/tools_generate.go
@@ -186,6 +186,7 @@ func (h *ToolHandler) toolGenerate(req JSONRPCRequest, args json.RawMessage) JSO
 	var params struct {
 		What   string `json:"what"`
 		Format string `json:"format"`
+		Action string `json:"action"`
 	}
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &params); err != nil {
@@ -194,8 +195,23 @@ func (h *ToolHandler) toolGenerate(req JSONRPCRequest, args json.RawMessage) JSO
 	}
 
 	what := params.What
+	usedAliasParam := ""
+	if what != "" && params.Format != "" && params.Format != what {
+		return whatAliasConflictResponse(req, "format", what, params.Format, getValidGenerateFormats())
+	}
+	if what != "" && params.Action != "" && params.Action != what {
+		if _, isTopLevelGenerateMode := generateHandlers[params.Action]; isTopLevelGenerateMode {
+			return whatAliasConflictResponse(req, "action", what, params.Action, getValidGenerateFormats())
+		}
+	}
 	if what == "" {
-		what = params.Format
+		if params.Format != "" {
+			what = params.Format
+			usedAliasParam = "format"
+		} else if _, isTopLevelGenerateMode := generateHandlers[params.Action]; isTopLevelGenerateMode {
+			what = params.Action
+			usedAliasParam = "action"
+		}
 	}
 
 	if what == "" {
@@ -211,10 +227,11 @@ func (h *ToolHandler) toolGenerate(req JSONRPCRequest, args json.RawMessage) JSO
 
 	// Strict parameter validation: reject unknown params for the given format
 	if errResp := validateGenerateParams(req, what, args); errResp != nil {
-		return *errResp
+		return appendCanonicalWhatAliasWarning(*errResp, usedAliasParam, what)
 	}
 
-	return handler(h, req, args)
+	resp := handler(h, req, args)
+	return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 }
 
 // ============================================

--- a/cmd/dev-console/tools_generate_handler_test.go
+++ b/cmd/dev-console/tools_generate_handler_test.go
@@ -85,6 +85,45 @@ func TestToolsGenerateDispatch_EmptyArgs(t *testing.T) {
 	}
 }
 
+func TestToolsGenerateDispatch_FormatAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callGenerateRaw(h, `{"format":"pr_summary"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("format alias should be accepted, got: %s", result.Content[0].Text)
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
+func TestToolsGenerateDispatch_ConflictingWhatAndFormat(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callGenerateRaw(h, `{"what":"test","format":"har"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("conflicting what/format should return isError:true")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "invalid_param") {
+		t.Fatalf("expected invalid_param, got: %s", text)
+	}
+	if !strings.Contains(text, "Conflicting parameters") {
+		t.Fatalf("expected conflict explanation, got: %s", text)
+	}
+}
+
 // ============================================
 // getValidGenerateFormats Tests
 // ============================================

--- a/cmd/dev-console/tools_interact.go
+++ b/cmd/dev-console/tools_interact.go
@@ -132,8 +132,15 @@ func (h *ToolHandler) toolInteract(req JSONRPCRequest, args json.RawMessage) JSO
 	}
 
 	what := params.What
+	usedAliasParam := ""
+	if what != "" && params.Action != "" && params.Action != what {
+		return whatAliasConflictResponse(req, "action", what, params.Action, h.getValidInteractActions())
+	}
 	if what == "" {
 		what = params.Action
+		if what != "" {
+			usedAliasParam = "action"
+		}
 	}
 
 	if what == "" {
@@ -164,6 +171,7 @@ func (h *ToolHandler) toolInteract(req JSONRPCRequest, args json.RawMessage) JSO
 		h.queueComposableSubtitle(req, *composableSubtitle.Subtitle)
 	}
 
+	resp = appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	return resp
 }
 

--- a/cmd/dev-console/tools_interact_gate_test.go
+++ b/cmd/dev-console/tools_interact_gate_test.go
@@ -81,7 +81,7 @@ func extractErrorCode(t *testing.T, resp JSONRPCResponse) string {
 	if err := json.Unmarshal([]byte(text[idx:]), &se); err != nil {
 		t.Fatalf("unmarshal structured error: %v\nraw: %s", err, text[idx:])
 	}
-	return se.Error
+	return se.ErrorCode
 }
 
 // isSuccessOrQueued returns true if the response is not a structured error.

--- a/cmd/dev-console/tools_interact_handler_test.go
+++ b/cmd/dev-console/tools_interact_handler_test.go
@@ -120,6 +120,48 @@ func TestToolsInteractDispatch_EmptyArgs(t *testing.T) {
 	}
 }
 
+func TestToolsInteractDispatch_ActionAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callInteractRaw(h, `{"action":"list_states"}`)
+	result := parseToolResult(t, resp)
+	if len(result.Content) == 0 {
+		t.Fatal("expected content blocks in alias response")
+	}
+	if strings.Contains(result.Content[0].Text, "unknown_mode") {
+		t.Fatalf("action alias should not route to unknown_mode, got: %s", result.Content[0].Text)
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
+func TestToolsInteractDispatch_ConflictingWhatAndAction(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callInteractRaw(h, `{"what":"list_states","action":"navigate"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("conflicting what/action should return isError:true")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "invalid_param") {
+		t.Fatalf("expected invalid_param, got: %s", text)
+	}
+	if !strings.Contains(text, "Conflicting parameters") {
+		t.Fatalf("expected conflict explanation, got: %s", text)
+	}
+}
+
 // ============================================
 // interact(action:"highlight") — Response Fields & Validation
 // ============================================

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -126,7 +126,9 @@ func getValidObserveModes() string {
 // toolObserve dispatches observe requests based on the 'what' parameter.
 func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
 	var params struct {
-		What string `json:"what"`
+		What   string `json:"what"`
+		Mode   string `json:"mode"`
+		Action string `json:"action"`
 	}
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &params); err != nil {
@@ -134,25 +136,43 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 		}
 	}
 
-	if params.What == "" {
+	what := params.What
+	usedAliasParam := ""
+	if what != "" && params.Mode != "" && params.Mode != what {
+		return whatAliasConflictResponse(req, "mode", what, params.Mode, getValidObserveModes())
+	}
+	if what != "" && params.Action != "" && params.Action != what {
+		return whatAliasConflictResponse(req, "action", what, params.Action, getValidObserveModes())
+	}
+	if what == "" {
+		if params.Mode != "" {
+			what = params.Mode
+			usedAliasParam = "mode"
+		} else if params.Action != "" {
+			what = params.Action
+			usedAliasParam = "action"
+		}
+	}
+
+	if what == "" {
 		validModes := getValidObserveModes()
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrMissingParam, "Required parameter 'what' is missing", "Add the 'what' parameter and call again", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
-	if alias, ok := observeAliases[params.What]; ok {
-		params.What = alias
+	if alias, ok := observeAliases[what]; ok {
+		what = alias
 	}
 
-	handler, ok := observeHandlers[params.What]
+	handler, ok := observeHandlers[what]
 	if !ok {
 		validModes := getValidObserveModes()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown observe mode: "+params.What, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown observe mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
 	}
 
 	resp := handler(h, req, args)
 
 	// Warn when extension is disconnected (except for server-side modes that don't need it)
-	if !h.capture.IsExtensionConnected() && !serverSideObserveModes[params.What] {
+	if !h.capture.IsExtensionConnected() && !serverSideObserveModes[what] {
 		resp = h.prependDisconnectWarning(resp)
 	}
 
@@ -162,6 +182,7 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 		resp = h.appendAlertsToResponse(resp, alerts)
 	}
 
+	resp = appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	return resp
 }
 

--- a/cmd/dev-console/tools_observe_handler_test.go
+++ b/cmd/dev-console/tools_observe_handler_test.go
@@ -752,14 +752,14 @@ func TestToolsObserve_StructuredErrorFields(t *testing.T) {
 	if err := json.Unmarshal([]byte(jsonPart), &se); err != nil {
 		t.Fatalf("structured error JSON parse failed: %v\nraw: %s", err, jsonPart)
 	}
-	if se.Error == "" {
-		t.Error("StructuredError.Error should not be empty")
+	if se.ErrorCode == "" {
+		t.Error("StructuredError.ErrorCode should not be empty")
 	}
 	if se.Message == "" {
 		t.Error("StructuredError.Message should not be empty")
 	}
-	if se.Retry == "" {
-		t.Error("StructuredError.Retry should not be empty")
+	if se.RecoveryPlaybook == "" {
+		t.Error("StructuredError.RecoveryPlaybook should not be empty")
 	}
 
 	// Verify JSON fields are snake_case

--- a/cmd/dev-console/tools_observe_handler_test.go
+++ b/cmd/dev-console/tools_observe_handler_test.go
@@ -85,6 +85,47 @@ func TestToolsObserveDispatch_EmptyArgs(t *testing.T) {
 	}
 }
 
+func TestToolsObserveDispatch_ModeAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"mode":"pilot"}`))
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("mode alias should be accepted, got: %s", result.Content[0].Text)
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
+func TestToolsObserveDispatch_ConflictingWhatAndMode(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"what":"pilot","mode":"errors"}`))
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("conflicting what/mode should return isError:true")
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "invalid_param") {
+		t.Fatalf("expected invalid_param, got: %s", text)
+	}
+	if !strings.Contains(text, "Conflicting parameters") {
+		t.Fatalf("expected conflict explanation, got: %s", text)
+	}
+}
+
 // ============================================
 // observe(what:"errors") — Response Field Tests
 // ============================================

--- a/cmd/dev-console/tools_test.go
+++ b/cmd/dev-console/tools_test.go
@@ -714,8 +714,14 @@ func TestMcpStructuredError(t *testing.T) {
 		if se["error"] != "missing_param" {
 			t.Errorf("Expected error code 'missing_param', got %v", se["error"])
 		}
+		if se["error_code"] != "missing_param" {
+			t.Errorf("Expected canonical error_code 'missing_param', got %v", se["error_code"])
+		}
 		if se["param"] != "what" {
 			t.Errorf("Expected param 'what', got %v", se["param"])
+		}
+		if se["recovery_playbook"] != "Add the 'what' parameter" {
+			t.Errorf("Expected canonical recovery_playbook, got %v", se["recovery_playbook"])
 		}
 
 		// Verify snake_case in the structured error JSON

--- a/cmd/dev-console/tools_test.go
+++ b/cmd/dev-console/tools_test.go
@@ -711,9 +711,6 @@ func TestMcpStructuredError(t *testing.T) {
 		if err := json.Unmarshal([]byte(text[jsonStart:]), &se); err != nil {
 			t.Fatalf("Expected valid JSON in structured error, got error: %v", err)
 		}
-		if se["error"] != "missing_param" {
-			t.Errorf("Expected error code 'missing_param', got %v", se["error"])
-		}
 		if se["error_code"] != "missing_param" {
 			t.Errorf("Expected canonical error_code 'missing_param', got %v", se["error_code"])
 		}
@@ -722,6 +719,12 @@ func TestMcpStructuredError(t *testing.T) {
 		}
 		if se["recovery_playbook"] != "Add the 'what' parameter" {
 			t.Errorf("Expected canonical recovery_playbook, got %v", se["recovery_playbook"])
+		}
+		if _, exists := se["error"]; exists {
+			t.Errorf("Legacy field 'error' should not be present: %v", se["error"])
+		}
+		if _, exists := se["retry"]; exists {
+			t.Errorf("Legacy field 'retry' should not be present: %v", se["retry"])
 		}
 
 		// Verify snake_case in the structured error JSON

--- a/docs/features/feature-test-harness.md
+++ b/docs/features/feature-test-harness.md
@@ -1,10 +1,10 @@
 ---
-status: proposed
+status: implemented
 scope: feature/test-harness/implementation
 ai-priority: high
 tags: [implementation, testing, architecture]
 relates-to: []
-last-verified: 2026-02-24
+last-verified: 2026-02-26
 doc_type: tech-spec
 feature_id: feature-test-harness
 ---
@@ -70,10 +70,23 @@ We will use a lightweight local server to host the `tests/pages/` directory duri
 * **Implementation:** A simple Python `http.server`, a small Go file server, or `vite preview`.
 * **Lifecycle:** Spun up at the start of `smoke-test.sh` and torn down automatically via `trap`.
 
+Implemented as:
+* `scripts/smoke-tests/harness-server.py` (ThreadingHTTPServer)
+* Root: `tests/pages/`
+* Deterministic API endpoints:
+  * `/healthz`
+  * `/api/status/404`
+  * `/api/status/500`
+  * `/api/slow`
+
 ### Refactoring `smoke-test.sh`
 The existing smoke tests will be updated to point to `http://localhost:8080/interact.html` (or similar) instead of `https://example.com`. 
 
 The test validations will be tightened. Instead of checking if `example.com` loaded, we will assert that Gasoline specifically caught the 800ms long task on `performance.html` or successfully navigated the React event trap on `interact.html`.
+
+Implemented migration strategy:
+* `scripts/smoke-tests/framework-smoke.sh` now starts the local harness automatically.
+* Smoke requests are URL-rewritten at the framework layer so legacy `https://example.com` navigations are routed to local deterministic pages under `tests/pages/example.com/`.
 
 ### The "Real World" Exceptions
 We will maintain a dedicated `external-evasion.sh` module for tests that *must* run against the open web to prove resilience against commercial anti-bot systems:

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -7,7 +7,6 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // Error codes are self-describing snake_case strings.
@@ -47,10 +46,6 @@ type StructuredError struct {
 	Message          string `json:"message"`
 	RecoveryPlaybook string `json:"recovery_playbook"`
 
-	// Backward-compatible aliases retained for existing clients/tests.
-	Error string `json:"error"`
-	Retry string `json:"retry"`
-
 	Retryable    bool   `json:"retryable"`
 	RetryAfterMs int    `json:"retry_after_ms,omitempty"`
 	Final        bool   `json:"final,omitempty"`
@@ -69,8 +64,6 @@ func StructuredErrorResponse(code, message, recoveryPlaybook string, opts ...fun
 		ErrorCode:        code,
 		Message:          message,
 		RecoveryPlaybook: recoveryPlaybook,
-		Error:            code,
-		Retry:            recoveryPlaybook,
 	}
 	// Apply retryable defaults based on error code first, then user opts can override
 	for _, defaultOpt := range RetryDefaultsForCode(code) {
@@ -79,7 +72,6 @@ func StructuredErrorResponse(code, message, recoveryPlaybook string, opts ...fun
 	for _, opt := range opts {
 		opt(&se)
 	}
-	normalizeStructuredErrorAliases(&se)
 
 	// Error impossible: StructuredError is a simple struct with no circular refs or unsupported types
 	seJSON, _ := json.Marshal(se)
@@ -90,21 +82,6 @@ func StructuredErrorResponse(code, message, recoveryPlaybook string, opts ...fun
 		IsError: true,
 	}
 	return SafeMarshal(result, `{"content":[{"type":"text","text":"Internal error: failed to marshal result"}],"isError":true}`)
-}
-
-func normalizeStructuredErrorAliases(se *StructuredError) {
-	if strings.TrimSpace(se.ErrorCode) == "" {
-		se.ErrorCode = se.Error
-	}
-	if strings.TrimSpace(se.Error) == "" {
-		se.Error = se.ErrorCode
-	}
-	if strings.TrimSpace(se.RecoveryPlaybook) == "" {
-		se.RecoveryPlaybook = se.Retry
-	}
-	if strings.TrimSpace(se.Retry) == "" {
-		se.Retry = se.RecoveryPlaybook
-	}
 }
 
 // WithParam is an option function to add param field to StructuredError.

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -7,6 +7,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Error codes are self-describing snake_case strings.
@@ -41,9 +42,15 @@ const (
 // StructuredError is embedded in MCP text content. Every field is
 // self-describing so an LLM can act on it without a lookup table.
 type StructuredError struct {
-	Error        string `json:"error"`
-	Message      string `json:"message"`
-	Retry        string `json:"retry"`
+	// Canonical contract fields.
+	ErrorCode        string `json:"error_code"`
+	Message          string `json:"message"`
+	RecoveryPlaybook string `json:"recovery_playbook"`
+
+	// Backward-compatible aliases retained for existing clients/tests.
+	Error string `json:"error"`
+	Retry string `json:"retry"`
+
 	Retryable    bool   `json:"retryable"`
 	RetryAfterMs int    `json:"retry_after_ms,omitempty"`
 	Final        bool   `json:"final,omitempty"`
@@ -54,11 +61,17 @@ type StructuredError struct {
 // StructuredErrorResponse constructs an MCP error response. Format:
 //
 //	Error: missing_param — Add the 'what' parameter and call again
-//	{"error":"missing_param","message":"...","retry":"Add the 'what' parameter and call again","hint":"..."}
+//	{"error_code":"missing_param","message":"...","recovery_playbook":"Add the 'what' parameter and call again",...}
 //
 // The retry string is a plain-English instruction the LLM can follow directly.
-func StructuredErrorResponse(code, message, retry string, opts ...func(*StructuredError)) json.RawMessage {
-	se := StructuredError{Error: code, Message: message, Retry: retry}
+func StructuredErrorResponse(code, message, recoveryPlaybook string, opts ...func(*StructuredError)) json.RawMessage {
+	se := StructuredError{
+		ErrorCode:        code,
+		Message:          message,
+		RecoveryPlaybook: recoveryPlaybook,
+		Error:            code,
+		Retry:            recoveryPlaybook,
+	}
 	// Apply retryable defaults based on error code first, then user opts can override
 	for _, defaultOpt := range RetryDefaultsForCode(code) {
 		defaultOpt(&se)
@@ -66,16 +79,32 @@ func StructuredErrorResponse(code, message, retry string, opts ...func(*Structur
 	for _, opt := range opts {
 		opt(&se)
 	}
+	normalizeStructuredErrorAliases(&se)
 
 	// Error impossible: StructuredError is a simple struct with no circular refs or unsupported types
 	seJSON, _ := json.Marshal(se)
-	text := fmt.Sprintf("Error: %s — %s\n%s", code, retry, string(seJSON))
+	text := fmt.Sprintf("Error: %s — %s\n%s", se.ErrorCode, se.RecoveryPlaybook, string(seJSON))
 
 	result := MCPToolResult{
 		Content: []MCPContentBlock{{Type: "text", Text: text}},
 		IsError: true,
 	}
 	return SafeMarshal(result, `{"content":[{"type":"text","text":"Internal error: failed to marshal result"}],"isError":true}`)
+}
+
+func normalizeStructuredErrorAliases(se *StructuredError) {
+	if strings.TrimSpace(se.ErrorCode) == "" {
+		se.ErrorCode = se.Error
+	}
+	if strings.TrimSpace(se.Error) == "" {
+		se.Error = se.ErrorCode
+	}
+	if strings.TrimSpace(se.RecoveryPlaybook) == "" {
+		se.RecoveryPlaybook = se.Retry
+	}
+	if strings.TrimSpace(se.Retry) == "" {
+		se.Retry = se.RecoveryPlaybook
+	}
 }
 
 // WithParam is an option function to add param field to StructuredError.

--- a/scripts/smoke-tests/framework-smoke.sh
+++ b/scripts/smoke-tests/framework-smoke.sh
@@ -46,6 +46,7 @@ register_cleanup() {
 
 # Master cleanup: runs all registered handlers, then base cleanup.
 _smoke_master_cleanup() {
+    _smoke_kill_harness 2>/dev/null || true
     for handler in $_smoke_cleanup_handlers; do
         "$handler" 2>/dev/null || true
     done
@@ -65,6 +66,50 @@ SMOKE_OUTPUT_DIR="${HOME}/.gasoline/smoke-results"
 mkdir -p "$SMOKE_OUTPUT_DIR"
 DIAGNOSTICS_FILE="$SMOKE_OUTPUT_DIR/diagnostics.log"
 SMOKE_OUTPUT_FILE="$SMOKE_OUTPUT_DIR/output.log"
+SMOKE_HARNESS_PORT="${SMOKE_HARNESS_PORT:-8787}"
+SMOKE_HARNESS_ROOT="${SMOKE_HARNESS_ROOT:-$SMOKE_FRAMEWORK_DIR/../../tests/pages}"
+SMOKE_HARNESS_PID=""
+SMOKE_BASE_URL="http://127.0.0.1:${SMOKE_HARNESS_PORT}"
+SMOKE_EXAMPLE_URL="${SMOKE_BASE_URL}/example.com"
+SMOKE_INTERACT_URL="${SMOKE_BASE_URL}/interact.html"
+SMOKE_PERFORMANCE_URL="${SMOKE_BASE_URL}/performance.html"
+SMOKE_TELEMETRY_URL="${SMOKE_BASE_URL}/telemetry.html"
+SMOKE_A11Y_URL="${SMOKE_BASE_URL}/a11y.html"
+
+_smoke_kill_harness() {
+    if [ -n "${SMOKE_HARNESS_PID:-}" ]; then
+        kill "$SMOKE_HARNESS_PID" 2>/dev/null || true
+        sleep 0.1
+        kill -0 "$SMOKE_HARNESS_PID" 2>/dev/null && kill -9 "$SMOKE_HARNESS_PID" 2>/dev/null || true
+        SMOKE_HARNESS_PID=""
+    fi
+}
+
+start_local_harness() {
+    _smoke_kill_harness
+    local harness_log="$SMOKE_OUTPUT_DIR/harness.log"
+    python3 "$SMOKE_FRAMEWORK_DIR/harness-server.py" \
+        --root "$SMOKE_HARNESS_ROOT" \
+        --port "$SMOKE_HARNESS_PORT" >"$harness_log" 2>&1 &
+    SMOKE_HARNESS_PID=$!
+
+    local ok=false
+    for _i in $(seq 1 30); do
+        if curl -s --connect-timeout 1 --max-time 2 "${SMOKE_BASE_URL}/healthz" >/dev/null 2>&1; then
+            ok=true
+            break
+        fi
+        sleep 0.2
+    done
+
+    if [ "$ok" != "true" ]; then
+        echo "FATAL: local harness failed to start on ${SMOKE_BASE_URL}" >&2
+        echo "  Harness log: $harness_log" >&2
+        tail -n 20 "$harness_log" >&2 || true
+        return 1
+    fi
+    return 0
+}
 
 wait_for_extension() {
     local timeout_s="${1:-10}"
@@ -91,12 +136,14 @@ init_smoke() {
     echo "Smoke Test Output — $(date)" > "$OUTPUT_FILE"
     echo "Smoke Test Diagnostics — $(date)" > "$DIAGNOSTICS_FILE"
     echo "Port: $port" >> "$DIAGNOSTICS_FILE"
+    echo "Harness: $SMOKE_BASE_URL" >> "$DIAGNOSTICS_FILE"
     echo "======================================" >> "$DIAGNOSTICS_FILE"
 
     # Print file locations and mode upfront so they're always visible
     echo ""
     echo "  Output:      $OUTPUT_FILE"
     echo "  Diagnostics: $DIAGNOSTICS_FILE"
+    echo "  Harness:     $SMOKE_BASE_URL"
     if [ "$_INTERACTIVE" = "true" ]; then
         echo "  Mode:        interactive (pauses between tests)"
     else
@@ -111,6 +158,28 @@ init_smoke() {
     # Trap ERR so crashes under set -e are immediately visible.
     # Logs the failing command, line, and function to both stderr and diagnostics.
     trap '_smoke_on_error $LINENO "${FUNCNAME[0]:-main}" "${BASH_COMMAND}"' ERR
+
+    start_local_harness
+}
+
+rewrite_smoke_urls() {
+    local payload="$1"
+    payload="${payload//https:\/\/example.com/$SMOKE_EXAMPLE_URL}"
+    payload="${payload//http:\/\/example.com/$SMOKE_EXAMPLE_URL}"
+    payload="${payload//https:\/\/www.example.com/$SMOKE_EXAMPLE_URL}"
+    payload="${payload//https:\/\/example.org/${SMOKE_BASE_URL}/example.org}"
+    payload="${payload//http:\/\/example.org/${SMOKE_BASE_URL}/example.org}"
+    echo "$payload"
+}
+
+# Override base framework call_tool so smoke runs stay on local harness pages.
+call_tool() {
+    local tool_name="$1"
+    local arguments="${2:-\{\}}"
+    local rewritten
+    rewritten="$(rewrite_smoke_urls "$arguments")"
+    local request="{\"jsonrpc\":\"2.0\",\"id\":${MCP_ID},\"method\":\"tools/call\",\"params\":{\"name\":\"${tool_name}\",\"arguments\":${rewritten}}}"
+    send_mcp "$request" "call_${tool_name}"
 }
 
 _smoke_on_error() {

--- a/scripts/smoke-tests/harness-server.py
+++ b/scripts/smoke-tests/harness-server.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Deterministic local harness server for smoke/integration tests.
+
+Serves static files from tests/pages and exposes deterministic API endpoints
+for telemetry/performance scenarios.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+class HarnessHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, directory: str, **kwargs):
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def log_message(self, fmt: str, *args) -> None:
+        # Keep smoke output readable while retaining request visibility in harness.log.
+        super().log_message(fmt, *args)
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+
+        if path == "/healthz":
+            self._send_json(HTTPStatus.OK, {"status": "ok"})
+            return
+
+        if path == "/api/status/404":
+            self._send_json(HTTPStatus.NOT_FOUND, {"status": 404, "error": "not_found"})
+            return
+
+        if path == "/api/status/500":
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"status": 500, "error": "server_error"})
+            return
+
+        if path == "/api/slow":
+            time.sleep(2.0)
+            self._send_json(HTTPStatus.OK, {"status": "ok", "delayed_ms": 2000})
+            return
+
+        super().do_GET()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gasoline deterministic test harness server")
+    parser.add_argument("--root", required=True, help="Directory to serve")
+    parser.add_argument("--port", type=int, default=8787, help="Bind port")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.exists() or not root.is_dir():
+        raise SystemExit(f"invalid harness root: {root}")
+
+    handler = lambda *a, **kw: HarnessHandler(*a, directory=str(root), **kw)  # noqa: E731
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    print(f"Harness server listening on http://127.0.0.1:{args.port} root={root}", flush=True)
+    try:
+        server.serve_forever(poll_interval=0.2)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pages/a11y.html
+++ b/tests/pages/a11y.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Accessibility Disaster</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #ffffff;
+      color: #222;
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 3;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      padding: 0.7rem;
+      background: #313131;
+      color: #fff;
+    }
+    nav a {
+      color: inherit;
+      text-decoration: none;
+      border: 1px solid rgba(255,255,255,0.4);
+      border-radius: 8px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.9rem;
+    }
+    .container {
+      max-width: 920px;
+      margin: 1rem auto;
+      padding: 0 1rem 2rem;
+    }
+    .low-contrast {
+      color: #d7d7d7;
+      background: #fff;
+      padding: 0.45rem;
+      border: 1px solid #eee;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1rem;
+    }
+    .panel {
+      border: 1px solid #ddd;
+      border-radius: 10px;
+      padding: 1rem;
+      background: #fafafa;
+    }
+    input {
+      width: 100%;
+      margin: 0.35rem 0 0.8rem;
+      padding: 0.5rem;
+      border: 1px solid #999;
+      border-radius: 8px;
+    }
+  </style>
+</head>
+<body>
+  <nav aria-label="Primary menu">
+    <a href="/">Home</a>
+    <a href="/interact.html">Interact</a>
+    <a href="/performance.html">Performance</a>
+    <a href="/telemetry.html">Telemetry</a>
+    <a href="/a11y.html">A11y</a>
+  </nav>
+
+  <div class="container">
+    <h1>Accessibility Disaster</h1>
+    <h4>Skipped heading level (h1 to h4)</h4>
+
+    <p class="low-contrast">This text intentionally fails color contrast checks.</p>
+
+    <div class="grid">
+      <section class="panel">
+        <h2>Missing Labels</h2>
+        <input id="orphan-email" type="email" placeholder="Email without label">
+        <input id="orphan-password" type="password" placeholder="Password without label">
+      </section>
+
+      <section class="panel">
+        <h2>Non-descriptive Controls</h2>
+        <button></button>
+        <button aria-label=""></button>
+        <a href="/performance.html"></a>
+      </section>
+
+      <section class="panel">
+        <h2>Keyboard Trap-ish Region</h2>
+        <div tabindex="0" style="height: 90px; overflow:auto; border:1px solid #ccc; padding:0.5rem;">
+          <p>Focusable region with poor instructions and no clear escape hint.</p>
+          <p>Tab focus may feel unclear in audits.</p>
+        </div>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/pages/example.com/index.html
+++ b/tests/pages/example.com/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>example.com (local harness mirror)</title>
+  <style>
+    body { font-family: Georgia, serif; max-width: 840px; margin: 2rem auto; padding: 0 1rem; }
+    nav a { margin-right: 0.7rem; }
+  </style>
+</head>
+<body>
+  <h1>example.com local mirror</h1>
+  <p>This page is served locally for deterministic smoke tests.</p>
+  <nav>
+    <a href="/interact.html">Interact</a>
+    <a href="/performance.html">Performance</a>
+    <a href="/telemetry.html">Telemetry</a>
+    <a href="/a11y.html">A11y</a>
+    <a href="/example.com/test">example.com/test</a>
+  </nav>
+</body>
+</html>

--- a/tests/pages/example.com/test
+++ b/tests/pages/example.com/test
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>example.com/test local</title></head>
+<body>
+  <h1>Local example.com/test</h1>
+  <p>Deterministic local substitute for https://example.com/test.</p>
+  <a href="/example.com/">Back to local example.com</a>
+</body>
+</html>

--- a/tests/pages/example.org/index.html
+++ b/tests/pages/example.org/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>example.org (local harness mirror)</title>
+</head>
+<body>
+  <h1>example.org local mirror</h1>
+  <p>Local deterministic replacement for macro replay tests.</p>
+  <a href="/example.com/">Go to local example.com mirror</a>
+</body>
+</html>

--- a/tests/pages/index.html
+++ b/tests/pages/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gasoline Test Harness</title>
+  <style>
+    :root {
+      --bg: #f5efe6;
+      --ink: #1f1f1f;
+      --accent: #0b6b88;
+      --panel: #fffdf7;
+    }
+    body {
+      margin: 0;
+      font-family: Georgia, "Times New Roman", serif;
+      background: radial-gradient(circle at 10% 10%, #fff8e8, var(--bg));
+      color: var(--ink);
+    }
+    header {
+      padding: 2rem 1rem 1rem;
+      text-align: center;
+    }
+    nav {
+      display: grid;
+      gap: 0.75rem;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    a {
+      text-decoration: none;
+      color: var(--ink);
+      background: var(--panel);
+      border: 1px solid #d5c7ad;
+      border-radius: 10px;
+      padding: 0.9rem;
+      box-shadow: 0 6px 20px rgba(31, 31, 31, 0.08);
+    }
+    a:hover {
+      border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+    .small {
+      color: #5b5b5b;
+      font-size: 0.92rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Gasoline Deterministic Harness</h1>
+    <p class="small">All links are local and deterministic.</p>
+  </header>
+  <nav aria-label="Harness pages">
+    <a href="/interact.html"><strong>Interaction Gauntlet</strong><br><span class="small">forms, overlays, event traps</span></a>
+    <a href="/performance.html"><strong>Performance Nightmare</strong><br><span class="small">LCP delay, CLS, long tasks</span></a>
+    <a href="/telemetry.html"><strong>Noise Factory</strong><br><span class="small">logs, errors, network failures</span></a>
+    <a href="/a11y.html"><strong>Accessibility Disaster</strong><br><span class="small">intentional WCAG violations</span></a>
+    <a href="/example.com/"><strong>example.com local mirror</strong><br><span class="small">compatibility for legacy smoke scripts</span></a>
+    <a href="/example.org/"><strong>example.org local mirror</strong><br><span class="small">compatibility for macro tests</span></a>
+  </nav>
+</body>
+</html>

--- a/tests/pages/interact.html
+++ b/tests/pages/interact.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Interaction Gauntlet</title>
+  <style>
+    :root {
+      --bg: #f2f5e8;
+      --ink: #111827;
+      --accent: #006a4e;
+      --warning: #8a1f11;
+      --panel: #ffffff;
+    }
+    body {
+      margin: 0;
+      font-family: "Trebuchet MS", Verdana, sans-serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, #f8fbe9 0%, var(--bg) 80%);
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      background: #132018;
+      color: #eef8f1;
+      padding: 0.7rem;
+    }
+    nav a {
+      color: #eef8f1;
+      text-decoration: none;
+      padding: 0.35rem 0.6rem;
+      border: 1px solid rgba(255,255,255,0.35);
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    main {
+      max-width: 980px;
+      margin: 1rem auto;
+      padding: 0 1rem 2rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+    .card {
+      background: var(--panel);
+      border-radius: 12px;
+      border: 1px solid #ced9ca;
+      padding: 1rem;
+      box-shadow: 0 8px 24px rgba(17, 24, 39, 0.08);
+    }
+    label {
+      display: block;
+      margin: 0.5rem 0 0.35rem;
+      font-weight: 600;
+    }
+    input, button, textarea {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.55rem;
+      border-radius: 8px;
+      border: 1px solid #9ca3af;
+      font: inherit;
+    }
+    button {
+      background: #0f5132;
+      color: #fff;
+      border-color: #0f5132;
+      cursor: pointer;
+    }
+    button:focus,
+    input:focus,
+    textarea:focus {
+      outline: 2px solid #ffbe3d;
+      outline-offset: 2px;
+    }
+    .warning { color: var(--warning); font-weight: 700; }
+    #overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.58);
+      display: none;
+      z-index: 9999;
+      align-items: center;
+      justify-content: center;
+    }
+    #overlay .modal {
+      width: min(420px, 92vw);
+      background: #fff;
+      border-radius: 12px;
+      padding: 1rem;
+      border: 2px solid #1f2937;
+    }
+    #trapStatus {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+    }
+    #real-submit-wrap {
+      position: relative;
+      margin-top: 0.8rem;
+    }
+    #honeypot {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0;
+      z-index: 2;
+    }
+    #real-submit {
+      position: relative;
+      z-index: 1;
+    }
+    .result-box {
+      min-height: 2rem;
+      margin-top: 0.7rem;
+      padding: 0.45rem;
+      border-radius: 8px;
+      background: #f3f7f3;
+      border: 1px dashed #94a3b8;
+    }
+  </style>
+</head>
+<body>
+  <nav aria-label="Primary menu">
+    <a href="/">Home</a>
+    <a href="/interact.html">Interact</a>
+    <a href="/performance.html">Performance</a>
+    <a href="/telemetry.html">Telemetry</a>
+    <a href="/a11y.html">A11y</a>
+    <a href="/example.com/">example.com</a>
+  </nav>
+
+  <main>
+    <h1>Interaction Gauntlet</h1>
+    <p>Deterministic page for click, type, select, form, modal, and overlay behavior.</p>
+
+    <div class="grid">
+      <section class="card" aria-labelledby="trap-heading">
+        <h2 id="trap-heading">React-style Input Trap</h2>
+        <p>Direct value assignments are reverted unless proper <code>input</code> event dispatch occurs.</p>
+        <label for="trap-input">Name</label>
+        <input id="trap-input" name="name" autocomplete="off">
+        <div id="trapStatus" role="status">status: waiting</div>
+      </section>
+
+      <section class="card" aria-labelledby="overlay-heading">
+        <h2 id="overlay-heading">Overlay and Modal</h2>
+        <button id="open-overlay" type="button">Open blocking modal</button>
+        <p class="warning">Simulated blocking overlay appears with z-index 9999.</p>
+        <div class="result-box" id="overlay-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" aria-labelledby="submit-heading">
+        <h2 id="submit-heading">Honeypot vs Real CTA</h2>
+        <p>A transparent honeypot overlaps the visible button.</p>
+        <div id="real-submit-wrap">
+          <button id="honeypot" type="button" aria-label="Invisible honeypot"></button>
+          <button id="real-submit" type="button">Submit real form</button>
+        </div>
+        <div class="result-box" id="submit-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" aria-labelledby="menu-heading">
+        <h2 id="menu-heading">Menu + Links</h2>
+        <ul>
+          <li><a id="link-performance" href="/performance.html">Go to performance page</a></li>
+          <li><a id="link-telemetry" href="/telemetry.html">Go to telemetry page</a></li>
+          <li><a id="link-a11y" href="/a11y.html">Go to accessibility page</a></li>
+          <li><a id="link-example-test" href="/example.com/test">Local example.com/test</a></li>
+        </ul>
+      </section>
+    </div>
+  </main>
+
+  <div id="overlay" role="dialog" aria-modal="true" aria-labelledby="overlay-title">
+    <div class="modal">
+      <h3 id="overlay-title">Blocking Modal</h3>
+      <p>This modal intentionally blocks underlying UI interactions.</p>
+      <button id="close-overlay" type="button">Close modal</button>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var trap = document.getElementById('trap-input');
+      var trapStatus = document.getElementById('trapStatus');
+      var trustedValue = '';
+
+      trap.addEventListener('input', function (event) {
+        trustedValue = event.target.value;
+        trapStatus.textContent = 'status: input event accepted';
+      });
+
+      setInterval(function () {
+        if (trap.value !== trustedValue) {
+          trap.value = trustedValue;
+          trapStatus.textContent = 'status: reverted direct assignment';
+        }
+      }, 250);
+
+      var overlay = document.getElementById('overlay');
+      var overlayResult = document.getElementById('overlay-result');
+      document.getElementById('open-overlay').addEventListener('click', function () {
+        overlay.style.display = 'flex';
+        overlayResult.textContent = 'overlay opened';
+      });
+      document.getElementById('close-overlay').addEventListener('click', function () {
+        overlay.style.display = 'none';
+        overlayResult.textContent = 'overlay closed';
+      });
+
+      var submitResult = document.getElementById('submit-result');
+      document.getElementById('honeypot').addEventListener('click', function () {
+        submitResult.textContent = 'honeypot clicked';
+      });
+      document.getElementById('real-submit').addEventListener('click', function () {
+        submitResult.textContent = 'real submit clicked';
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/tests/pages/performance.html
+++ b/tests/pages/performance.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Performance Nightmare</title>
+  <style>
+    :root {
+      --bg: #fff6ec;
+      --ink: #1b1b1b;
+      --accent: #a33f00;
+    }
+    body {
+      margin: 0;
+      font-family: "Lucida Sans", "Lucida Grande", sans-serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, #fff3e6 0%, var(--bg) 70%);
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 4;
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      background: #42210b;
+      color: #fff4ea;
+      padding: 0.7rem;
+    }
+    nav a {
+      color: inherit;
+      text-decoration: none;
+      border: 1px solid rgba(255,255,255,0.35);
+      padding: 0.35rem 0.6rem;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    main {
+      max-width: 980px;
+      margin: 1rem auto;
+      padding: 0 1rem 3rem;
+    }
+    .hero-placeholder {
+      min-height: 280px;
+      border-radius: 14px;
+      border: 2px dashed #b45309;
+      display: grid;
+      place-items: center;
+      background: repeating-linear-gradient(135deg, #ffe2c7 0 14px, #ffe9d7 14px 28px);
+      margin-bottom: 1rem;
+    }
+    #hero-image {
+      display: none;
+      width: 100%;
+      min-height: 320px;
+      border-radius: 14px;
+      background: linear-gradient(135deg, #8b1e3f, #f97316);
+      color: #fff;
+      font-size: 2rem;
+      font-weight: 700;
+      align-items: center;
+      justify-content: center;
+    }
+    #shift-slot {
+      min-height: 48px;
+      margin-bottom: 1rem;
+    }
+    #shift-banner {
+      display: none;
+      padding: 1rem;
+      border-left: 8px solid #ef4444;
+      background: #fee2e2;
+      border-radius: 10px;
+    }
+    .panel {
+      background: #fff;
+      border: 1px solid #f1c89c;
+      border-radius: 12px;
+      padding: 1rem;
+      box-shadow: 0 6px 18px rgba(139, 69, 19, 0.11);
+      margin-top: 1rem;
+    }
+    button {
+      padding: 0.6rem 0.9rem;
+      border-radius: 8px;
+      border: 1px solid #7c2d12;
+      background: #b45309;
+      color: #fff;
+      cursor: pointer;
+      font: inherit;
+    }
+    #block-result {
+      margin-top: 0.65rem;
+      font-weight: 700;
+    }
+    .spacer {
+      height: 1200px;
+      background: linear-gradient(180deg, rgba(180,83,9,0.05), rgba(180,83,9,0.13));
+      border-radius: 10px;
+      margin-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <nav aria-label="Primary menu">
+    <a href="/">Home</a>
+    <a href="/interact.html">Interact</a>
+    <a href="/performance.html">Performance</a>
+    <a href="/telemetry.html">Telemetry</a>
+    <a href="/a11y.html">A11y</a>
+  </nav>
+
+  <main>
+    <h1>Performance Nightmare</h1>
+    <p>Designed to trigger deterministic Web Vitals and long-task signals.</p>
+
+    <div id="lcp-slot" class="hero-placeholder" aria-live="polite">Hero loading... (delayed 2s)</div>
+    <div id="hero-image">Delayed LCP Hero</div>
+
+    <div id="shift-slot"></div>
+
+    <section class="panel">
+      <h2>Main-Thread Blocking Action</h2>
+      <p>Clicking this runs a deterministic busy loop for ~800ms.</p>
+      <button id="block-main" type="button">Run 800ms blocking task</button>
+      <div id="block-result" role="status"></div>
+    </section>
+
+    <div class="spacer" aria-hidden="true"></div>
+
+    <section class="panel" id="lower-content">
+      <h2>Lower Content</h2>
+      <p>This content gets pushed down when CLS banner appears.</p>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      setTimeout(function () {
+        var slot = document.getElementById('lcp-slot');
+        var hero = document.getElementById('hero-image');
+        slot.style.display = 'none';
+        hero.style.display = 'flex';
+      }, 2000);
+
+      setTimeout(function () {
+        var shiftSlot = document.getElementById('shift-slot');
+        var banner = document.createElement('div');
+        banner.id = 'shift-banner';
+        banner.textContent = 'Late-loading alert inserted to force layout shift.';
+        banner.style.display = 'block';
+        shiftSlot.appendChild(banner);
+      }, 1500);
+
+      document.getElementById('block-main').addEventListener('click', function () {
+        var start = performance.now();
+        while (performance.now() - start < 800) {
+          // Intentional busy loop to force long task.
+        }
+        document.getElementById('block-result').textContent = 'blocking task complete in ' + Math.round(performance.now() - start) + 'ms';
+      });
+    }());
+  </script>
+</body>
+</html>

--- a/tests/pages/telemetry.html
+++ b/tests/pages/telemetry.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Noise Factory</title>
+  <style>
+    :root {
+      --bg: #e9f1ff;
+      --ink: #111827;
+      --accent: #1d4ed8;
+      --panel: #fdfefe;
+    }
+    body {
+      margin: 0;
+      font-family: Tahoma, Geneva, sans-serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, #f5f9ff 0%, var(--bg) 74%);
+    }
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 3;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      background: #14213d;
+      color: #f1f5ff;
+      padding: 0.65rem;
+    }
+    nav a {
+      color: inherit;
+      text-decoration: none;
+      border: 1px solid rgba(241,245,255,0.4);
+      border-radius: 8px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.9rem;
+    }
+    main {
+      max-width: 980px;
+      margin: 1rem auto;
+      padding: 0 1rem 2.5rem;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid #b7c6f1;
+      border-radius: 12px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      box-shadow: 0 6px 18px rgba(20, 33, 61, 0.09);
+    }
+    button {
+      padding: 0.55rem 0.85rem;
+      border-radius: 8px;
+      border: 1px solid #1d4ed8;
+      background: #2563eb;
+      color: #fff;
+      cursor: pointer;
+      font: inherit;
+      margin-right: 0.5rem;
+      margin-bottom: 0.4rem;
+    }
+    #events {
+      font-family: Menlo, Monaco, monospace;
+      font-size: 0.86rem;
+      background: #f8fbff;
+      border: 1px dashed #93a7de;
+      border-radius: 10px;
+      min-height: 120px;
+      padding: 0.7rem;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <nav aria-label="Primary menu">
+    <a href="/">Home</a>
+    <a href="/interact.html">Interact</a>
+    <a href="/performance.html">Performance</a>
+    <a href="/telemetry.html">Telemetry</a>
+    <a href="/a11y.html">A11y</a>
+  </nav>
+
+  <main>
+    <h1>Noise Factory</h1>
+    <p>Deterministic source of console spam, network failures, and runtime exceptions.</p>
+
+    <section class="panel">
+      <h2>Triggers</h2>
+      <button id="trigger-spam" type="button">Emit 120 console logs</button>
+      <button id="trigger-network" type="button">Run failing network calls</button>
+      <button id="trigger-error" type="button">Throw deep runtime error</button>
+      <button id="trigger-ws" type="button">Open failing websocket</button>
+      <div id="events" role="log" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      var events = document.getElementById('events');
+      function logLine(line) {
+        events.textContent += line + '\n';
+      }
+
+      document.getElementById('trigger-spam').addEventListener('click', function () {
+        for (var i = 1; i <= 120; i += 1) {
+          console.log('smoke-noise-log-' + i);
+        }
+        console.warn('smoke-noise-warning');
+        logLine('console spam emitted: 120 log lines + 1 warning');
+      });
+
+      document.getElementById('trigger-network').addEventListener('click', function () {
+        fetch('/api/status/404').catch(function () {});
+        fetch('/api/status/500').catch(function () {});
+        fetch('/api/slow').catch(function () {});
+        fetch('http://127.0.0.1:9/cors-fail').catch(function () {
+          logLine('network error captured for unreachable endpoint');
+        });
+        logLine('network sequence started (404/500/slow/unreachable)');
+      });
+
+      document.getElementById('trigger-error').addEventListener('click', function () {
+        function layer3() {
+          var missing;
+          return missing.nope();
+        }
+        function layer2() { return layer3(); }
+        function layer1() { return layer2(); }
+        try {
+          layer1();
+        } catch (err) {
+          console.error('intentional telemetry error', err);
+          logLine('runtime error thrown: ' + err.message);
+        }
+      });
+
+      document.getElementById('trigger-ws').addEventListener('click', function () {
+        try {
+          var ws = new WebSocket('ws://127.0.0.1:9/socket');
+          ws.onerror = function () {
+            console.error('ws error event');
+            logLine('websocket error event fired');
+          };
+          ws.onclose = function (event) {
+            logLine('websocket closed code=' + event.code);
+          };
+        } catch (err) {
+          console.error('ws constructor error', err);
+          logLine('websocket constructor failed: ' + err.message);
+        }
+      });
+
+      // Emit a small baseline so logs are never empty.
+      console.info('telemetry page loaded');
+      logLine('page loaded; click triggers to generate deterministic telemetry');
+    }());
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enforce a strict structured recovery error contract in shared MCP errors by always emitting `error_code`, `message`, and `recovery_playbook` (while preserving legacy `error` + `retry` aliases)
- add conflict-aware alias routing across tool dispatchers (`interact`, `configure`, `generate`, `analyze`, `observe`) so alias params are accepted when unambiguous, and responses include a canonicalization warning that `what` is preferred
- add deterministic local harness infrastructure for smoke tests:
  - new `scripts/smoke-tests/harness-server.py`
  - new `tests/pages/` suite with `interact.html`, `performance.html`, `telemetry.html`, `a11y.html` plus local `example.com`/`example.org` mirrors
  - smoke framework now starts/stops the local harness and rewrites legacy external example URLs to local harness URLs
- update feature spec doc to reflect implemented harness architecture

## Issues
- Closes #300
- Closes #304

## Validation
- `go test ./cmd/dev-console -run 'TestStructuredError_CanonicalRecoveryContractFields|TestContractEnforcement_ErrorsHaveRetryableField|TestTools(Interact|Configure|Generate|Analyze|Observe)Dispatch_.*(Alias|Conflicting)' -count=1`
- `go test ./cmd/dev-console -run 'TestTools(Interact|Configure|Generate|Analyze|Observe)Dispatch_|TestStructuredError_|TestContractEnforcement_ErrorsHaveRetryableField|TestMcpStructuredError' -count=1`
- `bash -n scripts/smoke-tests/framework-smoke.sh`
- `python3 -m py_compile scripts/smoke-tests/harness-server.py`

## Notes
- Full package `go test ./cmd/dev-console` is not runnable in this sandbox due local bind restrictions (`listen tcp ...:0: bind: operation not permitted`).
