### PR TITLE
QA follow-up: harden smoke URL rewrite and reduce handler/test drift

### DIFF
--- a/cmd/dev-console/tools_analyze_handler_test.go
+++ b/cmd/dev-console/tools_analyze_handler_test.go
@@ -80,16 +80,7 @@ func TestToolsAnalyzeDispatch_UnknownModeAliasAddsCanonicalWhatWarning(t *testin
 	if !result.IsError {
 		t.Fatal("unknown mode alias should return isError:true")
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsAnalyzeDispatch_EmptyArgs(t *testing.T) {
@@ -113,16 +104,7 @@ func TestToolsAnalyzeDispatch_ModeAliasAddsCanonicalWhatWarning(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("mode alias should be accepted, got: %s", result.Content[0].Text)
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsAnalyzeDispatch_ConflictingWhatAndMode(t *testing.T) {

--- a/cmd/dev-console/tools_configure_handler_test.go
+++ b/cmd/dev-console/tools_configure_handler_test.go
@@ -80,16 +80,7 @@ func TestToolsConfigureDispatch_UnknownActionAliasAddsCanonicalWhatWarning(t *te
 	if !result.IsError {
 		t.Fatal("unknown action alias should return isError:true")
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsConfigureDispatch_EmptyArgs(t *testing.T) {
@@ -113,16 +104,7 @@ func TestToolsConfigureDispatch_ActionAliasAddsCanonicalWhatWarning(t *testing.T
 	if result.IsError {
 		t.Fatalf("action alias should be accepted, got: %s", result.Content[0].Text)
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsConfigureDispatch_ConflictingWhatAndAction(t *testing.T) {

--- a/cmd/dev-console/tools_generate_handler_test.go
+++ b/cmd/dev-console/tools_generate_handler_test.go
@@ -82,16 +82,7 @@ func TestToolsGenerateDispatch_UnknownFormatAliasAddsCanonicalWhatWarning(t *tes
 	if !result.IsError {
 		t.Fatal("unknown format alias should return isError:true")
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsGenerateDispatch_EmptyArgs(t *testing.T) {
@@ -115,16 +106,7 @@ func TestToolsGenerateDispatch_FormatAliasAddsCanonicalWhatWarning(t *testing.T)
 	if result.IsError {
 		t.Fatalf("format alias should be accepted, got: %s", result.Content[0].Text)
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsGenerateDispatch_ConflictingWhatAndFormat(t *testing.T) {

--- a/cmd/dev-console/tools_interact.go
+++ b/cmd/dev-console/tools_interact.go
@@ -144,15 +144,6 @@ func (h *ToolHandler) toolInteract(req JSONRPCRequest, args json.RawMessage) JSO
 		}
 	}
 
-	if params.What != "" && params.Action != "" && params.What != params.Action {
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
-			ErrInvalidParam,
-			"Conflicting dispatch values: 'what' and 'action' do not match",
-			"Provide only one dispatch field, or set both to the same action value",
-			withParam("what"),
-		)}
-	}
-
 	if what == "" {
 		validActions := h.getValidInteractActions()
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(

--- a/cmd/dev-console/tools_interact_evidence_test.go
+++ b/cmd/dev-console/tools_interact_evidence_test.go
@@ -217,3 +217,20 @@ func TestInteractEvidence_InvalidModeReturnsError(t *testing.T) {
 		t.Fatalf("expected invalid evidence error details, got: %s", firstText(result))
 	}
 }
+
+func TestInteractEvidence_InvalidModeWithActionAliasAddsCanonicalWarning(t *testing.T) {
+	env := newInteractTestEnv(t)
+
+	result, ok := env.callInteract(t, `{"action":"click","selector":"#btn","evidence":"sometimes"}`)
+	if !ok {
+		t.Fatal("interact should return a structured error result")
+	}
+	if !result.IsError {
+		t.Fatalf("invalid evidence mode should return isError=true, got: %s", firstText(result))
+	}
+	text := strings.ToLower(firstText(result))
+	if !strings.Contains(text, "evidence") || !strings.Contains(text, "invalid") {
+		t.Fatalf("expected invalid evidence error details, got: %s", firstText(result))
+	}
+	assertCanonicalWhatWarning(t, result)
+}

--- a/cmd/dev-console/tools_interact_handler_test.go
+++ b/cmd/dev-console/tools_interact_handler_test.go
@@ -82,16 +82,7 @@ func TestToolsInteractDispatch_UnknownActionAliasAddsCanonicalWhatWarning(t *tes
 	if !result.IsError {
 		t.Fatal("unknown action alias should return isError:true")
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsInteractDispatch_ScreenshotAlias(t *testing.T) {
@@ -153,16 +144,7 @@ func TestToolsInteractDispatch_ActionAliasAddsCanonicalWhatWarning(t *testing.T)
 	if strings.Contains(result.Content[0].Text, "unknown_mode") {
 		t.Fatalf("action alias should not route to unknown_mode, got: %s", result.Content[0].Text)
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsInteractDispatch_ConflictingWhatAndAction(t *testing.T) {

--- a/cmd/dev-console/tools_observe_handler_test.go
+++ b/cmd/dev-console/tools_observe_handler_test.go
@@ -82,16 +82,7 @@ func TestToolsObserveDispatch_UnknownModeAliasAddsCanonicalWhatWarning(t *testin
 	if !result.IsError {
 		t.Fatal("unknown mode alias should return isError:true")
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block on error path, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsObserveDispatch_EmptyArgs(t *testing.T) {
@@ -117,16 +108,7 @@ func TestToolsObserveDispatch_ModeAliasAddsCanonicalWhatWarning(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("mode alias should be accepted, got: %s", result.Content[0].Text)
 	}
-	foundCanonicalWarning := false
-	for _, block := range result.Content {
-		if strings.Contains(block.Text, "canonical parameter is 'what'") {
-			foundCanonicalWarning = true
-			break
-		}
-	}
-	if !foundCanonicalWarning {
-		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
-	}
+	assertCanonicalWhatWarning(t, result)
 }
 
 func TestToolsObserveDispatch_ConflictingWhatAndMode(t *testing.T) {

--- a/cmd/dev-console/tools_test_helpers_test.go
+++ b/cmd/dev-console/tools_test_helpers_test.go
@@ -140,6 +140,22 @@ func firstText(result MCPToolResult) string {
 	return ""
 }
 
+func hasCanonicalWhatWarning(result MCPToolResult) bool {
+	for _, block := range result.Content {
+		if strings.Contains(block.Text, "canonical parameter is 'what'") {
+			return true
+		}
+	}
+	return false
+}
+
+func assertCanonicalWhatWarning(t *testing.T, result MCPToolResult) {
+	t.Helper()
+	if !hasCanonicalWhatWarning(result) {
+		t.Fatalf("expected canonical what warning block, got %d content blocks", len(result.Content))
+	}
+}
+
 // ============================================
 // Tool Call Wrappers
 // ============================================

--- a/scripts/smoke-tests/12-cross-cutting.sh
+++ b/scripts/smoke-tests/12-cross-cutting.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# 12-cross-cutting.sh — 12.1-12.3: Pagination, error recovery, buffer overflow.
+# 12-cross-cutting.sh — 12.1-12.4: Pagination, error recovery, buffer overflow, rewrite safety.
 set -eo pipefail
 
-begin_category "12" "Cross-Cutting Concerns" "3"
+begin_category "12" "Cross-Cutting Concerns" "4"
 
 # ── Test 12.1: Pagination via cursors ────────────────────
 begin_test "12.1" "[BROWSER] Pagination: observe(logs) with limit and cursor" \
@@ -191,3 +191,48 @@ except:
     fi
 }
 run_test_12_3
+
+# ── Test 12.4: Rewrite safety ─────────────────────────────
+begin_test "12.4" "[DAEMON ONLY] rewrite_smoke_urls key-scoped rewriting + non-JSON pass-through" \
+    "Verify non-JSON payloads pass through unchanged and JSON rewrites only url/base_url/from_url/to_url fields" \
+    "Tests: smoke URL rewriting safety under set -e/pipefail"
+
+run_test_12_4() {
+    local raw_payload="https://example.com raw text"
+    local raw_out
+    if ! raw_out=$(rewrite_smoke_urls "$raw_payload"); then
+        fail "rewrite_smoke_urls exited non-zero for non-JSON payload under set -e/pipefail."
+        return
+    fi
+    if [ "$raw_out" != "$raw_payload" ]; then
+        fail "Non-JSON payload should pass through unchanged. Got: $(truncate "$raw_out" 120)"
+        return
+    fi
+
+    local json_payload='{"url":"https://example.com/path","note":"https://example.com keep","nested":{"from_url":"https://example.org/a","other":"https://example.org keep"},"steps":[{"to_url":"http://example.com/x"}],"email":"test@example.com"}'
+    local json_out
+    if ! json_out=$(rewrite_smoke_urls "$json_payload"); then
+        fail "rewrite_smoke_urls failed for valid JSON payload."
+        return
+    fi
+
+    local verdict
+    verdict=$(printf '%s' "$json_out" | SMOKE_BASE_URL="$SMOKE_BASE_URL" jq -r '
+        if .url == (env.SMOKE_BASE_URL + "/example.com/path")
+            and .nested.from_url == (env.SMOKE_BASE_URL + "/example.org/a")
+            and .steps[0].to_url == (env.SMOKE_BASE_URL + "/example.com/x")
+            and .note == "https://example.com keep"
+            and .nested.other == "https://example.org keep"
+            and .email == "test@example.com"
+        then "ok"
+        else "bad"
+        end
+    ' 2>/dev/null || echo "bad")
+
+    if [ "$verdict" = "ok" ]; then
+        pass "rewrite_smoke_urls preserves non-URL text and rewrites only URL-key fields."
+    else
+        fail "rewrite_smoke_urls did not produce expected field-scoped rewrite. Output: $(truncate "$json_out" 200)"
+    fi
+}
+run_test_12_4

--- a/scripts/smoke-tests/framework-smoke.sh
+++ b/scripts/smoke-tests/framework-smoke.sh
@@ -165,7 +165,7 @@ init_smoke() {
 rewrite_smoke_urls() {
     local payload="$1"
     local rewritten
-    rewritten=$(
+    if rewritten=$(
         printf '%s' "$payload" | \
             SMOKE_EXAMPLE_URL="$SMOKE_EXAMPLE_URL" SMOKE_BASE_URL="$SMOKE_BASE_URL" \
             jq -c '
@@ -192,14 +192,15 @@ rewrite_smoke_urls() {
 
                 rewrite_url_fields
             ' 2>/dev/null
-    )
-
-    if [ -n "$rewritten" ]; then
-        echo "$rewritten"
-    else
-        # Non-JSON payloads should pass through unchanged.
-        echo "$payload"
+    ); then
+        if [ -n "$rewritten" ]; then
+            echo "$rewritten"
+            return
+        fi
     fi
+
+    # Non-JSON payloads should pass through unchanged.
+    echo "$payload"
 }
 
 # Override base framework call_tool so smoke runs stay on local harness pages.


### PR DESCRIPTION
## Summary
This is the post-merge QA/principal follow-up for #311.

- harden `rewrite_smoke_urls` so non-JSON payloads truly pass through under `set -e -o pipefail`
- add smoke regression test `12.4` to verify:
  - non-JSON payload pass-through
  - key-scoped JSON URL rewriting (`url`, `base_url`, `from_url`, `to_url`) without rewriting arbitrary text fields
- remove dead duplicate `what`/`action` conflict branch in `toolInteract` (single canonical conflict path)
- add regression test for `interact` alias + invalid `evidence` to ensure canonical `what` warning is present on this error path
- reduce handler test duplication by centralizing canonical warning assertion helper

## Why
#311 was merged first; this PR applies the remaining review-driven quality/maintainability follow-ups.

## Validation
- `bash -n scripts/smoke-tests/framework-smoke.sh`
- `bash -n scripts/smoke-tests/12-cross-cutting.sh`
- `go test ./cmd/dev-console -run 'TestTools(Interact|Configure|Generate|Analyze|Observe)Dispatch_.*(Alias|Conflicting|Unknown)|TestInteractEvidence_InvalidMode(ReturnsError|WithActionAliasAddsCanonicalWarning)|TestStructuredError_|TestMcpStructuredError|TestContractEnforcement_ErrorsHaveRetryableField' -count=1`
- manual check: `rewrite_smoke_urls` non-JSON pass-through and key-scoped JSON rewrite
