### PR TITLE
fix(interact): graceful cold-start queuing — wait up to 5s for extension before failing (#302)

### DIFF
--- a/cmd/dev-console/tools_core.go
+++ b/cmd/dev-console/tools_core.go
@@ -190,6 +190,10 @@ type ToolHandler struct {
 	summaryPrefMu    sync.RWMutex
 	summaryPrefValue bool
 	summaryPrefReady bool
+
+	// extensionReadinessTimeout overrides the cold-start wait duration for requireExtension.
+	// Zero uses capture.ExtensionReadinessTimeout (5s). Tests set this to 100ms.
+	extensionReadinessTimeout time.Duration
 }
 
 // GetCapture returns the capture instance

--- a/cmd/dev-console/tools_errors.go
+++ b/cmd/dev-console/tools_errors.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/dev-console/dev-console/internal/capture"
 	"github.com/dev-console/dev-console/internal/mcp"
 )
 
@@ -150,11 +152,17 @@ func (h *ToolHandler) requirePilot(req JSONRPCRequest, extraOpts ...func(*Struct
 }
 
 // requireExtension returns (resp, true) if the browser extension is not connected,
-// short-circuiting the caller with an immediate structured error (~5ms) instead of
-// queuing a command that would time out after 15s.
+// short-circuiting the caller with a structured error. On cold starts it waits up to
+// ExtensionReadinessTimeout (5s) for the extension to connect before giving up.
 // Usage: if resp, blocked := h.requireExtension(req); blocked { return resp }
 func (h *ToolHandler) requireExtension(req JSONRPCRequest, extraOpts ...func(*StructuredError)) (JSONRPCResponse, bool) {
-	if h.capture.IsExtensionConnected() {
+	timeout := h.extensionReadinessTimeout
+	if timeout <= 0 {
+		timeout = capture.ExtensionReadinessTimeout
+	}
+	// TODO(#302): Use request-scoped context once JSONRPCRequest carries one.
+	// context.Background() means cold-start waits are not cancellable during shutdown.
+	if h.capture.WaitForExtensionConnected(context.Background(), timeout) {
 		return JSONRPCResponse{}, false
 	}
 	opts := append([]func(*StructuredError){h.diagnosticHint(), withRetryable(true), withRetryAfterMs(3000)}, extraOpts...)

--- a/cmd/dev-console/tools_interact_gate_test.go
+++ b/cmd/dev-console/tools_interact_gate_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dev-console/dev-console/internal/capture"
 )
@@ -41,7 +42,18 @@ func newGateTestEnv(t *testing.T) *gateTestEnv {
 	cap := capture.NewCapture()
 	mcpHandler := NewToolHandler(server, cap)
 	handler := mcpHandler.toolHandler.(*ToolHandler)
+	// Keep disconnect tests fast — override the 5s production readiness timeout.
+	handler.extensionReadinessTimeout = 100 * time.Millisecond
 	return &gateTestEnv{handler: handler, server: server, capture: cap}
+}
+
+// newGateTestEnvWithTimeout creates a gate test env with an explicit readiness timeout,
+// avoiding the double-override pattern (newGateTestEnv default + manual field write).
+func newGateTestEnvWithTimeout(t *testing.T, timeout time.Duration) *gateTestEnv {
+	t.Helper()
+	env := newGateTestEnv(t)
+	env.handler.extensionReadinessTimeout = timeout
+	return env
 }
 
 // simulateConnection sends a /sync POST to mark extension as connected.
@@ -347,6 +359,28 @@ func TestGateOrder_Extension_BeforeCSP(t *testing.T) {
 // ============================================
 // Diagnostic hint test
 // ============================================
+
+// TestRequireExtension_ConnectsDuringWait verifies the cold-start readiness gate:
+// if the extension connects within the wait window, the gate passes instead of failing.
+func TestRequireExtension_ConnectsDuringWait(t *testing.T) {
+	t.Parallel()
+	// 500ms window: goroutine connects at 150ms, caught on the 200ms poll tick.
+	env := newGateTestEnvWithTimeout(t, 500*time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(150 * time.Millisecond)
+		env.simulateConnection(t)
+	}()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: json.RawMessage(`1`)}
+	resp, blocked := env.handler.requireExtension(req)
+	<-done // ensure goroutine finished before test returns
+	if blocked {
+		t.Fatalf("expected requireExtension to pass after late connection, got blocked: %v", resp)
+	}
+}
 
 func TestDiagnosticHint_IncludesCSP(t *testing.T) {
 	t.Parallel()

--- a/internal/capture/constants.go
+++ b/internal/capture/constants.go
@@ -39,6 +39,14 @@ const (
 
 )
 
+// ExtensionReadinessTimeout is how long requireExtension will wait for a cold-start
+// connection before returning no_data. Tests override this via ToolHandler.extensionReadinessTimeout.
+const ExtensionReadinessTimeout = 5 * time.Second
+
+// extensionReadinessPollInterval is the server-side connection check cadence.
+// Faster than the extension's idle heartbeat (1s) to detect connection promptly.
+const extensionReadinessPollInterval = 200 * time.Millisecond
+
 var (
 	// extensionDisconnectThreshold is how long since last /sync before
 	// the extension is considered disconnected. Pending queries are auto-expired

--- a/internal/capture/extension_state.go
+++ b/internal/capture/extension_state.go
@@ -4,7 +4,10 @@
 
 package capture
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	PilotStateAssumedEnabled    = "assumed_enabled"
@@ -114,6 +117,31 @@ func (c *Capture) IsPilotExplicitlyDisabled() bool {
 	defer c.mu.RUnlock()
 	snap := pilotStatusSnapshotFromExtensionState(c.ext)
 	return snap.State == PilotStateExplicitlyDisable
+}
+
+// WaitForExtensionConnected polls until the extension connects, the timeout elapses,
+// or ctx is cancelled. Returns true if connected within the window, false otherwise.
+// A zero or negative timeout returns false immediately (no polling).
+// Poll interval is extensionReadinessPollInterval (200ms). ctx cancellation is
+// honoured between polls.
+func (c *Capture) WaitForExtensionConnected(ctx context.Context, timeout time.Duration) bool {
+	if c.IsExtensionConnected() {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(extensionReadinessPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			if c.IsExtensionConnected() {
+				return true
+			}
+		}
+	}
 }
 
 // IsExtensionConnected returns true if the extension has synced within the

--- a/internal/capture/extension_state_unit_test.go
+++ b/internal/capture/extension_state_unit_test.go
@@ -5,6 +5,7 @@
 package capture
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -80,6 +81,67 @@ func TestExtensionStateGettersAndBoundaries(t *testing.T) {
 	c.mu.RUnlock()
 	if snap.ExtSessionID != "session-a" || !snap.PilotEnabled || snap.ActiveTestIDCount != 1 {
 		t.Fatalf("extension snapshot = %+v, unexpected values", snap)
+	}
+}
+
+// ============================================
+// WaitForExtensionConnected tests (issue #302)
+// ============================================
+
+func TestWaitForExtensionConnected_AlreadyConnected(t *testing.T) {
+	t.Parallel()
+	c := NewCapture()
+
+	// Simulate extension already connected.
+	c.mu.Lock()
+	c.ext.lastSyncSeen = time.Now()
+	c.mu.Unlock()
+
+	if !c.WaitForExtensionConnected(context.Background(), 5*time.Second) {
+		t.Fatal("WaitForExtensionConnected returned false when extension already connected")
+	}
+}
+
+func TestWaitForExtensionConnected_ConnectsDuringWait(t *testing.T) {
+	t.Parallel()
+	c := NewCapture()
+
+	// Connect at 50ms — well before the first 200ms poll tick, giving a comfortable
+	// 150ms margin before the tick catches the connection.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		c.mu.Lock()
+		c.ext.lastSyncSeen = time.Now()
+		c.mu.Unlock()
+	}()
+
+	if !c.WaitForExtensionConnected(context.Background(), time.Second) {
+		t.Fatal("WaitForExtensionConnected returned false; expected true after late connection")
+	}
+}
+
+func TestWaitForExtensionConnected_Timeout(t *testing.T) {
+	t.Parallel()
+	c := NewCapture()
+	// Extension never connects.
+
+	if c.WaitForExtensionConnected(context.Background(), 100*time.Millisecond) {
+		t.Fatal("WaitForExtensionConnected returned true; expected false after timeout")
+	}
+}
+
+func TestWaitForExtensionConnected_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	c := NewCapture()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	if c.WaitForExtensionConnected(ctx, 5*time.Second) {
+		t.Fatal("WaitForExtensionConnected returned true; expected false after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** First `interact` call during a cold start fails instantly with `no_data` because the extension hasn't connected yet, forcing the LLM to wait 3s and retry manually.
- **Fix:** `requireExtension` now holds the request for up to 5s polling every 200ms (matching the extension's `/sync` heartbeat) before returning `no_data`. If the extension connects within that window, the command proceeds normally.
- **Timing budget:** 5s readiness wait + 15s command wait = 20s worst case, well under the 35s `SlowTimeout`.

## Changes

| File | Change |
|------|--------|
| `internal/capture/constants.go` | `ExtensionReadinessTimeout = 5s`, `extensionReadinessPollInterval = 200ms` |
| `internal/capture/extension_state.go` | `WaitForExtensionConnected(ctx, timeout)` — ticker+context, no sleep overshoot |
| `internal/capture/extension_state_unit_test.go` | 3 new unit tests |
| `cmd/dev-console/tools_errors.go` | `requireExtension` calls `WaitForExtensionConnected`; `<= 0` guard |
| `cmd/dev-console/tools_core.go` | `extensionReadinessTimeout` field for test overrides |
| `cmd/dev-console/tools_interact_gate_test.go` | 100ms override in `newGateTestEnv`; `newGateTestEnvWithTimeout` helper; new gate test |

## Implementation notes

- Uses `context.WithTimeout` + `time.NewTicker` instead of `time.Sleep` so the deadline is precise (no ≥200ms overshoot) and the wait is cancellable
- Tests override `extensionReadinessTimeout = 100ms` to keep disconnect tests fast (~100ms instead of 5s)
- `WaitForExtensionConnected` accepts `context.Context` for future cancellation threading

## Test plan

- [ ] `go test ./internal/capture/ -run TestWaitForExtension -v` — 3 unit tests pass
- [ ] `go test ./cmd/dev-console/ -run "TestRequireExtension|TestNavigate_Ext|TestClick_Ext|TestGateOrder" -v` — all gate tests pass
- [ ] Manual: start Gasoline without extension → send `interact` command → connect extension within 5s → command succeeds instead of returning `no_data`

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)