### PR TITLE
Follow-up: alias warnings on error paths + strict smoke URL rewrite

### DIFF
--- a/cmd/dev-console/tools_analyze.go
+++ b/cmd/dev-console/tools_analyze.go
@@ -156,7 +156,8 @@ func (h *ToolHandler) toolAnalyze(req JSONRPCRequest, args json.RawMessage) JSON
 	handler, ok := analyzeHandlers[what]
 	if !ok {
 		validModes := getValidAnalyzeModes()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		resp := JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown analyze mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	}
 
 	resp := handler(h, req, args)

--- a/cmd/dev-console/tools_analyze_handler_test.go
+++ b/cmd/dev-console/tools_analyze_handler_test.go
@@ -71,6 +71,27 @@ func TestToolsAnalyzeDispatch_UnknownMode(t *testing.T) {
 	assertSnakeCaseFields(t, string(resp.Result))
 }
 
+func TestToolsAnalyzeDispatch_UnknownModeAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callAnalyzeRaw(h, `{"mode":"nonexistent_mode"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("unknown mode alias should return isError:true")
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
+	}
+}
+
 func TestToolsAnalyzeDispatch_EmptyArgs(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)

--- a/cmd/dev-console/tools_configure.go
+++ b/cmd/dev-console/tools_configure.go
@@ -149,7 +149,8 @@ func (h *ToolHandler) toolConfigure(req JSONRPCRequest, args json.RawMessage) JS
 	handler, ok := configureHandlers[what]
 	if !ok {
 		validActions := getValidConfigureActions()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown configure action: "+what, "Use a valid action from the 'what' enum", withParam("what"), withHint("Valid values: "+validActions))}
+		resp := JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown configure action: "+what, "Use a valid action from the 'what' enum", withParam("what"), withHint("Valid values: "+validActions))}
+		return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	}
 
 	resp := handler(h, req, args)

--- a/cmd/dev-console/tools_configure_handler_test.go
+++ b/cmd/dev-console/tools_configure_handler_test.go
@@ -71,6 +71,27 @@ func TestToolsConfigureDispatch_UnknownAction(t *testing.T) {
 	assertSnakeCaseFields(t, string(resp.Result))
 }
 
+func TestToolsConfigureDispatch_UnknownActionAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callConfigureRaw(h, `{"action":"nonexistent_action"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("unknown action alias should return isError:true")
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
+	}
+}
+
 func TestToolsConfigureDispatch_EmptyArgs(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)

--- a/cmd/dev-console/tools_generate.go
+++ b/cmd/dev-console/tools_generate.go
@@ -222,7 +222,8 @@ func (h *ToolHandler) toolGenerate(req JSONRPCRequest, args json.RawMessage) JSO
 	handler, ok := generateHandlers[what]
 	if !ok {
 		validFormats := getValidGenerateFormats()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown generate format: "+what, "Use a valid format from the 'what' enum", withParam("what"), withHint("Valid values: "+validFormats))}
+		resp := JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown generate format: "+what, "Use a valid format from the 'what' enum", withParam("what"), withHint("Valid values: "+validFormats))}
+		return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	}
 
 	// Strict parameter validation: reject unknown params for the given format

--- a/cmd/dev-console/tools_generate_handler_test.go
+++ b/cmd/dev-console/tools_generate_handler_test.go
@@ -73,6 +73,27 @@ func TestToolsGenerateDispatch_UnknownFormat(t *testing.T) {
 	assertSnakeCaseFields(t, string(resp.Result))
 }
 
+func TestToolsGenerateDispatch_UnknownFormatAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callGenerateRaw(h, `{"format":"nonexistent_format"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("unknown format alias should return isError:true")
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
+	}
+}
+
 func TestToolsGenerateDispatch_EmptyArgs(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)

--- a/cmd/dev-console/tools_interact.go
+++ b/cmd/dev-console/tools_interact.go
@@ -164,12 +164,13 @@ func (h *ToolHandler) toolInteract(req JSONRPCRequest, args json.RawMessage) JSO
 	}
 
 	if _, err := parseEvidenceMode(args); err != nil {
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
+		resp := JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
 			ErrInvalidParam,
 			"Invalid 'evidence' value",
 			"Use evidence='off' (default), 'on_mutation', or 'always'",
 			withParam("evidence"),
 		)}
+		return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	}
 
 	// Extract optional subtitle param (composable: works on any action)

--- a/cmd/dev-console/tools_interact_handler_test.go
+++ b/cmd/dev-console/tools_interact_handler_test.go
@@ -73,6 +73,27 @@ func TestToolsInteractDispatch_UnknownAction(t *testing.T) {
 	assertSnakeCaseFields(t, string(resp.Result))
 }
 
+func TestToolsInteractDispatch_UnknownActionAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	resp := callInteractRaw(h, `{"action":"nonexistent_action"}`)
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("unknown action alias should return isError:true")
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
+	}
+}
+
 func TestToolsInteractDispatch_ScreenshotAlias(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)

--- a/cmd/dev-console/tools_observe.go
+++ b/cmd/dev-console/tools_observe.go
@@ -166,7 +166,8 @@ func (h *ToolHandler) toolObserve(req JSONRPCRequest, args json.RawMessage) JSON
 	handler, ok := observeHandlers[what]
 	if !ok {
 		validModes := getValidObserveModes()
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown observe mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		resp := JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrUnknownMode, "Unknown observe mode: "+what, "Use a valid mode from the 'what' enum", withParam("what"), withHint("Valid values: "+validModes))}
+		return appendCanonicalWhatAliasWarning(resp, usedAliasParam, what)
 	}
 
 	args = h.maybeInjectSummary(args)

--- a/cmd/dev-console/tools_observe_handler_test.go
+++ b/cmd/dev-console/tools_observe_handler_test.go
@@ -72,6 +72,28 @@ func TestToolsObserveDispatch_UnknownMode(t *testing.T) {
 	}
 }
 
+func TestToolsObserveDispatch_UnknownModeAliasAddsCanonicalWhatWarning(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	resp := h.toolObserve(req, json.RawMessage(`{"mode":"nonexistent_mode"}`))
+	result := parseToolResult(t, resp)
+	if !result.IsError {
+		t.Fatal("unknown mode alias should return isError:true")
+	}
+	foundCanonicalWarning := false
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			foundCanonicalWarning = true
+			break
+		}
+	}
+	if !foundCanonicalWarning {
+		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
+	}
+}
+
 func TestToolsObserveDispatch_EmptyArgs(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)

--- a/docs/features/feature-test-harness.md
+++ b/docs/features/feature-test-harness.md
@@ -1,5 +1,5 @@
 ---
-status: implemented
+status: partially_implemented
 scope: feature/test-harness/implementation
 ai-priority: high
 tags: [implementation, testing, architecture]
@@ -96,6 +96,11 @@ We will maintain a dedicated `external-evasion.sh` module for tests that *must* 
 ---
 
 ## Execution Plan
+
+Current phase status:
+* Phase 1: implemented
+* Phase 2: partially implemented (framework rewrite is in place; per-module assertion hardening remains)
+* Phase 3: pending
 
 1. **Phase 1: Create the Test Server & Pages**
    * Setup the local web server in the Makefile/test scripts.

--- a/scripts/smoke-tests/framework-smoke.sh
+++ b/scripts/smoke-tests/framework-smoke.sh
@@ -164,12 +164,42 @@ init_smoke() {
 
 rewrite_smoke_urls() {
     local payload="$1"
-    payload="${payload//https:\/\/example.com/$SMOKE_EXAMPLE_URL}"
-    payload="${payload//http:\/\/example.com/$SMOKE_EXAMPLE_URL}"
-    payload="${payload//https:\/\/www.example.com/$SMOKE_EXAMPLE_URL}"
-    payload="${payload//https:\/\/example.org/${SMOKE_BASE_URL}/example.org}"
-    payload="${payload//http:\/\/example.org/${SMOKE_BASE_URL}/example.org}"
-    echo "$payload"
+    local rewritten
+    rewritten=$(
+        printf '%s' "$payload" | \
+            SMOKE_EXAMPLE_URL="$SMOKE_EXAMPLE_URL" SMOKE_BASE_URL="$SMOKE_BASE_URL" \
+            jq -c '
+                def rewrite_example_domain_url:
+                    if type != "string" then .
+                    elif test("^https?://(www\\.)?example\\.com(/|$)") then
+                        sub("^https?://(www\\.)?example\\.com"; env.SMOKE_EXAMPLE_URL)
+                    elif test("^https?://example\\.org(/|$)") then
+                        sub("^https?://example\\.org"; (env.SMOKE_BASE_URL + "/example.org"))
+                    else .
+                    end;
+
+                def rewrite_url_fields:
+                    if type == "object" then
+                        with_entries(
+                            if (.key == "url" or .key == "base_url" or .key == "from_url" or .key == "to_url")
+                            then .value |= rewrite_example_domain_url
+                            else .value |= rewrite_url_fields
+                            end
+                        )
+                    elif type == "array" then map(rewrite_url_fields)
+                    else .
+                    end;
+
+                rewrite_url_fields
+            ' 2>/dev/null
+    )
+
+    if [ -n "$rewritten" ]; then
+        echo "$rewritten"
+    else
+        # Non-JSON payloads should pass through unchanged.
+        echo "$payload"
+    fi
 }
 
 # Override base framework call_tool so smoke runs stay on local harness pages.


### PR DESCRIPTION
## Summary
- append canonical what alias warning on alias-driven error paths for configure/generate/analyze/observe/interact
- add regression tests proving canonical warning appears when alias params hit unknown mode/action paths
- update harness feature doc status to partially_implemented with explicit phase status
- tighten smoke URL rewriting to only rewrite URL-typed fields (url, base_url, from_url, to_url) in JSON payloads

## Why
These are the accepted follow-ups from principal/QA review to improve guidance consistency and avoid over-broad token mutation in smoke payload rewriting.

## Validation
- bash -n scripts/smoke-tests/framework-smoke.sh
- go test ./cmd/dev-console -run 'TestTools(Interact|Configure|Generate|Analyze|Observe)Dispatch_.*(Alias|Conflicting|Unknown)|TestStructuredError_|TestMcpStructuredError|TestContractEnforcement_ErrorsHaveRetryableField' -count=1 (currently blocked by baseline compile issue in internal/tools/configure/capabilities.go: missing inferDispatchParam on UNSTABLE)
