### PR TITLE
feat(test-harness): embed smoke-test V2 pages in Go daemon (#304)

### DIFF
--- a/cmd/dev-console/server_routes.go
+++ b/cmd/dev-console/server_routes.go
@@ -486,6 +486,8 @@ func registerCoreRoutes(mux *http.ServeMux, server *Server, cap *capture.Capture
 		serveEmbeddedHTML(w, r, docsHTML, "docs")
 	}))
 
+	// NOT MCP — WebSocket echo server for test harness (must be registered before /tests/ subtree)
+	mux.HandleFunc("/tests/ws", handleTestHarnessWS)
 	// NOT MCP — Embedded test/demo pages for self-testing
 	mux.HandleFunc("/tests/", corsMiddleware(handleTestPages()))
 

--- a/cmd/dev-console/server_routes.go
+++ b/cmd/dev-console/server_routes.go
@@ -486,8 +486,10 @@ func registerCoreRoutes(mux *http.ServeMux, server *Server, cap *capture.Capture
 		serveEmbeddedHTML(w, r, docsHTML, "docs")
 	}))
 
-	// NOT MCP — WebSocket echo server for test harness (must be registered before /tests/ subtree)
-	mux.HandleFunc("/tests/ws", handleTestHarnessWS)
+	// NOT MCP — WebSocket echo server for test harness (must be registered before /tests/ subtree).
+	// corsMiddleware sets headers on http.ResponseWriter pre-hijack; those headers are not included
+	// in the manually-written 101 response (intentional — WS upgrade bypasses HTTP CORS).
+	mux.HandleFunc("/tests/ws", corsMiddleware(handleTestHarnessWS))
 	// NOT MCP — Embedded test/demo pages for self-testing
 	mux.HandleFunc("/tests/", corsMiddleware(handleTestPages()))
 

--- a/cmd/dev-console/testpages.go
+++ b/cmd/dev-console/testpages.go
@@ -1,7 +1,7 @@
 // testpages.go — Embedded test/demo pages served at /tests/.
 // Includes a WebSocket echo server at /tests/ws and deterministic error
 // endpoints at /tests/404, /tests/500, /tests/cors-test, /tests/slow
-// for use by the local smoke-test harness (tests/pages/).
+// for use by the Gasoline smoke-test harness.
 package main
 
 import (
@@ -12,8 +12,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"path"
 	"strings"
@@ -23,6 +25,14 @@ import (
 //go:embed testpages
 var testPagesFS embed.FS
 
+// maxWSPayload caps incoming frame payloads to prevent DoS via oversized allocation.
+const maxWSPayload = 1 << 20 // 1 MiB
+
+// wsIdleTimeout is the per-read deadline, reset after every successful frame.
+// This is an idle timeout — an active connection that keeps sending frames will
+// never be cut. An idle connection is closed after this duration.
+const wsIdleTimeout = 60 * time.Second
+
 // handleTestPages serves embedded test pages at /tests/.
 // GET /tests/          → branded HTML index listing all pages.
 // GET /tests/{file}    → embedded HTML/CSS file.
@@ -31,7 +41,10 @@ var testPagesFS embed.FS
 // GET /tests/cors-test → 200 JSON, no CORS headers (CORS-block test).
 // GET /tests/slow      → 200 after 3 s delay (latency/waterfall test).
 func handleTestPages() http.HandlerFunc {
-	sub, _ := fs.Sub(testPagesFS, "testpages")
+	sub, err := fs.Sub(testPagesFS, "testpages")
+	if err != nil {
+		panic(fmt.Sprintf("testpages: embed misconfigured: %v", err))
+	}
 	fileServer := http.StripPrefix("/tests/", http.FileServerFS(sub))
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -73,6 +86,9 @@ func handleTestPages() http.HandlerFunc {
 
 // handleTestHarnessWS upgrades a GET /tests/ws request to a WebSocket echo
 // server implemented with zero external dependencies (net/http hijacking).
+// Note: CORS headers set by corsMiddleware are buffered in http.ResponseWriter
+// but are not included in the 101 handshake written directly to the hijacked
+// connection. This is intentional — WebSocket upgrade bypasses HTTP CORS.
 func handleTestHarnessWS(w http.ResponseWriter, r *http.Request) {
 	key := r.Header.Get("Sec-WebSocket-Key")
 	if key == "" || strings.ToLower(r.Header.Get("Upgrade")) != "websocket" {
@@ -109,26 +125,69 @@ func handleTestHarnessWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
 	wsEchoLoop(conn, bufrw)
 }
 
-// wsEchoLoop reads WebSocket frames and echoes text frames as JSON.
-func wsEchoLoop(conn io.ReadWriteCloser, rw *bufio.ReadWriter) {
+// wsEchoLoop reads WebSocket frames and echoes data frames.
+// Text frames are echoed as a JSON envelope; binary frames are echoed as-is.
+// The per-read deadline is refreshed after every successful frame, implementing
+// an idle timeout: active connections are never cut; idle ones time out after
+// wsIdleTimeout.
+func wsEchoLoop(conn net.Conn, rw *bufio.ReadWriter) {
+	// fragOpcode and fragBuf accumulate fragments for reassembly (RFC 6455 §5.4).
+	var fragOpcode byte
+	var fragBuf []byte
+
 	for {
-		opcode, payload, err := wsReadFrame(rw)
+		// Reset the idle deadline before each read. A connection that sends
+		// at least one frame per wsIdleTimeout period is never disconnected.
+		_ = conn.SetReadDeadline(time.Now().Add(wsIdleTimeout))
+
+		fin, opcode, payload, err := wsReadFrame(rw)
 		if err != nil {
 			return
 		}
-		switch opcode {
-		case 0x8: // Close
-			_ = wsWriteFrame(rw, 0x8, nil)
-			return
-		case 0x9: // Ping → Pong
-			if err := wsWriteFrame(rw, 0xA, payload); err != nil {
+
+		// Control frames (0x8–0xF) must not be fragmented (RFC 6455 §5.5) and
+		// are dispatched immediately regardless of any in-progress fragment sequence.
+		if opcode >= 0x8 {
+			switch opcode {
+			case 0x8: // Close — echo close frame and exit.
+				_ = wsWriteFrame(rw, 0x8, nil)
 				return
+			case 0x9: // Ping → Pong
+				if err := wsWriteFrame(rw, 0xA, payload); err != nil {
+					return
+				}
 			}
-		case 0x1: // Text → echo JSON
+			continue
+		}
+
+		// Data frame fragmentation reassembly (RFC 6455 §5.4).
+		if opcode != 0x0 {
+			// Non-zero opcode = first (or only) frame of a data message.
+			if !fin {
+				// First fragment: record opcode and begin accumulation.
+				fragOpcode = opcode
+				fragBuf = append(fragBuf[:0], payload...)
+				continue
+			}
+			// FIN=1 with non-continuation opcode = single unfragmented message.
+		} else {
+			// Continuation frame (opcode 0x0): append to accumulation buffer.
+			fragBuf = append(fragBuf, payload...)
+			if !fin {
+				continue // More fragments incoming.
+			}
+			// Final fragment — reassemble the full message.
+			opcode = fragOpcode
+			payload = fragBuf
+			fragBuf = fragBuf[:0]
+		}
+
+		// Dispatch complete (possibly reassembled) message.
+		switch opcode {
+		case 0x1: // Text → echo as JSON envelope
 			reply, _ := json.Marshal(map[string]any{
 				"type":   "echo",
 				"echo":   string(payload),
@@ -147,11 +206,14 @@ func wsEchoLoop(conn io.ReadWriteCloser, rw *bufio.ReadWriter) {
 }
 
 // wsReadFrame reads one complete WebSocket frame, handling masking.
-func wsReadFrame(r io.Reader) (opcode byte, payload []byte, err error) {
+// Returns the FIN bit, opcode, unmasked payload, and any I/O error.
+// Payloads larger than maxWSPayload are rejected to prevent DoS.
+func wsReadFrame(r io.Reader) (fin bool, opcode byte, payload []byte, err error) {
 	header := make([]byte, 2)
 	if _, err = io.ReadFull(r, header); err != nil {
 		return
 	}
+	fin = header[0]&0x80 != 0
 	opcode = header[0] & 0x0F
 	masked := header[1]&0x80 != 0
 	length := uint64(header[1] & 0x7F)
@@ -169,6 +231,11 @@ func wsReadFrame(r io.Reader) (opcode byte, payload []byte, err error) {
 			return
 		}
 		length = binary.BigEndian.Uint64(ext)
+	}
+
+	if length > maxWSPayload {
+		err = fmt.Errorf("ws: frame payload %d bytes exceeds limit %d", length, uint64(maxWSPayload))
+		return
 	}
 
 	var mask [4]byte
@@ -190,9 +257,11 @@ func wsReadFrame(r io.Reader) (opcode byte, payload []byte, err error) {
 	return
 }
 
-// wsWriteFrame writes one unmasked WebSocket frame.
+// wsWriteFrame writes one unmasked WebSocket frame (FIN=1, server→client).
+// Payload length is encoded per RFC 6455 §5.2, including the full 8-byte
+// big-endian form for payloads ≥ 65536 bytes.
 func wsWriteFrame(w *bufio.ReadWriter, opcode byte, payload []byte) error {
-	length := len(payload)
+	length := uint64(len(payload))
 	header := []byte{0x80 | opcode}
 	switch {
 	case length < 126:
@@ -201,8 +270,9 @@ func wsWriteFrame(w *bufio.ReadWriter, opcode byte, payload []byte) error {
 		header = append(header, 126,
 			byte(length>>8), byte(length))
 	default:
+		// Full 8-byte big-endian uint64 per RFC 6455 §5.2.
 		header = append(header, 127,
-			0, 0, 0, 0,
+			byte(length>>56), byte(length>>48), byte(length>>40), byte(length>>32),
 			byte(length>>24), byte(length>>16), byte(length>>8), byte(length))
 	}
 	if _, err := w.Write(append(header, payload...)); err != nil {
@@ -220,6 +290,8 @@ func wsAcceptKey(key string) string {
 }
 
 // serveTestIndex generates a branded HTML index of available test pages.
+// File names and labels are HTML-escaped to prevent injection from any
+// unexpected entries in the embedded filesystem.
 func serveTestIndex(w http.ResponseWriter) {
 	entries, err := fs.ReadDir(testPagesFS, "testpages")
 	if err != nil {
@@ -233,8 +305,9 @@ func serveTestIndex(w http.ResponseWriter) {
 		if e.IsDir() || !strings.HasSuffix(name, ".html") {
 			continue
 		}
-		label := strings.TrimSuffix(name, path.Ext(name))
-		links = append(links, fmt.Sprintf(`<li><a href="/tests/%s">%s</a></li>`, name, label))
+		safeName := html.EscapeString(name)
+		safeLabel := html.EscapeString(strings.TrimSuffix(name, path.Ext(name)))
+		links = append(links, fmt.Sprintf(`<li><a href="/tests/%s">%s</a></li>`, safeName, safeLabel))
 	}
 
 	body := fmt.Sprintf(`<!DOCTYPE html>

--- a/cmd/dev-console/testpages.go
+++ b/cmd/dev-console/testpages.go
@@ -1,21 +1,35 @@
 // testpages.go — Embedded test/demo pages served at /tests/.
+// Includes a WebSocket echo server at /tests/ws and deterministic error
+// endpoints at /tests/404, /tests/500, /tests/cors-test, /tests/slow
+// for use by the local smoke-test harness (tests/pages/).
 package main
 
 import (
+	"bufio"
+	"crypto/sha1"
 	"embed"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"path"
 	"strings"
+	"time"
 )
 
 //go:embed testpages
 var testPagesFS embed.FS
 
 // handleTestPages serves embedded test pages at /tests/.
-// GET /tests/ returns an HTML index listing available pages.
-// GET /tests/{filename} serves the embedded file.
+// GET /tests/          → branded HTML index listing all pages.
+// GET /tests/{file}    → embedded HTML/CSS file.
+// GET /tests/404       → 404 response (network error test).
+// GET /tests/500       → 500 response (network error test).
+// GET /tests/cors-test → 200 JSON, no CORS headers (CORS-block test).
+// GET /tests/slow      → 200 after 3 s delay (latency/waterfall test).
 func handleTestPages() http.HandlerFunc {
 	sub, _ := fs.Sub(testPagesFS, "testpages")
 	fileServer := http.StripPrefix("/tests/", http.FileServerFS(sub))
@@ -29,16 +43,183 @@ func handleTestPages() http.HandlerFunc {
 		trimmed := strings.TrimPrefix(r.URL.Path, "/tests")
 		trimmed = strings.TrimPrefix(trimmed, "/")
 
-		if trimmed == "" {
+		switch trimmed {
+		case "":
 			serveTestIndex(w)
-			return
+		case "404":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprintln(w, `{"error":"not_found","endpoint":"/tests/404","test":"network_error"}`)
+		case "500":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprintln(w, `{"error":"internal_server_error","endpoint":"/tests/500","test":"network_error"}`)
+		case "cors-test":
+			// Intentionally omit CORS headers — browser blocks cross-origin fetch.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintln(w, `{"cors":"no_headers","test":"cors_block"}`)
+		case "slow":
+			time.Sleep(3 * time.Second)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintln(w, `{"delayed":true,"delay_ms":3000,"test":"slow_response"}`)
+		default:
+			fileServer.ServeHTTP(w, r)
 		}
-
-		fileServer.ServeHTTP(w, r)
 	}
 }
 
-// serveTestIndex generates an HTML index of available test pages.
+// handleTestHarnessWS upgrades a GET /tests/ws request to a WebSocket echo
+// server implemented with zero external dependencies (net/http hijacking).
+func handleTestHarnessWS(w http.ResponseWriter, r *http.Request) {
+	key := r.Header.Get("Sec-WebSocket-Key")
+	if key == "" || strings.ToLower(r.Header.Get("Upgrade")) != "websocket" {
+		http.Error(w, "websocket upgrade required", http.StatusBadRequest)
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "server does not support hijacking", http.StatusInternalServerError)
+		return
+	}
+
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer conn.Close()
+
+	// Send the 101 handshake.
+	accept := wsAcceptKey(key)
+	handshake := fmt.Sprintf(
+		"HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Accept: %s\r\n\r\n",
+		accept,
+	)
+	if _, err := bufrw.WriteString(handshake); err != nil {
+		return
+	}
+	if err := bufrw.Flush(); err != nil {
+		return
+	}
+
+	_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
+	wsEchoLoop(conn, bufrw)
+}
+
+// wsEchoLoop reads WebSocket frames and echoes text frames as JSON.
+func wsEchoLoop(conn io.ReadWriteCloser, rw *bufio.ReadWriter) {
+	for {
+		opcode, payload, err := wsReadFrame(rw)
+		if err != nil {
+			return
+		}
+		switch opcode {
+		case 0x8: // Close
+			_ = wsWriteFrame(rw, 0x8, nil)
+			return
+		case 0x9: // Ping → Pong
+			if err := wsWriteFrame(rw, 0xA, payload); err != nil {
+				return
+			}
+		case 0x1: // Text → echo JSON
+			reply, _ := json.Marshal(map[string]any{
+				"type":   "echo",
+				"echo":   string(payload),
+				"server": "gasoline-test-harness",
+				"ts":     time.Now().UnixMilli(),
+			})
+			if err := wsWriteFrame(rw, 0x1, reply); err != nil {
+				return
+			}
+		case 0x2: // Binary → echo binary
+			if err := wsWriteFrame(rw, 0x2, payload); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// wsReadFrame reads one complete WebSocket frame, handling masking.
+func wsReadFrame(r io.Reader) (opcode byte, payload []byte, err error) {
+	header := make([]byte, 2)
+	if _, err = io.ReadFull(r, header); err != nil {
+		return
+	}
+	opcode = header[0] & 0x0F
+	masked := header[1]&0x80 != 0
+	length := uint64(header[1] & 0x7F)
+
+	switch length {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err = io.ReadFull(r, ext); err != nil {
+			return
+		}
+		length = uint64(binary.BigEndian.Uint16(ext))
+	case 127:
+		ext := make([]byte, 8)
+		if _, err = io.ReadFull(r, ext); err != nil {
+			return
+		}
+		length = binary.BigEndian.Uint64(ext)
+	}
+
+	var mask [4]byte
+	if masked {
+		if _, err = io.ReadFull(r, mask[:]); err != nil {
+			return
+		}
+	}
+
+	payload = make([]byte, length)
+	if _, err = io.ReadFull(r, payload); err != nil {
+		return
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return
+}
+
+// wsWriteFrame writes one unmasked WebSocket frame.
+func wsWriteFrame(w *bufio.ReadWriter, opcode byte, payload []byte) error {
+	length := len(payload)
+	header := []byte{0x80 | opcode}
+	switch {
+	case length < 126:
+		header = append(header, byte(length))
+	case length < 65536:
+		header = append(header, 126,
+			byte(length>>8), byte(length))
+	default:
+		header = append(header, 127,
+			0, 0, 0, 0,
+			byte(length>>24), byte(length>>16), byte(length>>8), byte(length))
+	}
+	if _, err := w.Write(append(header, payload...)); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// wsAcceptKey computes the Sec-WebSocket-Accept value per RFC 6455.
+func wsAcceptKey(key string) string {
+	const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+	h := sha1.New()
+	h.Write([]byte(key + guid))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// serveTestIndex generates a branded HTML index of available test pages.
 func serveTestIndex(w http.ResponseWriter) {
 	entries, err := fs.ReadDir(testPagesFS, "testpages")
 	if err != nil {
@@ -46,25 +227,46 @@ func serveTestIndex(w http.ResponseWriter) {
 		return
 	}
 
-	var b strings.Builder
-	b.WriteString("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">")
-	b.WriteString("<title>Test Pages</title>")
-	b.WriteString("<style>body{font-family:system-ui,sans-serif;padding:40px;max-width:600px;margin:0 auto}")
-	b.WriteString("a{display:block;padding:8px 0;font-size:16px}</style></head><body>")
-	b.WriteString("<h1>Test Pages</h1><ul>")
-
+	var links []string
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".html") {
 			continue
 		}
 		label := strings.TrimSuffix(name, path.Ext(name))
-		b.WriteString(fmt.Sprintf("<li><a href=\"/tests/%s\">%s</a></li>", name, label))
+		links = append(links, fmt.Sprintf(`<li><a href="/tests/%s">%s</a></li>`, name, label))
 	}
 
-	b.WriteString("</ul></body></html>")
+	body := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Gasoline Test Pages</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+     background:#1a1a1a;color:#e0e0e0;padding:40px;max-width:600px;margin:0 auto}
+h1{font-size:20px;color:#fff;margin-bottom:4px}
+p{font-size:13px;color:#888;margin-bottom:24px}
+ul{list-style:none;padding:0}
+li{margin:6px 0}
+a{color:#58a6ff;text-decoration:none;font-size:14px}
+a:hover{text-decoration:underline}
+.ep{font-family:monospace;font-size:12px;color:#888;margin-top:20px;padding-top:16px;border-top:1px solid #333}
+.ep a{color:#d29922}
+</style></head>
+<body>
+<h1>🔥 Gasoline — Test Harness</h1>
+<p>Deterministic smoke-test pages served by the Gasoline Go daemon.</p>
+<ul>%s</ul>
+<div class="ep">
+  <div>Test endpoints:</div>
+  <div><a href="/tests/404">/tests/404</a> — 404 Not Found</div>
+  <div><a href="/tests/500">/tests/500</a> — 500 Server Error</div>
+  <div><a href="/tests/cors-test">/tests/cors-test</a> — no CORS headers</div>
+  <div><a href="/tests/slow">/tests/slow</a> — 3 s delay</div>
+  <div>ws://{host}/tests/ws — WebSocket echo</div>
+</div>
+</body></html>`, strings.Join(links, "\n"))
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(b.String()))
+	_, _ = fmt.Fprint(w, body)
 }

--- a/cmd/dev-console/testpages/a11y.html
+++ b/cmd/dev-console/testpages/a11y.html
@@ -11,8 +11,10 @@
     /* ── Deliberate WCAG violations ── */
 
     /* Violation: insufficient contrast (fails AA 4.5:1) */
-    .v-contrast-fail-1 { color: #aaaaaa; background: #252525; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
-    .v-contrast-fail-2 { color: #999999; background: #ffffff; padding: 10px 12px; border-radius: 4px; font-size: 13px; color: #aaaaaa; margin-bottom: 6px; }
+    /* #777777 on #252525 → ratio ≈ 3.5:1 — fails WCAG 1.4.3 AA (requires 4.5:1) */
+    .v-contrast-fail-1 { color: #777777; background: #252525; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
+    /* #aaaaaa on #ffffff → ratio ≈ 2.3:1 — fails WCAG 1.4.3 AA */
+    .v-contrast-fail-2 { color: #aaaaaa; background: #ffffff; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
     .v-contrast-fail-3 { color: #888888; background: #707070; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
 
     /* Violation: tiny font (below 14px) */
@@ -38,7 +40,7 @@
     }
   </style>
 </head>
-<!-- Violation: <body> inside <html> without <head> lang (lang already set, but aria-hidden missing) -->
+<!-- NOTE: No aria-label on <body>, and page intentionally lacks <main> landmark (see §D). -->
 <body>
 
 <!-- NOTE: No <header> landmark — intentional WCAG violation (missing banner role) -->
@@ -95,9 +97,9 @@
       <h2>Color Contrast Failures <span class="violation-badge">WCAG 1.4.3</span></h2>
     </div>
     <div class="gh-section-body">
-      <!-- Violation: #aaa on #252525 — ratio ≈ 2.9:1 (fails AA 4.5:1) -->
+      <!-- Violation: #777777 on #252525 — ratio ≈ 3.5:1 (fails AA 4.5:1) -->
       <div class="v-contrast-fail-1">
-        This text is #aaaaaa on #252525 — contrast ratio ≈ 2.9:1. Fails WCAG 1.4.3 (AA requires 4.5:1).
+        This text is #777777 on #252525 — contrast ratio ≈ 3.5:1. Fails WCAG 1.4.3 (AA requires 4.5:1).
       </div>
       <!-- Violation: #aaa on #ffffff — ratio ≈ 2.3:1 -->
       <div style="background:#ffffff;padding:10px 12px;border-radius:4px;margin-bottom:6px;">

--- a/cmd/dev-console/testpages/a11y.html
+++ b/cmd/dev-console/testpages/a11y.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<!-- a11y.html — Deliberate WCAG violations for SARIF generation testing.
+     WARNING: This page is intentionally inaccessible. Do not use as a template. -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accessibility Disaster — Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+  <style>
+    /* ── Deliberate WCAG violations ── */
+
+    /* Violation: insufficient contrast (fails AA 4.5:1) */
+    .v-contrast-fail-1 { color: #aaaaaa; background: #252525; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
+    .v-contrast-fail-2 { color: #999999; background: #ffffff; padding: 10px 12px; border-radius: 4px; font-size: 13px; color: #aaaaaa; margin-bottom: 6px; }
+    .v-contrast-fail-3 { color: #888888; background: #707070; padding: 10px 12px; border-radius: 4px; font-size: 13px; margin-bottom: 6px; }
+
+    /* Violation: tiny font (below 14px) */
+    .v-tiny-text { font-size: 9px; color: #888; margin-bottom: 6px; }
+
+    /* Violation: no focus styles */
+    .v-no-focus { outline: none !important; }
+    .v-no-focus:focus { outline: none !important; box-shadow: none !important; }
+
+    /* Violation: positive tabindex */
+    /* (applied via HTML attribute) */
+
+    .violation-badge {
+      display: inline-block;
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      background: rgba(248, 81, 73, 0.15);
+      color: #f85149;
+      border: 1px solid rgba(248, 81, 73, 0.3);
+      font-family: monospace;
+      margin-left: 6px;
+    }
+  </style>
+</head>
+<!-- Violation: <body> inside <html> without <head> lang (lang already set, but aria-hidden missing) -->
+<body>
+
+<!-- NOTE: No <header> landmark — intentional WCAG violation (missing banner role) -->
+<div style="background:var(--bg-section);border-bottom:1px solid var(--border);padding:10px 20px;display:flex;align-items:center;gap:10px;">
+  <a href="index.html" style="display:flex;align-items:center;gap:8px;text-decoration:none;">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span style="font-size:15px;font-weight:700;color:#ffffff;">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-red">A11y Disaster</span>
+  <div style="display:flex;gap:2px;margin-left:auto;">
+    <a href="index.html" style="color:#888;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;">Hub</a>
+    <a href="interact.html" style="color:#888;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;">Interact</a>
+    <a href="telemetry.html" style="color:#888;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;">Telemetry</a>
+    <a href="performance.html" style="color:#888;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;">Performance</a>
+    <a href="a11y.html" style="color:#ffffff;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;background:var(--bg-card);">A11y</a>
+    <a href="recording.html" style="color:#888;text-decoration:none;font-size:12px;padding:4px 9px;border-radius:6px;">Recording</a>
+  </div>
+</div>
+
+<!-- Violation: No <main> landmark — entire page content is outside a main landmark -->
+
+<!-- Violation: Heading hierarchy — starts at h1, jumps to h4 -->
+<h1 style="padding:20px 20px 0;font-size:20px;font-weight:700;color:#fff;">
+  ♿ Accessibility Disaster
+  <span class="violation-badge">WCAG violations below</span>
+</h1>
+<h4 style="padding:4px 20px 16px;color:#888;font-size:13px;font-weight:400;">
+  Every section on this page contains deliberate WCAG violations.
+  Use <code style="color:#58a6ff;">analyze(accessibility)</code> and
+  <code style="color:#58a6ff;">generate(sarif)</code> to audit.
+</h4>
+
+<div style="max-width:960px;margin:0 auto;padding:0 20px 80px;">
+
+  <!-- ── §A: Color Contrast Violations ────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Color Contrast Failures <span class="violation-badge">WCAG 1.4.3</span></h2>
+    </div>
+    <div class="gh-section-body">
+      <!-- Violation: #aaa on #252525 — ratio ≈ 2.9:1 (fails AA 4.5:1) -->
+      <div class="v-contrast-fail-1">
+        This text is #aaaaaa on #252525 — contrast ratio ≈ 2.9:1. Fails WCAG 1.4.3 (AA requires 4.5:1).
+      </div>
+      <!-- Violation: #aaa on #ffffff — ratio ≈ 2.3:1 -->
+      <div style="background:#ffffff;padding:10px 12px;border-radius:4px;margin-bottom:6px;">
+        <span style="color:#aaaaaa;font-size:13px;">
+          This text is #aaaaaa on white — contrast ratio ≈ 2.3:1. Fails WCAG 1.4.3.
+        </span>
+      </div>
+      <!-- Violation: near-identical fg/bg -->
+      <div class="v-contrast-fail-3">
+        This text is #888888 on #707070 — ratio ≈ 1.3:1. Catastrophic contrast failure.
+      </div>
+      <!-- Violation: tiny text (below minimum size) -->
+      <div class="v-tiny-text">
+        This text is 9px — below the minimum recommended 14px for body text and 18px for headings.
+        At this size, contrast requirements are even stricter and this still fails.
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §B: Missing ARIA / Labels on Buttons ─────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Missing ARIA Labels <span class="violation-badge">WCAG 4.1.2</span></h2>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Buttons and interactive controls without accessible names — screen readers
+        cannot announce their purpose.
+      </p>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px;">
+        <!-- Violation: button with no text, no aria-label, no aria-labelledby -->
+        <button type="button" style="width:40px;height:40px;background:var(--red);border:none;border-radius:6px;cursor:pointer;"></button>
+        <!-- Violation: button with icon only, no accessible name -->
+        <button type="button" style="width:40px;height:40px;background:var(--bg-card);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:20px;">✕</button>
+        <!-- Violation: icon button, tooltip only via title attribute (not sufficient) -->
+        <button type="button" title="Delete item" style="width:40px;height:40px;background:var(--amber-bg);border:1px solid rgba(210,153,34,0.3);border-radius:6px;cursor:pointer;font-size:18px;">🗑</button>
+        <!-- Violation: div acting as button without role -->
+        <div onclick="void(0)" style="width:40px;height:40px;background:var(--bg-card);border:1px solid var(--border);border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;">⚙</div>
+        <!-- Violation: link with no text -->
+        <a href="#void" style="width:40px;height:40px;background:var(--blue-bg);border:1px solid rgba(88,166,255,0.3);border-radius:6px;display:inline-flex;align-items:center;justify-content:center;font-size:18px;">→</a>
+      </div>
+      <!-- Violation: input with placeholder only (no label, no aria-label) -->
+      <input type="text" placeholder="Search..." style="background:var(--bg-input);border:1px solid var(--border-bright);border-radius:6px;color:var(--text);font-size:13px;padding:7px 10px;width:100%;outline:none;margin-bottom:8px;">
+      <!-- Violation: button inside form with generic text -->
+      <button type="button" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 14px;border-radius:6px;cursor:pointer;">Click</button>
+    </div>
+  </div>
+
+  <!-- ── §C: Form Label Violations ────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <!-- Violation: heading level skipped (h3 inside h2-level section, but using h5) -->
+      <h5 style="font-size:13px;font-weight:600;color:var(--text-bright);">
+        Broken Form Labels <span class="violation-badge">WCAG 1.3.1 / 3.3.2</span>
+      </h5>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Labels that are not programmatically associated with their inputs.
+        Screen readers cannot announce which label belongs to which field.
+      </p>
+
+      <!-- Violation: label references a non-existent for= target -->
+      <div style="margin-bottom:10px;">
+        <label for="nonexistent-id" style="display:block;font-size:12px;color:var(--text-dim);margin-bottom:4px;">
+          Full Name (label points to wrong ID)
+        </label>
+        <input type="text" id="bad-input-name" style="background:var(--bg-input);border:1px solid var(--border-bright);border-radius:6px;color:var(--text);font-size:13px;padding:7px 10px;width:100%;outline:none;">
+      </div>
+
+      <!-- Violation: label is a sibling, not wrapping or using for= -->
+      <div style="margin-bottom:10px;">
+        <span style="font-size:12px;color:var(--text-dim);display:block;margin-bottom:4px;">Email Address (span, not label)</span>
+        <input type="email" id="bad-input-email" style="background:var(--bg-input);border:1px solid var(--border-bright);border-radius:6px;color:var(--text);font-size:13px;padding:7px 10px;width:100%;outline:none;">
+      </div>
+
+      <!-- Violation: required field without required attribute or indication -->
+      <div style="margin-bottom:10px;">
+        <label style="display:block;font-size:12px;color:var(--text-dim);margin-bottom:4px;">Password</label>
+        <input type="password" style="background:var(--bg-input);border:1px solid var(--border-bright);border-radius:6px;color:var(--text);font-size:13px;padding:7px 10px;width:100%;outline:none;">
+        <!-- required but attribute missing -->
+      </div>
+
+      <!-- Violation: select without label -->
+      <select style="background:var(--bg-input);border:1px solid var(--border-bright);border-radius:6px;color:var(--text);font-size:13px;padding:7px 10px;width:100%;outline:none;margin-bottom:10px;">
+        <option>-- Select role --</option>
+        <option>Admin</option>
+        <option>User</option>
+      </select>
+
+      <!-- Violation: no error association -->
+      <div style="color:var(--red);font-size:12px;margin-bottom:6px;" role="alert">
+        Error: This field is required. (not linked to input via aria-describedby)
+      </div>
+
+      <!-- Violation: submit button missing from form context -->
+      <button type="button" class="v-no-focus" style="background:var(--blue);color:#fff;padding:7px 14px;border-radius:6px;border:none;cursor:pointer;font-size:13px;">
+        Submit
+      </button>
+    </div>
+  </div>
+
+  <!-- ── §D: Structure / Landmark Violations ──────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Broken Structure <span class="violation-badge">WCAG 1.3.1 / 2.4.6</span></h2>
+    </div>
+    <div class="gh-section-body">
+      <!-- Violation: heading order h2 → h6 (skip h3,h4,h5 then jump) -->
+      <h6 style="color:var(--text);font-size:14px;margin-bottom:8px;">
+        Heading Level 6 — after H2 above (skipped H3, H4, H5)
+      </h6>
+      <h3 style="color:var(--text);font-size:16px;margin-bottom:8px;">
+        Back to Heading 3 — out of order
+      </h3>
+
+      <!-- Violation: table without caption or summary -->
+      <table style="width:100%;border-collapse:collapse;margin-bottom:12px;" cellpadding="6">
+        <tr style="border-bottom:1px solid var(--border);">
+          <td style="color:var(--text-dim);font-size:12px;">Row 1, Col A</td>
+          <td style="color:var(--text-dim);font-size:12px;">Row 1, Col B</td>
+          <!-- Violation: no <th> elements, no scope, no caption -->
+        </tr>
+        <tr>
+          <td style="color:var(--text-dim);font-size:12px;">Row 2, Col A</td>
+          <td style="color:var(--text-dim);font-size:12px;">Row 2, Col B</td>
+        </tr>
+      </table>
+
+      <!-- Violation: positive tabindex (disrupts natural tab order) -->
+      <div style="display:flex;gap:8px;flex-wrap:wrap;">
+        <button type="button" tabindex="5" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;">tabindex=5</button>
+        <button type="button" tabindex="1" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;">tabindex=1</button>
+        <button type="button" tabindex="3" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;">tabindex=3</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §E: Images Without Alt ───────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Images Without Alt <span class="violation-badge">WCAG 1.1.1</span></h2>
+    </div>
+    <div class="gh-section-body">
+      <div style="display:flex;gap:12px;flex-wrap:wrap;">
+        <!-- Violation: no alt attribute -->
+        <div style="background:linear-gradient(135deg,#f97316,#fbbf24);width:80px;height:80px;border-radius:6px;display:flex;align-items:center;justify-content:center;">
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='18' fill='%231a1a1a'/%3E%3C/svg%3E" width="40" height="40">
+        </div>
+        <!-- Violation: alt="" on a meaningful image (decorative exemption misused) -->
+        <div style="background:linear-gradient(135deg,#58a6ff,#a371f7);width:80px;height:80px;border-radius:6px;display:flex;align-items:center;justify-content:center;">
+          <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%231a1a1a' rx='4'/%3E%3C/svg%3E" alt="" width="40" height="40">
+        </div>
+        <!-- Violation: filename as alt text (unhelpful) -->
+        <div style="background:linear-gradient(135deg,#f85149,#d29922);width:80px;height:80px;border-radius:6px;display:flex;align-items:center;justify-content:center;">
+          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="icon-128.png" width="40" height="40">
+        </div>
+      </div>
+      <!-- Violation: CSS background image conveying information (no text alternative) -->
+      <div style="margin-top:12px;background:linear-gradient(90deg,#f97316,#fbbf24);height:40px;border-radius:6px;"></div>
+      <p class="v-tiny-text" style="margin-top:4px;">
+        The gradient above conveys "Gasoline brand" but has no text alternative.
+      </p>
+    </div>
+  </div>
+
+  <!-- ── §F: ARIA Misuse ───────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>ARIA Misuse <span class="violation-badge">WCAG 4.1.2</span></h2>
+    </div>
+    <div class="gh-section-body">
+      <!-- Violation: aria-hidden on focusable element -->
+      <button type="button" aria-hidden="true" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;margin-bottom:8px;">
+        aria-hidden but focusable
+      </button>
+      <!-- Violation: role conflict -->
+      <div role="button" role="link" style="display:inline-block;background:var(--blue-bg);border:1px solid rgba(88,166,255,0.3);color:var(--blue);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;margin-bottom:8px;">
+        role="button" AND role="link" (duplicate role attribute)
+      </div>
+      <!-- Violation: aria-expanded without a controlled region -->
+      <button type="button" aria-expanded="true" style="background:var(--bg-card);border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:6px;cursor:pointer;font-size:13px;">
+        aria-expanded="true" (no controlled panel)
+      </button>
+    </div>
+  </div>
+
+</div><!-- end no-landmark wrapper -->
+
+<script>
+// Emit a11y test marker to console for observe(logs) verification
+console.log('A11Y_DISASTER_PAGE_LOADED — ' + document.querySelectorAll('[role]').length + ' ARIA roles present');
+console.warn('A11Y_VIOLATIONS_ACTIVE — run analyze(accessibility) to audit');
+</script>
+
+</body>
+</html>

--- a/cmd/dev-console/testpages/gasoline.css
+++ b/cmd/dev-console/testpages/gasoline.css
@@ -1,0 +1,442 @@
+/* gasoline.css — Gasoline Test Harness Design System */
+
+/* ─── Reset & Base ─────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:            #1a1a1a;
+  --bg-section:    #252525;
+  --bg-card:       #2a2a2a;
+  --bg-input:      #1e1e1e;
+  --text:          #e0e0e0;
+  --text-dim:      #888;
+  --text-bright:   #ffffff;
+  --border:        #333;
+  --border-bright: #444;
+  --green:         #3fb950;
+  --green-bg:      rgba(63, 185, 80, 0.12);
+  --red:           #f85149;
+  --red-bg:        rgba(248, 81, 73, 0.12);
+  --blue:          #58a6ff;
+  --blue-bg:       rgba(88, 166, 255, 0.12);
+  --amber:         #d29922;
+  --amber-bg:      rgba(210, 153, 34, 0.12);
+  --purple:        #a371f7;
+  --purple-bg:     rgba(163, 113, 247, 0.12);
+  --flame-base:    #f97316;
+  --flame-mid:     #fb923c;
+  --flame-tip:     #fbbf24;
+  --flame-inner:   #fef3c7;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+/* ─── Header ────────────────────────────────────────── */
+.gh-header {
+  background: var(--bg-section);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.gh-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.gh-wordmark {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-bright);
+  letter-spacing: -0.3px;
+}
+
+.gh-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+}
+
+.gh-badge-harness { background: var(--blue-bg);   color: var(--blue);   border: 1px solid rgba(88,166,255,0.3); }
+.gh-badge-green   { background: var(--green-bg);  color: var(--green);  border: 1px solid rgba(63,185,80,0.3);  }
+.gh-badge-red     { background: var(--red-bg);    color: var(--red);    border: 1px solid rgba(248,81,73,0.3);  }
+.gh-badge-amber   { background: var(--amber-bg);  color: var(--amber);  border: 1px solid rgba(210,153,34,0.3); }
+.gh-badge-purple  { background: var(--purple-bg); color: var(--purple); border: 1px solid rgba(163,113,247,0.3);}
+
+.gh-nav {
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.gh-nav a {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 12px;
+  padding: 4px 9px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.gh-nav a:hover  { background: var(--border); color: var(--text); }
+.gh-nav a.active { background: var(--bg-card); color: var(--text-bright); }
+
+/* ─── Layout ────────────────────────────────────────── */
+.gh-main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 20px 80px;
+}
+
+.gh-hero {
+  padding: 28px 0 22px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+}
+
+.gh-hero h1 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-bright);
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.gh-hero p {
+  color: var(--text-dim);
+  font-size: 13px;
+  max-width: 640px;
+  line-height: 1.6;
+}
+
+/* ─── Section / Card ────────────────────────────────── */
+.gh-section {
+  background: var(--bg-section);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.gh-section-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gh-section-header h2 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.gh-section-header .section-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-left: auto;
+  font-family: monospace;
+}
+
+.gh-section-body { padding: 16px; }
+
+/* ─── Form Elements ─────────────────────────────────── */
+input[type=text],
+input[type=email],
+input[type=password],
+input[type=number],
+select,
+textarea {
+  background: var(--bg-input);
+  border: 1px solid var(--border-bright);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  padding: 7px 10px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  font-family: inherit;
+}
+
+input:focus, select:focus, textarea:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(88,166,255,0.15);
+}
+
+select option { background: var(--bg-section); }
+
+label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+
+.gh-form-row   { margin-bottom: 12px; }
+
+.gh-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.gh-form-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gh-form-inline label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 0;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 13px;
+}
+
+input[type=checkbox] {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--green);
+  flex-shrink: 0;
+}
+
+/* ─── Buttons ───────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+  font-family: inherit;
+  white-space: nowrap;
+}
+.btn:active   { transform: scale(0.97); }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.btn-primary { background: var(--blue);               color: #fff; }
+.btn-green   { background: var(--green);              color: #000; }
+.btn-red     { background: var(--red);                color: #fff; }
+.btn-amber   { background: var(--amber);              color: #000; }
+.btn-ghost   { background: var(--bg-card);            color: var(--text);  border: 1px solid var(--border-bright); }
+.btn-danger  { background: var(--red-bg);             color: var(--red);   border: 1px solid rgba(248,81,73,0.3); }
+.btn-purple  { background: var(--purple-bg);          color: var(--purple);border: 1px solid rgba(163,113,247,0.3);}
+.btn-sm      { padding: 4px 10px; font-size: 12px; }
+
+.btn-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
+
+/* ─── Status / Log Output ───────────────────────────── */
+.gh-status {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+  min-height: 36px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin-top: 8px;
+}
+.gh-status.ok   { border-color: rgba(63,185,80,0.4);  color: var(--green); }
+.gh-status.err  { border-color: rgba(248,81,73,0.4);  color: var(--red); }
+.gh-status.info { border-color: rgba(88,166,255,0.4); color: var(--blue); }
+
+.gh-log {
+  background: #0d0d0d;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: 'SF Mono', 'Fira Code', ui-monospace, monospace;
+  font-size: 11px;
+  height: 180px;
+  overflow-y: auto;
+  margin-top: 8px;
+}
+.log-line        { margin: 1px 0; }
+.log-line.log    { color: #7ee787; }
+.log-line.warn   { color: var(--amber); }
+.log-line.error  { color: var(--red); }
+.log-line.info   { color: var(--blue); }
+.log-line.ws     { color: var(--purple); }
+.log-line.system { color: var(--text-dim); }
+
+/* ─── Tags / Badges ─────────────────────────────────── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-family: monospace;
+}
+.tag-id     { background: var(--purple-bg); color: var(--purple); }
+.tag-dom    { background: var(--blue-bg);   color: var(--blue); }
+.tag-error  { background: var(--red-bg);    color: var(--red); }
+.tag-ok     { background: var(--green-bg);  color: var(--green); }
+.tag-warn   { background: var(--amber-bg);  color: var(--amber); }
+
+/* ─── Indicator Dot ─────────────────────────────────── */
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.dot-green  { background: var(--green); box-shadow: 0 0 5px var(--green); }
+.dot-red    { background: var(--red); }
+.dot-amber  { background: var(--amber); animation: pulse 1.2s ease-in-out infinite; }
+.dot-dim    { background: var(--text-dim); }
+
+/* ─── Index Page ────────────────────────────────────── */
+.gh-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.gh-card {
+  background: var(--bg-section);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px;
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+  display: block;
+}
+.gh-card:hover { border-color: var(--border-bright); background: var(--bg-card); }
+
+.gh-card-icon  { font-size: 26px; margin-bottom: 10px; }
+.gh-card-title { font-size: 14px; font-weight: 600; color: var(--text-bright); margin-bottom: 5px; }
+.gh-card-desc  { font-size: 12px; color: var(--text-dim); margin-bottom: 10px; line-height: 1.6; }
+.gh-card-tags  { display: flex; flex-wrap: wrap; gap: 4px; }
+
+/* ─── Special Elements ──────────────────────────────── */
+.flame-text {
+  background: linear-gradient(90deg, var(--flame-base), var(--flame-mid), var(--flame-tip));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.overlay-trap {
+  position: relative;
+  display: inline-block;
+}
+.overlay-trap .honeypot {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  opacity: 0;
+  cursor: default;
+  pointer-events: none; /* disabled by default — enable via JS to test */
+}
+
+.gh-modal-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  z-index: 9998;
+  align-items: center;
+  justify-content: center;
+}
+.gh-modal-backdrop.open { display: flex; }
+.gh-modal {
+  background: var(--bg-section);
+  border: 1px solid var(--border-bright);
+  border-radius: 10px;
+  padding: 24px;
+  max-width: 400px;
+  width: 90%;
+  z-index: 9999;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.6);
+}
+
+/* ─── Performance Page ──────────────────────────────── */
+.cls-box {
+  background: linear-gradient(135deg, var(--blue-bg), var(--purple-bg));
+  border: 1px solid rgba(88,166,255,0.3);
+  border-radius: 6px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--blue);
+  font-size: 12px;
+  transition: height 0.3s ease;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.lcp-hero {
+  width: 100%;
+  height: 200px;
+  background: var(--bg-card);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  font-size: 12px;
+  border: 1px dashed var(--border-bright);
+}
+
+/* ─── A11y Page (deliberate violations inline) ──────── */
+.a11y-contrast-fail {
+  color: #aaaaaa;       /* fails on #252525 bg */
+  background: #2d2d2d;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.a11y-contrast-bad {
+  color: #888;          /* fails WCAG AA */
+  background: #707070;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+/* ─── Animations ────────────────────────────────────── */
+@keyframes pulse  { 0%,100% { opacity:1; } 50% { opacity:0.3; } }
+@keyframes glow   { 0%,100% { box-shadow:0 0 5px var(--red); } 50% { box-shadow:0 0 15px var(--red); } }
+@keyframes shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position:  200% 0; }
+}

--- a/cmd/dev-console/testpages/gasoline.css
+++ b/cmd/dev-console/testpages/gasoline.css
@@ -399,7 +399,7 @@ input[type=checkbox] {
   justify-content: center;
   color: var(--blue);
   font-size: 12px;
-  transition: height 0.3s ease;
+  transition: none; /* No transition — sudden shift must be unanimated to register as CLS */
   margin-bottom: 8px;
   overflow: hidden;
 }

--- a/cmd/dev-console/testpages/index.html
+++ b/cmd/dev-console/testpages/index.html
@@ -104,7 +104,7 @@
       <div class="gh-card-desc">
         Auto-fires 100+ console messages, fetch()es /404 /500 and a CORS-blocked URL,
         opens a WebSocket to the local echo server, and offers one-click error bombs
-        for error cluster testing. Tests 2.x, 4.x.
+        for error cluster testing. Tests 2.x.
       </div>
       <div class="gh-card-tags">
         <span class="tag tag-error">console.error</span>
@@ -196,7 +196,7 @@
     };
     ws.onerror = () => {
       dot.className    = 'dot dot-red';
-      status.textContent = 'WebSocket error — is server.py running?';
+      status.textContent = 'WebSocket error — is the Gasoline daemon running?';
       status.style.color = 'var(--red)';
     };
   }
@@ -204,6 +204,11 @@
 
   // Keep server URL in sync
   document.getElementById('server-url').textContent = window.location.origin;
+
+  // Close the WebSocket cleanly on navigation.
+  window.addEventListener('pagehide', function() {
+    if (ws && ws.readyState === WebSocket.OPEN) { ws.close(1000, 'page unload'); }
+  });
 })();
 </script>
 

--- a/cmd/dev-console/testpages/index.html
+++ b/cmd/dev-console/testpages/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+</head>
+<body>
+
+<header class="gh-header">
+  <a href="index.html" class="gh-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span class="gh-wordmark">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-harness">Test Harness</span>
+  <nav class="gh-nav">
+    <a href="interact.html">Interact</a>
+    <a href="telemetry.html">Telemetry</a>
+    <a href="performance.html">Performance</a>
+    <a href="a11y.html">A11y</a>
+    <a href="recording.html">Recording</a>
+  </nav>
+</header>
+
+<main class="gh-main">
+  <div class="gh-hero">
+    <h1>
+      <span class="flame-text">Smoke Test V2</span>
+      — Deterministic Test Harness
+    </h1>
+    <p>
+      Self-hosted test pages for the Gasoline MCP suite. Every page is purpose-built to trigger
+      specific capabilities deterministically — no flaky external dependencies, no network timeouts,
+      no DOM surprises from third-party sites.
+    </p>
+  </div>
+
+  <!-- Server status -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Server Status</h2>
+      <span class="section-meta" id="server-url">http://localhost:8080</span>
+    </div>
+    <div class="gh-section-body" style="display:flex;gap:24px;flex-wrap:wrap;">
+      <div>
+        <label>HTTP Endpoints</label>
+        <div style="display:flex;flex-direction:column;gap:4px;margin-top:4px;">
+          <a href="/tests/404"      style="color:var(--red);font-family:monospace;font-size:12px;">/404 → 404 Not Found</a>
+          <a href="/tests/500"      style="color:var(--red);font-family:monospace;font-size:12px;">/500 → 500 Server Error</a>
+          <a href="/tests/cors-test"style="color:var(--amber);font-family:monospace;font-size:12px;">/cors-test → No CORS headers</a>
+          <a href="/tests/slow"     style="color:var(--text-dim);font-family:monospace;font-size:12px;">/slow → 3s delay response</a>
+        </div>
+      </div>
+      <div>
+        <label>WebSocket</label>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:6px;">
+          <span class="dot" id="ws-dot" style="background:var(--text-dim)"></span>
+          <span id="ws-status" style="font-size:12px;color:var(--text-dim)">Connecting...</span>
+        </div>
+        <div class="gh-status" id="ws-msg" style="margin-top:8px;min-height:28px;font-size:11px;">Waiting for messages…</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Page cards -->
+  <div class="gh-card-grid">
+
+    <a href="interact.html" class="gh-card">
+      <div class="gh-card-icon">🎯</div>
+      <div class="gh-card-title">Interaction Gauntlet</div>
+      <div class="gh-card-desc">
+        Full smoke form with all DOM primitives pre-loaded. React-style event traps,
+        ambiguous duplicate targets, overlapping overlays, delayed elements, and a
+        2 000 px scroll anchor. Tests 5.1 – 5.19.
+      </div>
+      <div class="gh-card-tags">
+        <span class="tag tag-dom">#smoke-form-dom</span>
+        <span class="tag tag-dom">#sf-name</span>
+        <span class="tag tag-dom">.dup-target</span>
+        <span class="tag tag-dom">#delayed-el</span>
+      </div>
+    </a>
+
+    <a href="telemetry.html" class="gh-card">
+      <div class="gh-card-icon">📡</div>
+      <div class="gh-card-title">Noise Factory</div>
+      <div class="gh-card-desc">
+        Auto-fires 100+ console messages, fetch()es /404 /500 and a CORS-blocked URL,
+        opens a WebSocket to the local echo server, and offers one-click error bombs
+        for error cluster testing. Tests 2.x, 4.x.
+      </div>
+      <div class="gh-card-tags">
+        <span class="tag tag-error">console.error</span>
+        <span class="tag tag-warn">console.warn</span>
+        <span class="tag tag-dom">WebSocket</span>
+        <span class="tag tag-error">fetch 404/500</span>
+      </div>
+    </a>
+
+    <a href="performance.html" class="gh-card">
+      <div class="gh-card-icon">⚡</div>
+      <div class="gh-card-title">Performance Nightmare</div>
+      <div class="gh-card-desc">
+        Deliberately terrible Web Vitals: delayed LCP image, CLS shift at 1.5 s,
+        800 ms main-thread block button, User Timing marks on load. Tests 9.x.
+      </div>
+      <div class="gh-card-tags">
+        <span class="tag tag-warn">LCP delay</span>
+        <span class="tag tag-error">CLS shift</span>
+        <span class="tag tag-error">Long Task 800ms</span>
+        <span class="tag tag-dom">User Timing</span>
+      </div>
+    </a>
+
+    <a href="a11y.html" class="gh-card">
+      <div class="gh-card-icon">♿</div>
+      <div class="gh-card-title">Accessibility Disaster</div>
+      <div class="gh-card-desc">
+        Deliberate WCAG violations: contrast failures, buttons without labels,
+        inputs without associated labels, broken heading order, missing
+        &lt;main&gt; landmark. Generates rich SARIF output.
+      </div>
+      <div class="gh-card-tags">
+        <span class="tag tag-error">Contrast</span>
+        <span class="tag tag-error">Missing ARIA</span>
+        <span class="tag tag-error">Bad Headings</span>
+        <span class="tag tag-error">No &lt;main&gt;</span>
+      </div>
+    </a>
+
+    <a href="recording.html" class="gh-card">
+      <div class="gh-card-icon">🎬</div>
+      <div class="gh-card-title">Recording Test Page</div>
+      <div class="gh-card-desc">
+        Embedded YouTube lofi stream (the same stream used in smoke test 10.x)
+        in an iframe. Provides a local, branded target for tab recording and audio
+        capture tests without navigating away.
+      </div>
+      <div class="gh-card-tags">
+        <span class="tag tag-dom">YouTube embed</span>
+        <span class="tag tag-dom">tabCapture</span>
+        <span class="tag tag-dom">audio:tab</span>
+      </div>
+    </a>
+
+  </div>
+
+  <div style="margin-top:32px;padding-top:20px;border-top:1px solid var(--border);color:var(--text-dim);font-size:12px;">
+    Gasoline Agentic Browser &mdash; Test Harness &mdash;
+    <a href="https://github.com/anthropics/gasoline" style="color:var(--blue);">Issue #304</a>
+  </div>
+</main>
+
+<script>
+// Index page: probe the WS echo server to show live status
+(function() {
+  const dot    = document.getElementById('ws-dot');
+  const status = document.getElementById('ws-status');
+  const msgEl  = document.getElementById('ws-msg');
+
+  function connect() {
+    const host = window.location.host || 'localhost:8080';
+    const ws = new WebSocket('ws://' + host + '/tests/ws');
+
+    ws.onopen = () => {
+      dot.className    = 'dot dot-green';
+      status.textContent = 'Connected — ws://' + host + '/tests/ws';
+      status.style.color = 'var(--green)';
+      ws.send(JSON.stringify({ ping: true, from: 'index.html', ts: Date.now() }));
+    };
+    ws.onmessage = (e) => {
+      msgEl.textContent = e.data;
+      msgEl.className   = 'gh-status ok';
+    };
+    ws.onclose = () => {
+      dot.className    = 'dot dot-dim';
+      status.textContent = 'Disconnected';
+      status.style.color = 'var(--text-dim)';
+    };
+    ws.onerror = () => {
+      dot.className    = 'dot dot-red';
+      status.textContent = 'WebSocket error — is server.py running?';
+      status.style.color = 'var(--red)';
+    };
+  }
+  connect();
+
+  // Keep server URL in sync
+  document.getElementById('server-url').textContent = window.location.origin;
+})();
+</script>
+
+</body>
+</html>

--- a/cmd/dev-console/testpages/interact.html
+++ b/cmd/dev-console/testpages/interact.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interaction Gauntlet — Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+</head>
+<body>
+
+<header class="gh-header">
+  <a href="index.html" class="gh-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span class="gh-wordmark">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-harness">Interaction Gauntlet</span>
+  <nav class="gh-nav">
+    <a href="index.html">Hub</a>
+    <a href="interact.html" class="active">Interact</a>
+    <a href="telemetry.html">Telemetry</a>
+    <a href="performance.html">Performance</a>
+    <a href="a11y.html">A11y</a>
+    <a href="recording.html">Recording</a>
+  </nav>
+</header>
+
+<main class="gh-main">
+  <div class="gh-hero">
+    <h1>🎯 Interaction Gauntlet</h1>
+    <p>
+      All 19 DOM primitives pre-loaded. Mirrors the smoke form injected by
+      <code style="color:var(--blue);font-size:12px;">_inject_smoke_form</code> in 05-interact-dom.sh —
+      no injection needed. Also includes React-style traps, ambiguous targets, overlapping overlays,
+      delayed elements, and a 2 000 px scroll anchor.
+    </p>
+  </div>
+
+  <!-- ── §1: Standard Smoke Form (mirrors _inject_smoke_form) ─────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Standard Smoke Form</h2>
+      <span class="section-meta">Tests 5.1 – 5.12 · #smoke-form-dom</span>
+    </div>
+    <div class="gh-section-body">
+      <!-- smoke-form-dom: exact structure expected by 05-interact-dom.sh -->
+      <div id="smoke-form-dom" style="display:flex;flex-direction:column;gap:10px;">
+        <div class="gh-form-grid">
+          <input type="text"  id="sf-name"  placeholder="Name">
+          <input type="email" id="sf-email" placeholder="Email">
+        </div>
+        <select id="sf-role">
+          <option value="">Pick</option>
+          <option value="admin">Admin</option>
+          <option value="user">User</option>
+        </select>
+        <div class="gh-form-inline">
+          <label><input type="checkbox" id="sf-agree"> I agree to the test terms</label>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+          <button id="sf-btn" type="button" class="btn btn-primary">Submit</button>
+          <a id="sf-link" href="/tests/test" style="color:var(--blue);font-size:13px;">Test Link</a>
+        </div>
+        <div class="gh-status" id="sf-result">Waiting for interaction…</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §2: Ambiguous Targets (test 5.17) ──────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-amber"></span>
+      <h2>Ambiguous Targets</h2>
+      <span class="section-meta">Test 5.17 · .dup-target in #dup-a / #dup-b</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Two identical <code>.dup-target</code> buttons. Selecting <code>.dup-target</code> without
+        a <code>scope_selector</code> triggers <code>ambiguous_target</code>. Recover with
+        <code>scope_selector:"#dup-a"</code> or <code>"#dup-b"</code>.
+      </p>
+      <div style="display:flex;gap:16px;">
+        <div id="dup-a" style="flex:1;background:var(--bg-card);border:1px solid var(--border);border-radius:6px;padding:12px;">
+          <label style="color:var(--text-dim);margin-bottom:8px;">Container A <span class="tag tag-id">#dup-a</span></label>
+          <button class="dup-target btn btn-ghost" type="button">Post</button>
+        </div>
+        <div id="dup-b" style="flex:1;background:var(--bg-card);border:1px solid var(--border);border-radius:6px;padding:12px;">
+          <label style="color:var(--text-dim);margin-bottom:8px;">Container B <span class="tag tag-id">#dup-b</span></label>
+          <button class="dup-target btn btn-ghost" type="button">Post</button>
+        </div>
+      </div>
+      <div class="gh-status" id="dup-result">Click a Post button to test…</div>
+    </div>
+  </div>
+
+  <!-- ── §3: Dynamic / Delayed Elements (test 5.9) ────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-amber"></span>
+      <h2>Dynamic Elements</h2>
+      <span class="section-meta">Test 5.9 · wait_for · #delayed-el</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Click to schedule <code>#delayed-el</code> to appear after 1 000 ms.
+        Use <code>wait_for("#delayed-el", timeout_ms:5000)</code> to verify.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost" onclick="scheduleDelayedEl(1000)">
+          Add #delayed-el (1 s delay)
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="removeDelayedEl()">
+          Remove #delayed-el
+        </button>
+      </div>
+      <div id="delayed-target-area" style="margin-top:10px;min-height:32px;"></div>
+    </div>
+  </div>
+
+  <!-- ── §4: React-Style Controlled Input ──────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-amber"></span>
+      <h2>React-Style Event Trap</h2>
+      <span class="section-meta">Controlled input · requires input event</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        This input manages its own state via an <code>input</code> listener and rejects direct
+        <code>.value</code> assignments. Typing via CDP/keyboard events works; raw value writes are ignored.
+      </p>
+      <div class="gh-form-row">
+        <label>Controlled Input <span class="tag tag-id">#react-input</span></label>
+        <input type="text" id="react-input" placeholder="Type something…" autocomplete="off">
+      </div>
+      <div class="gh-status" id="react-mirror">State: (empty)</div>
+    </div>
+  </div>
+
+  <!-- ── §5: Overlay / Modal Trap ──────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Overlay &amp; Modal Trap</h2>
+      <span class="section-meta">z-index trap · dismiss_top_overlay · confirm_top_dialog</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        The real button is obscured by a transparent overlay (honeypot). Dismiss the overlay first,
+        then click the button. Also tests <code>confirm_top_dialog</code> via native <code>alert()</code>.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost" onclick="showModal()">Open Modal</button>
+        <button type="button" class="btn btn-ghost" onclick="triggerAlert()">Fire alert()</button>
+        <button type="button" class="btn btn-ghost" onclick="triggerConfirm()">Fire confirm()</button>
+      </div>
+      <div style="position:relative;display:inline-block;margin-top:10px;">
+        <button id="real-target-btn" type="button" class="btn btn-green">Real Target Button</button>
+        <div id="honeypot-overlay"
+             style="position:absolute;inset:0;z-index:10;background:rgba(248,81,73,0.08);
+                    border:1px dashed var(--red);border-radius:6px;cursor:not-allowed;display:none;"
+             title="Honeypot overlay — dismiss me first">
+        </div>
+      </div>
+      <div style="margin-top:8px;">
+        <button type="button" class="btn btn-sm btn-danger" onclick="toggleHoneypot()">
+          Toggle honeypot overlay
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §6: State Management ──────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>State Management</h2>
+      <span class="section-meta">Test 6.x · localStorage · sessionStorage</span>
+    </div>
+    <div class="gh-section-body">
+      <div class="gh-form-grid">
+        <div>
+          <label>localStorage key</label>
+          <input type="text" id="ls-key" value="gasoline_test_key">
+        </div>
+        <div>
+          <label>value</label>
+          <input type="text" id="ls-val" value="smoke-value-123">
+        </div>
+      </div>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="lsSet()">localStorage.setItem</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="lsGet()">localStorage.getItem</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="ssSet()">sessionStorage.setItem</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="ssGet()">sessionStorage.getItem</button>
+      </div>
+      <div class="gh-status" id="storage-result">Storage output…</div>
+    </div>
+  </div>
+
+  <!-- ── §7: Full Form Lifecycle (test 2.7) ────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Full Form Lifecycle</h2>
+      <span class="section-meta">Test 2.7 · multi-field fill + submit</span>
+    </div>
+    <div class="gh-section-body">
+      <form id="smoke-form" onsubmit="formSubmit(event)">
+        <div class="gh-form-grid">
+          <div class="gh-form-row">
+            <label for="sf-user">Username</label>
+            <input type="text"     id="sf-user" name="username" placeholder="smokeuser">
+          </div>
+          <div class="gh-form-row">
+            <label for="sf-email2">Email</label>
+            <input type="email"    id="sf-email2" name="email" placeholder="smoke@test.com">
+          </div>
+        </div>
+        <div class="gh-form-row">
+          <label for="sf-pass">Password</label>
+          <input type="password"   id="sf-pass" name="password" placeholder="••••••••">
+        </div>
+        <div class="gh-form-row">
+          <label for="sf-role2">Role</label>
+          <select id="sf-role2" name="role">
+            <option value="user">User</option>
+            <option value="admin">Admin</option>
+          </select>
+        </div>
+        <button type="submit" id="sf-submit" class="btn btn-primary">Submit</button>
+      </form>
+      <div class="gh-status" id="form-result">Submit to see captured events…</div>
+    </div>
+  </div>
+
+  <!-- ── Scroll anchor at 2000px ───────────────────────────────────────────── -->
+  <div style="margin-top:2000px;padding-top:20px;border-top:1px dashed var(--border);" id="sf-scroll-target">
+    <div style="display:flex;align-items:center;gap:10px;color:var(--green);">
+      <span class="dot dot-green"></span>
+      <strong>Scroll Target</strong>
+      <span class="tag tag-id">#sf-scroll-target</span>
+    </div>
+    <p style="margin-top:8px;font-size:12px;color:var(--text-dim);">
+      scroll_to("#sf-scroll-target") navigated here successfully.
+      window.scrollY should be &gt; 1000.
+    </p>
+  </div>
+</main>
+
+<!-- Native modal -->
+<div class="gh-modal-backdrop" id="modal-backdrop">
+  <div class="gh-modal">
+    <h2 style="font-size:15px;font-weight:600;color:var(--text-bright);margin-bottom:8px;">
+      Test Modal
+    </h2>
+    <p style="font-size:13px;color:var(--text-dim);margin-bottom:16px;">
+      This modal sits at <code>z-index:9999</code>. Use
+      <code>dismiss_top_overlay</code> to close it, then interact with
+      elements beneath.
+    </p>
+    <div class="btn-row">
+      <button type="button" class="btn btn-ghost" onclick="closeModal()">Dismiss</button>
+      <button id="modal-confirm-btn" type="button" class="btn btn-primary">Confirm</button>
+    </div>
+  </div>
+</div>
+
+<script>
+// ── Smoke form feedback ──────────────────────────────────────────────────────
+document.getElementById('sf-btn').addEventListener('click', () => {
+  const name  = document.getElementById('sf-name').value;
+  const email = document.getElementById('sf-email').value;
+  const role  = document.getElementById('sf-role').value;
+  const agree = document.getElementById('sf-agree').checked;
+  const el    = document.getElementById('sf-result');
+  el.textContent = `Clicked — name="${name}" email="${email}" role="${role}" agree=${agree}`;
+  el.className = 'gh-status ok';
+});
+
+document.querySelectorAll('.dup-target').forEach(btn => {
+  btn.addEventListener('click', (e) => {
+    const container = e.target.closest('[id]');
+    const el = document.getElementById('dup-result');
+    el.textContent = `Clicked .dup-target in #${container ? container.id : '?'}`;
+    el.className = 'gh-status ok';
+  });
+});
+
+// ── Delayed element ──────────────────────────────────────────────────────────
+function scheduleDelayedEl(ms) {
+  const area = document.getElementById('delayed-target-area');
+  area.innerHTML = '<span style="color:var(--text-dim);font-size:12px;">Scheduling…</span>';
+  setTimeout(() => {
+    var d = document.createElement('div');
+    d.id = 'delayed-el';
+    d.style.cssText = 'padding:8px 12px;background:var(--green-bg);border:1px solid rgba(63,185,80,0.3);border-radius:6px;color:var(--green);font-size:13px;';
+    d.textContent = 'I appeared! (#delayed-el)';
+    area.innerHTML = '';
+    area.appendChild(d);
+  }, ms);
+}
+function removeDelayedEl() {
+  var el = document.getElementById('delayed-el');
+  if (el) el.remove();
+  document.getElementById('delayed-target-area').innerHTML = '';
+}
+
+// ── React-style controlled input ─────────────────────────────────────────────
+(function() {
+  var state = '';
+  var input = document.getElementById('react-input');
+  var mirror = document.getElementById('react-mirror');
+
+  // Listen for real input events — ignores direct .value writes
+  input.addEventListener('input', (e) => {
+    state = e.target.value;
+    mirror.textContent = 'State: "' + state + '" (length=' + state.length + ')';
+    mirror.className = state ? 'gh-status ok' : 'gh-status';
+  });
+
+  // Override value setter to show when direct assignment is attempted
+  var descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  Object.defineProperty(input, 'value', {
+    get: () => state,
+    set: (v) => {
+      // Silently reject — only event-driven updates are accepted
+      mirror.textContent = 'Direct .value write rejected (tried: "' + v + '"). Use input events.';
+      mirror.className = 'gh-status err';
+    }
+  });
+})();
+
+// ── Overlay / modal ──────────────────────────────────────────────────────────
+function showModal()       { document.getElementById('modal-backdrop').classList.add('open'); }
+function closeModal()      { document.getElementById('modal-backdrop').classList.remove('open'); }
+function toggleHoneypot()  {
+  var hp = document.getElementById('honeypot-overlay');
+  hp.style.display = hp.style.display === 'none' ? 'block' : 'none';
+}
+function triggerAlert()    { window.alert('Gasoline alert() test — use confirm_top_dialog to dismiss'); }
+function triggerConfirm()  { window.confirm('Gasoline confirm() test — confirm or cancel'); }
+
+document.getElementById('real-target-btn').addEventListener('click', () => {
+  console.log('real-target-btn clicked');
+});
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+function lsSet() {
+  var k = document.getElementById('ls-key').value;
+  var v = document.getElementById('ls-val').value;
+  localStorage.setItem(k, v);
+  setStorageResult('localStorage.setItem("' + k + '", "' + v + '") ✓');
+}
+function lsGet() {
+  var k = document.getElementById('ls-key').value;
+  var v = localStorage.getItem(k);
+  setStorageResult('localStorage.getItem("' + k + '") = ' + JSON.stringify(v));
+}
+function ssSet() {
+  var k = document.getElementById('ls-key').value;
+  var v = document.getElementById('ls-val').value;
+  sessionStorage.setItem(k, v);
+  setStorageResult('sessionStorage.setItem("' + k + '", "' + v + '") ✓');
+}
+function ssGet() {
+  var k = document.getElementById('ls-key').value;
+  var v = sessionStorage.getItem(k);
+  setStorageResult('sessionStorage.getItem("' + k + '") = ' + JSON.stringify(v));
+}
+function setStorageResult(msg) {
+  var el = document.getElementById('storage-result');
+  el.textContent = msg;
+  el.className = 'gh-status ok';
+}
+
+// ── Full form ────────────────────────────────────────────────────────────────
+window.__SMOKE_FORM_SUBMITTED__ = false;
+function formSubmit(e) {
+  e.preventDefault();
+  window.__SMOKE_FORM_SUBMITTED__ = true;
+  var el = document.getElementById('form-result');
+  el.textContent = 'Form submitted ✓ (window.__SMOKE_FORM_SUBMITTED__ = true)';
+  el.className = 'gh-status ok';
+}
+</script>
+
+</body>
+</html>

--- a/cmd/dev-console/testpages/interact.html
+++ b/cmd/dev-console/testpages/interact.html
@@ -74,7 +74,7 @@
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
           <button id="sf-btn" type="button" class="btn btn-primary">Submit</button>
-          <a id="sf-link" href="/tests/test" style="color:var(--blue);font-size:13px;">Test Link</a>
+          <a id="sf-link" href="https://example.com/test" style="color:var(--blue);font-size:13px;">Test Link</a>
         </div>
         <div class="gh-status" id="sf-result">Waiting for interaction…</div>
       </div>
@@ -190,7 +190,7 @@
     <div class="gh-section-header">
       <span class="dot dot-green"></span>
       <h2>State Management</h2>
-      <span class="section-meta">Test 6.x · localStorage · sessionStorage</span>
+      <span class="section-meta">Manual · localStorage · sessionStorage</span>
     </div>
     <div class="gh-section-body">
       <div class="gh-form-grid">
@@ -218,7 +218,7 @@
     <div class="gh-section-header">
       <span class="dot dot-green"></span>
       <h2>Full Form Lifecycle</h2>
-      <span class="section-meta">Test 2.7 · multi-field fill + submit</span>
+      <span class="section-meta">Manual · multi-field fill + submit</span>
     </div>
     <div class="gh-section-body">
       <form id="smoke-form" onsubmit="formSubmit(event)">

--- a/cmd/dev-console/testpages/performance.html
+++ b/cmd/dev-console/testpages/performance.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Performance Nightmare — Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+  <style>
+    .perf-metric {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+    }
+    .perf-metric:last-child { border-bottom: none; }
+    .perf-metric-name  { color: var(--text-dim); font-family: monospace; }
+    .perf-metric-value { color: var(--text-bright); font-weight: 600; font-family: monospace; }
+    .perf-metric-value.poor { color: var(--red); }
+    .perf-metric-value.ok   { color: var(--green); }
+  </style>
+</head>
+<body>
+
+<header class="gh-header">
+  <a href="index.html" class="gh-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span class="gh-wordmark">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-amber">Performance Nightmare</span>
+  <nav class="gh-nav">
+    <a href="index.html">Hub</a>
+    <a href="interact.html">Interact</a>
+    <a href="telemetry.html">Telemetry</a>
+    <a href="performance.html" class="active">Performance</a>
+    <a href="a11y.html">A11y</a>
+    <a href="recording.html">Recording</a>
+  </nav>
+</header>
+
+<main class="gh-main">
+  <div class="gh-hero">
+    <h1>⚡ Performance Nightmare</h1>
+    <p>
+      Deliberately bad Web Vitals: delayed LCP image, CLS layout shift at 1.5 s,
+      800 ms main-thread blocking button, and User Timing marks on every load.
+      Tests 9.x — <code>analyze(performance)</code>, <code>perf_diff</code>,
+      <code>user_timing</code>, Long Tasks.
+    </p>
+  </div>
+
+  <!-- ── §1: LCP Disaster ──────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>LCP Disaster</h2>
+      <span class="section-meta">Delayed Largest Contentful Paint</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        The hero image below loads after a 2 000 ms artificial delay.
+        This pushes LCP well past the "poor" threshold of 4 s
+        and registers as a delayed resource in the network waterfall.
+      </p>
+      <!-- LCP target: large, slow-loading element -->
+      <div class="lcp-hero" id="lcp-hero">
+        <span id="lcp-placeholder" style="color:var(--text-dim);">
+          ⏳ LCP image loading in 2 000 ms…
+        </span>
+        <img id="lcp-image" alt="LCP Hero"
+             style="width:100%;height:100%;object-fit:cover;border-radius:6px;display:none;">
+      </div>
+      <div class="gh-status" id="lcp-status">Waiting for LCP image…</div>
+    </div>
+  </div>
+
+  <!-- ── §2: CLS Bomb ─────────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>CLS Bomb</h2>
+      <span class="section-meta">Layout shift at 1 500 ms after load</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        The box below grows from 60 px to 200 px at 1.5 s, pushing content down and
+        triggering a measurable Cumulative Layout Shift. CLS score shows in
+        <code>analyze(performance)</code>.
+      </p>
+      <!-- CLS target element -->
+      <div class="cls-box" id="cls-box">
+        <span id="cls-label">Stable (pre-shift)</span>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:6px;padding:10px;font-size:12px;color:var(--text-dim);">
+        This text shifts downward when the box above expands. The layout shift
+        is captured by the PerformanceObserver watching <code>layout-shift</code> entries.
+      </div>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="triggerCLS()">Force CLS now</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="resetCLS()">Reset</button>
+      </div>
+      <div class="gh-status" id="cls-status">CLS shift fires automatically at 1 500 ms…</div>
+    </div>
+  </div>
+
+  <!-- ── §3: Long Task / Main Thread Block ─────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Long Task Factory</h2>
+      <span class="section-meta">800 ms main-thread block · INP trigger</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Runs a tight computation loop for exactly 800 ms — well over the 50 ms
+        Long Task threshold. Appears in <code>analyze(performance)</code> as a
+        long task and degrades INP (Interaction to Next Paint).
+      </p>
+      <div class="btn-row">
+        <button id="long-task-btn" type="button" class="btn btn-danger" onclick="runLongTask(800)">
+          Block main thread 800 ms
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="runLongTask(200)">
+          200 ms block
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="runLongTask(50)">
+          50 ms (threshold)
+        </button>
+      </div>
+      <div class="gh-status" id="long-task-status">Click to trigger a Long Task.</div>
+    </div>
+  </div>
+
+  <!-- ── §4: User Timing Lab ───────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>User Timing Lab</h2>
+      <span class="section-meta">Test 9.4 · performance.mark / measure</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Marks are set automatically on load: <code>harness_load_start</code>,
+        <code>harness_interactive</code>, <code>harness_load_end</code>.
+        Use the buttons to add custom marks and measures.
+        Verify with <code>analyze(performance)</code> &rarr; <code>user_timing</code>.
+      </p>
+      <div class="gh-form-row">
+        <label>Mark name</label>
+        <input type="text" id="mark-name" value="smoke_custom_mark" style="max-width:320px;">
+      </div>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="addMark()">performance.mark()</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="addMeasure()">performance.measure()</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="clearMarks()">clearMarks()</button>
+      </div>
+      <div class="gh-log" id="timing-log"></div>
+    </div>
+  </div>
+
+  <!-- ── §5: Live Metrics Panel ────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Live Metrics</h2>
+      <span class="section-meta">PerformanceObserver · Web Vitals</span>
+    </div>
+    <div class="gh-section-body">
+      <div id="perf-metrics">
+        <div class="perf-metric">
+          <span class="perf-metric-name">TTFB</span>
+          <span class="perf-metric-value" id="m-ttfb">—</span>
+        </div>
+        <div class="perf-metric">
+          <span class="perf-metric-name">FCP</span>
+          <span class="perf-metric-value" id="m-fcp">—</span>
+        </div>
+        <div class="perf-metric">
+          <span class="perf-metric-name">LCP</span>
+          <span class="perf-metric-value" id="m-lcp">— (expect &gt;2000ms)</span>
+        </div>
+        <div class="perf-metric">
+          <span class="perf-metric-name">CLS</span>
+          <span class="perf-metric-value" id="m-cls">0.000 (expect &gt;0.1)</span>
+        </div>
+        <div class="perf-metric">
+          <span class="perf-metric-name">Long Tasks</span>
+          <span class="perf-metric-value" id="m-lt">0</span>
+        </div>
+        <div class="perf-metric">
+          <span class="perf-metric-name">User Marks</span>
+          <span class="perf-metric-value" id="m-marks">0</span>
+        </div>
+      </div>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="refreshMetrics()">Refresh metrics</button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script>
+// ── User Timing: auto-marks on load ──────────────────────────────────────────
+performance.mark('harness_load_start');
+var timingLog = document.getElementById('timing-log');
+var markCount = 0;
+var ltCount = 0;
+var clsTotal = 0;
+
+function appendTimingLog(msg, cls) {
+  var d = document.createElement('div');
+  d.className = 'log-line ' + (cls || 'log');
+  d.textContent = msg;
+  timingLog.appendChild(d);
+  timingLog.scrollTop = timingLog.scrollHeight;
+}
+
+// ── §1: LCP delay ────────────────────────────────────────────────────────────
+window.addEventListener('load', function() {
+  performance.mark('harness_interactive');
+
+  // Delay LCP image by 2000ms
+  setTimeout(function() {
+    var img   = document.getElementById('lcp-image');
+    var ph    = document.getElementById('lcp-placeholder');
+    var hero  = document.getElementById('lcp-hero');
+    var st    = document.getElementById('lcp-status');
+
+    // Use a large, eye-catching gradient rendered as a data URI
+    var canvas = document.createElement('canvas');
+    canvas.width  = 800;
+    canvas.height = 200;
+    var ctx = canvas.getContext('2d');
+    var grd = ctx.createLinearGradient(0, 0, 800, 200);
+    grd.addColorStop(0,   '#f97316');
+    grd.addColorStop(0.5, '#fb923c');
+    grd.addColorStop(1,   '#fbbf24');
+    ctx.fillStyle = grd;
+    ctx.fillRect(0, 0, 800, 200);
+    ctx.fillStyle = 'rgba(26,26,26,0.5)';
+    ctx.fillRect(0, 0, 800, 200);
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 28px -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Gasoline LCP Hero — Loaded after 2 000 ms delay', 400, 110);
+
+    img.src     = canvas.toDataURL('image/png');
+    img.style.display = 'block';
+    ph.style.display  = 'none';
+    hero.style.height = 'auto';
+
+    st.textContent = 'LCP image rendered at ' + Math.round(performance.now()) + ' ms ✓';
+    st.className = 'gh-status ok';
+
+    performance.mark('harness_lcp_rendered');
+    performance.measure('harness_lcp_delay', 'harness_load_start', 'harness_lcp_rendered');
+    appendTimingLog('measure: harness_lcp_delay = ' + Math.round(performance.now()) + 'ms', 'warn');
+    updateMarkCount();
+  }, 2000);
+
+  // CLS shift at 1500ms
+  setTimeout(function() { triggerCLS(); }, 1500);
+
+  performance.mark('harness_load_end');
+  performance.measure('harness_load_duration', 'harness_load_start', 'harness_load_end');
+  appendTimingLog('mark: harness_load_start', 'log');
+  appendTimingLog('mark: harness_interactive', 'log');
+  appendTimingLog('mark: harness_load_end', 'log');
+  appendTimingLog('measure: harness_load_duration = ' + Math.round(
+    performance.getEntriesByName('harness_load_duration')[0].duration
+  ) + 'ms', 'log');
+  updateMarkCount();
+
+  // Update TTFB/FCP from Navigation/Paint API
+  requestAnimationFrame(function() { setTimeout(refreshMetrics, 500); });
+});
+
+// ── §2: CLS ──────────────────────────────────────────────────────────────────
+function triggerCLS() {
+  var box   = document.getElementById('cls-box');
+  var label = document.getElementById('cls-label');
+  var st    = document.getElementById('cls-status');
+  box.style.height     = '200px';
+  box.style.transition = 'none'; // sudden shift — no animation so it counts
+  label.textContent    = 'SHIFTED — height expanded to 200 px';
+  st.textContent       = 'CLS shift triggered — check analyze(performance) for layout-shift entries';
+  st.className         = 'gh-status err';
+}
+function resetCLS() {
+  var box   = document.getElementById('cls-box');
+  var label = document.getElementById('cls-label');
+  var st    = document.getElementById('cls-status');
+  box.style.height  = '60px';
+  label.textContent = 'Stable (pre-shift)';
+  st.textContent    = 'Reset — trigger again for another CLS event.';
+  st.className      = 'gh-status';
+}
+
+// ── §3: Long Task ────────────────────────────────────────────────────────────
+function runLongTask(ms) {
+  var btn = document.getElementById('long-task-btn');
+  var st  = document.getElementById('long-task-status');
+  btn.disabled = true;
+  st.textContent = 'Running ' + ms + 'ms block…';
+  st.className = 'gh-status info';
+
+  performance.mark('long_task_start_' + ms);
+
+  setTimeout(function() {
+    // Synchronous CPU burn — this IS the Long Task
+    var end = performance.now() + ms;
+    var i = 0;
+    while (performance.now() < end) { i++; } // tight loop
+
+    performance.mark('long_task_end_' + ms);
+    performance.measure('long_task_' + ms + 'ms', 'long_task_start_' + ms, 'long_task_end_' + ms);
+
+    btn.disabled = false;
+    st.textContent = 'Long Task completed: ' + ms + 'ms block (' + i + ' iterations). Check analyze(performance).';
+    st.className = 'gh-status err';
+    ltCount++;
+    document.getElementById('m-lt').textContent = ltCount;
+    appendTimingLog('long_task: ' + ms + 'ms completed', 'warn');
+    updateMarkCount();
+  }, 0);
+}
+
+// ── §4: User Timing controls ─────────────────────────────────────────────────
+function addMark() {
+  var name = document.getElementById('mark-name').value || 'smoke_mark';
+  var fullName = name + '_' + Date.now();
+  performance.mark(fullName);
+  appendTimingLog('mark: ' + fullName + ' @ ' + Math.round(performance.now()) + 'ms', 'log');
+  updateMarkCount();
+}
+function addMeasure() {
+  var name = document.getElementById('mark-name').value || 'smoke_measure';
+  try {
+    var start = performance.getEntriesByType('mark').slice(-2)[0];
+    var end   = performance.getEntriesByType('mark').slice(-1)[0];
+    if (start && end) {
+      performance.measure(name + '_measure', start.name, end.name);
+      appendTimingLog('measure: ' + name + '_measure = ' +
+        Math.round(performance.getEntriesByName(name + '_measure').slice(-1)[0].duration) + 'ms', 'log');
+    } else {
+      appendTimingLog('Need at least 2 marks to measure.', 'warn');
+    }
+  } catch(e) {
+    appendTimingLog('measure error: ' + e.message, 'error');
+  }
+}
+function clearMarks() {
+  performance.clearMarks();
+  performance.clearMeasures();
+  appendTimingLog('Marks and measures cleared.', 'system');
+  updateMarkCount();
+}
+function updateMarkCount() {
+  var count = performance.getEntriesByType('mark').length;
+  document.getElementById('m-marks').textContent = count;
+  markCount = count;
+}
+
+// ── §5: Live Metrics ─────────────────────────────────────────────────────────
+function refreshMetrics() {
+  try {
+    var nav = performance.getEntriesByType('navigation')[0];
+    if (nav) {
+      var ttfb = Math.round(nav.responseStart - nav.requestStart);
+      document.getElementById('m-ttfb').textContent = ttfb + 'ms';
+      document.getElementById('m-ttfb').className = 'perf-metric-value ' + (ttfb > 800 ? 'poor' : 'ok');
+    }
+    var paint = performance.getEntriesByType('paint');
+    paint.forEach(function(p) {
+      if (p.name === 'first-contentful-paint') {
+        var fcp = Math.round(p.startTime);
+        document.getElementById('m-fcp').textContent = fcp + 'ms';
+        document.getElementById('m-fcp').className = 'perf-metric-value ' + (fcp > 1800 ? 'poor' : 'ok');
+      }
+    });
+    updateMarkCount();
+  } catch(e) { /* non-critical */ }
+}
+
+// PerformanceObserver: LCP
+if (window.PerformanceObserver) {
+  try {
+    new PerformanceObserver(function(list) {
+      var entries = list.getEntries();
+      var last = entries[entries.length - 1];
+      var lcp = Math.round(last.startTime);
+      var el = document.getElementById('m-lcp');
+      el.textContent = lcp + 'ms';
+      el.className = 'perf-metric-value ' + (lcp > 2500 ? 'poor' : 'ok');
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch(e) {}
+
+  // CLS observer
+  try {
+    new PerformanceObserver(function(list) {
+      list.getEntries().forEach(function(entry) {
+        if (!entry.hadRecentInput) {
+          clsTotal += entry.value;
+          var el = document.getElementById('m-cls');
+          el.textContent = clsTotal.toFixed(4);
+          el.className = 'perf-metric-value ' + (clsTotal > 0.1 ? 'poor' : 'ok');
+        }
+      });
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch(e) {}
+
+  // Long Tasks observer
+  try {
+    new PerformanceObserver(function(list) {
+      list.getEntries().forEach(function() {
+        ltCount++;
+        document.getElementById('m-lt').textContent = ltCount;
+      });
+    }).observe({ type: 'longtask', buffered: true });
+  } catch(e) {}
+}
+</script>
+
+</body>
+</html>

--- a/cmd/dev-console/testpages/performance.html
+++ b/cmd/dev-console/testpages/performance.html
@@ -242,7 +242,9 @@ window.addEventListener('load', function() {
     var hero  = document.getElementById('lcp-hero');
     var st    = document.getElementById('lcp-status');
 
-    // Use a large, eye-catching gradient rendered as a data URI
+    // Use a large, eye-catching gradient as the LCP image.
+    // canvas.toBlob() + createObjectURL() produces a blob: URL that Chrome
+    // includes as an LCP candidate — unlike data: URIs, which are excluded.
     var canvas = document.createElement('canvas');
     canvas.width  = 800;
     canvas.height = 200;
@@ -260,7 +262,12 @@ window.addEventListener('load', function() {
     ctx.textAlign = 'center';
     ctx.fillText('Gasoline LCP Hero — Loaded after 2 000 ms delay', 400, 110);
 
-    img.src     = canvas.toDataURL('image/png');
+    canvas.toBlob(function(blob) {
+      var blobUrl = URL.createObjectURL(blob);
+      img.src = blobUrl;
+      // Store for cleanup on unload.
+      img.dataset.blobUrl = blobUrl;
+    }, 'image/png');
     img.style.display = 'block';
     ph.style.display  = 'none';
     hero.style.height = 'auto';
@@ -306,6 +313,9 @@ function resetCLS() {
   var box   = document.getElementById('cls-box');
   var label = document.getElementById('cls-label');
   var st    = document.getElementById('cls-status');
+  // Keep transition:none so the reset itself doesn't become an animated shift
+  // (animated shifts are excluded from CLS scoring — we want the reset invisible).
+  box.style.transition = 'none';
   box.style.height  = '60px';
   label.textContent = 'Stable (pre-shift)';
   st.textContent    = 'Reset — trigger again for another CLS event.';
@@ -334,8 +344,8 @@ function runLongTask(ms) {
     btn.disabled = false;
     st.textContent = 'Long Task completed: ' + ms + 'ms block (' + i + ' iterations). Check analyze(performance).';
     st.className = 'gh-status err';
-    ltCount++;
-    document.getElementById('m-lt').textContent = ltCount;
+    // ltCount is incremented by the PerformanceObserver below — do not also
+    // increment here or the counter will be doubled (once per click + once per entry).
     appendTimingLog('long_task: ' + ms + 'ms completed', 'warn');
     updateMarkCount();
   }, 0);
@@ -425,7 +435,7 @@ if (window.PerformanceObserver) {
     }).observe({ type: 'layout-shift', buffered: true });
   } catch(e) {}
 
-  // Long Tasks observer
+  // Long Tasks observer — sole source of truth for ltCount.
   try {
     new PerformanceObserver(function(list) {
       list.getEntries().forEach(function() {
@@ -435,6 +445,12 @@ if (window.PerformanceObserver) {
     }).observe({ type: 'longtask', buffered: true });
   } catch(e) {}
 }
+
+// Release the LCP blob URL on navigation to avoid memory leaks.
+window.addEventListener('pagehide', function() {
+  var img = document.getElementById('lcp-image');
+  if (img && img.dataset.blobUrl) { URL.revokeObjectURL(img.dataset.blobUrl); }
+});
 </script>
 
 </body>

--- a/cmd/dev-console/testpages/recording.html
+++ b/cmd/dev-console/testpages/recording.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Recording Test — Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+  <style>
+    .yt-frame-wrapper {
+      position: relative;
+      width: 100%;
+      padding-top: 56.25%; /* 16:9 */
+      background: #000;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .yt-frame-wrapper iframe {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+    .recording-step {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .recording-step:last-child { border-bottom: none; }
+    .step-num {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--blue-bg);
+      border: 1px solid rgba(88,166,255,0.4);
+      color: var(--blue);
+      font-size: 11px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .step-text { font-size: 13px; color: var(--text); line-height: 1.5; }
+    .step-code { font-family: monospace; font-size: 12px; color: var(--blue); background: var(--bg-card); padding: 2px 6px; border-radius: 4px; }
+    .rec-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 12px;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .rec-active { background: rgba(229,57,53,0.15); color: #e53935; border: 1px solid rgba(229,57,53,0.4); animation: glow 1.5s ease-in-out infinite; }
+    .rec-idle   { background: var(--bg-card); color: var(--text-dim); border: 1px solid var(--border); }
+  </style>
+</head>
+<body>
+
+<header class="gh-header">
+  <a href="index.html" class="gh-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span class="gh-wordmark">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-purple">Recording Test</span>
+  <div class="rec-indicator rec-idle" id="rec-indicator">
+    <span style="width:8px;height:8px;border-radius:50%;background:currentColor;display:inline-block;"></span>
+    Not Recording
+  </div>
+  <nav class="gh-nav">
+    <a href="index.html">Hub</a>
+    <a href="interact.html">Interact</a>
+    <a href="telemetry.html">Telemetry</a>
+    <a href="performance.html">Performance</a>
+    <a href="a11y.html">A11y</a>
+    <a href="recording.html" class="active">Recording</a>
+  </nav>
+</header>
+
+<main class="gh-main">
+  <div class="gh-hero">
+    <h1>🎬 Recording Test Page</h1>
+    <p>
+      Embedded YouTube lofi stream — the same stream used in smoke test 10.x.
+      Provides a local, branded target for <code>record_start</code> / <code>record_stop</code>
+      and tab audio capture (<code>audio:"tab"</code>) without navigating to YouTube directly.
+    </p>
+  </div>
+
+  <!-- ── §1: Embedded YouTube ──────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Lofi Stream (YouTube Embed)</h2>
+      <span class="section-meta">Tests 10.1 / 10.2 · tabCapture · audio:tab</span>
+    </div>
+    <div class="gh-section-body">
+      <div class="yt-frame-wrapper">
+        <!-- Same video as 10-recording.sh: youtu.be/n61ULEU7CO0 starting at t=646 -->
+        <iframe
+          id="yt-player"
+          src="https://www.youtube.com/embed/n61ULEU7CO0?start=646&autoplay=1&mute=0&rel=0&modestbranding=1"
+          title="Lofi Hip Hop Radio — beats to relax/study to (Recording Test)"
+          allow="autoplay; encrypted-media; picture-in-picture"
+          allowfullscreen>
+        </iframe>
+      </div>
+      <div style="margin-top:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+        <span class="tag tag-dom">youtu.be/n61ULEU7CO0</span>
+        <span class="tag tag-dom">t=646</span>
+        <span class="tag tag-dom">autoplay=1</span>
+        <span style="font-size:12px;color:var(--text-dim);">
+          Browser may block autoplay. Click the video to start playback before recording with audio.
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §2: Recording Instructions ──────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-amber"></span>
+      <h2>Smoke Test 10 — Quick Reference</h2>
+      <span class="section-meta">record_start · record_stop · watermark persistence</span>
+    </div>
+    <div class="gh-section-body">
+      <div class="recording-step">
+        <div class="step-num">1</div>
+        <div class="step-text">
+          Ensure Gasoline is tracking this tab. Click the extension icon if needed.
+        </div>
+      </div>
+      <div class="recording-step">
+        <div class="step-num">2</div>
+        <div class="step-text">
+          Start tab recording (video only):
+          <br><span class="step-code">interact(record_start, name:"smoke-video-test")</span>
+        </div>
+      </div>
+      <div class="recording-step">
+        <div class="step-num">3</div>
+        <div class="step-text">
+          Wait 5 seconds. The Gasoline watermark <span class="tag tag-id">#gasoline-recording-watermark</span>
+          should appear in the corner.
+        </div>
+      </div>
+      <div class="recording-step">
+        <div class="step-num">4</div>
+        <div class="step-text">
+          Stop and verify: <span class="step-code">interact(record_stop)</span>
+          then <span class="step-code">observe(saved_videos, last_n:5)</span>
+        </div>
+      </div>
+      <div class="recording-step">
+        <div class="step-num">5</div>
+        <div class="step-text">
+          For audio test: <span class="step-code">interact(record_start, name:"smoke-audio-test", audio:"tab")</span>.
+          Start YouTube playback first, then verify <code>has_audio:true</code> in saved_videos.
+        </div>
+      </div>
+      <div class="recording-step">
+        <div class="step-num">6</div>
+        <div class="step-text">
+          Watermark persistence test: start recording, then
+          <span class="step-code">interact(refresh)</span> — watermark should reappear
+          after the page reloads (tests <code>tabs.onUpdated</code> re-send).
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── §3: Watermark Detection Helper ─────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Watermark Detection</h2>
+      <span class="section-meta">execute_js check · #gasoline-recording-watermark</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+        Use this to verify the recording watermark is present (smoke test 10.3):
+      </p>
+      <div class="gh-status" style="font-size:12px;">document.getElementById("gasoline-recording-watermark") ? "WATERMARK_FOUND" : "WATERMARK_MISSING"</div>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="checkWatermark()">
+          Check watermark (execute_js)
+        </button>
+      </div>
+      <div class="gh-status" id="watermark-result">Click to check…</div>
+    </div>
+  </div>
+
+  <!-- ── §4: Rich UI for Recording Content ───────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Recording Test Canvas</h2>
+      <span class="section-meta">Interactive elements · visual interest for recordings</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        These elements provide visual variety and interactive content for recording tests.
+        Use <code>interact(click)</code> and <code>interact(type)</code> while recording
+        to capture representative agent interactions.
+      </p>
+      <div class="gh-form-grid" style="margin-bottom:12px;">
+        <div class="gh-form-row">
+          <label>Search query</label>
+          <input type="text" id="rec-search" placeholder="Type while recording…">
+        </div>
+        <div class="gh-form-row">
+          <label>Category</label>
+          <select id="rec-category">
+            <option value="music">Music</option>
+            <option value="code">Code Review</option>
+            <option value="design">Design</option>
+            <option value="research">Research</option>
+          </select>
+        </div>
+      </div>
+      <div class="btn-row">
+        <button id="rec-btn-a" type="button" class="btn btn-primary">Analyze</button>
+        <button id="rec-btn-b" type="button" class="btn btn-ghost">Save</button>
+        <button id="rec-btn-c" type="button" class="btn btn-ghost">Share</button>
+        <button id="rec-btn-d" type="button" class="btn btn-danger btn-sm">Reset</button>
+      </div>
+
+      <!-- Animated flame for visual interest in recordings -->
+      <div style="text-align:center;margin-top:24px;padding:20px 0;">
+        <svg id="anim-flame" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="64" height="64">
+          <defs>
+            <linearGradient id="afl" x1="0%" y1="100%" x2="0%" y2="0%">
+              <stop offset="0%"   style="stop-color:#f97316"/>
+              <stop offset="50%"  style="stop-color:#fb923c"/>
+              <stop offset="100%" style="stop-color:#fbbf24"/>
+            </linearGradient>
+            <linearGradient id="aifl" x1="0%" y1="100%" x2="0%" y2="0%">
+              <stop offset="0%"   style="stop-color:#fbbf24"/>
+              <stop offset="100%" style="stop-color:#fef3c7"/>
+            </linearGradient>
+          </defs>
+          <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+          <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#afl)"/>
+          <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#aifl)"/>
+        </svg>
+        <div style="margin-top:8px;font-size:14px;font-weight:600;" class="flame-text">Gasoline Agentic Browser</div>
+        <div style="font-size:12px;color:var(--text-dim);margin-top:4px;" id="rec-clock">Recording target ready</div>
+      </div>
+      <div class="gh-status" id="rec-canvas-result">Interact with elements above while recording…</div>
+    </div>
+  </div>
+</main>
+
+<script>
+// ── Live clock for visual interest ───────────────────────────────────────────
+(function() {
+  var clockEl = document.getElementById('rec-clock');
+  function update() {
+    clockEl.textContent = new Date().toLocaleTimeString('en-US', { hour12: false });
+  }
+  update();
+  setInterval(update, 1000);
+})();
+
+// ── Watermark check ──────────────────────────────────────────────────────────
+function checkWatermark() {
+  var found = !!document.getElementById('gasoline-recording-watermark');
+  var el    = document.getElementById('watermark-result');
+  el.textContent = found ? 'WATERMARK_FOUND — recording is active' : 'WATERMARK_MISSING — recording not started';
+  el.className   = 'gh-status ' + (found ? 'ok' : 'err');
+}
+
+// ── Recording indicator: watch for watermark insertion ───────────────────────
+var observer = new MutationObserver(function() {
+  var ind = document.getElementById('rec-indicator');
+  if (document.getElementById('gasoline-recording-watermark')) {
+    ind.className   = 'rec-indicator rec-active';
+    ind.innerHTML   = '<span style="width:8px;height:8px;border-radius:50%;background:currentColor;display:inline-block;"></span> Recording…';
+  } else {
+    ind.className   = 'rec-indicator rec-idle';
+    ind.innerHTML   = '<span style="width:8px;height:8px;border-radius:50%;background:currentColor;display:inline-block;"></span> Not Recording';
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });
+
+// ── Canvas feedback ──────────────────────────────────────────────────────────
+var canvasResult = document.getElementById('rec-canvas-result');
+function showCanvasAction(msg) {
+  canvasResult.textContent = msg;
+  canvasResult.className = 'gh-status ok';
+}
+document.getElementById('rec-search').addEventListener('input', function(e) {
+  showCanvasAction('Typed: "' + e.target.value + '"');
+});
+document.getElementById('rec-btn-a').addEventListener('click', function() { showCanvasAction('Clicked: Analyze'); });
+document.getElementById('rec-btn-b').addEventListener('click', function() { showCanvasAction('Clicked: Save'); });
+document.getElementById('rec-btn-c').addEventListener('click', function() { showCanvasAction('Clicked: Share'); });
+document.getElementById('rec-btn-d').addEventListener('click', function() {
+  document.getElementById('rec-search').value = '';
+  document.getElementById('rec-category').value = 'music';
+  showCanvasAction('Reset — form cleared');
+});
+</script>
+
+</body>
+</html>

--- a/cmd/dev-console/testpages/telemetry.html
+++ b/cmd/dev-console/testpages/telemetry.html
@@ -123,11 +123,11 @@
     <div class="gh-section-header">
       <span class="dot" id="ws-section-dot" style="background:var(--amber);animation:pulse 1.2s infinite"></span>
       <h2>WebSocket Arena</h2>
-      <span class="section-meta">Test 4.1 · observe(websocket_status) · observe(websocket_events)</span>
+      <span class="section-meta">observe(websocket_status) · observe(websocket_events)</span>
     </div>
     <div class="gh-section-body">
       <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
-        Auto-connects to <code>ws://localhost:8080/ws</code> on load.
+        Auto-connects to <code>ws://{host}/tests/ws</code> on load.
         Gasoline's early-patch intercepts the <code>WebSocket</code> constructor.
         Connection state and messages are visible in <code>observe(websocket_status)</code>.
       </p>
@@ -317,7 +317,7 @@ function setWsStatus(state, color) {
 function wsConnect() {
   var host = window.location.host || 'localhost:8080';
   setWsStatus('Connecting', 'var(--amber)');
-  appendLog(wslog, 'Connecting to ws://' + host + '/ws…', 'system');
+  appendLog(wslog, 'Connecting to ws://' + host + '/tests/ws…', 'system');
   ws = new WebSocket('ws://' + host + '/tests/ws');
 
   ws.onopen = function() {
@@ -334,7 +334,7 @@ function wsConnect() {
   };
   ws.onerror = function() {
     setWsStatus('Error', 'var(--red)');
-    appendLog(wslog, 'WebSocket error — is server.py running?', 'error');
+    appendLog(wslog, 'WebSocket error — is the Gasoline daemon running on ' + host + '?', 'error');
   };
 }
 
@@ -364,6 +364,12 @@ function wsReconnect() {
 
 window.addEventListener('load', function() {
   setTimeout(wsConnect, 500);
+});
+
+// Close the WebSocket cleanly on navigation so the server receives a proper
+// close frame rather than an abrupt TCP FIN.
+window.addEventListener('pagehide', function() {
+  if (ws && ws.readyState === WebSocket.OPEN) { ws.close(1000, 'page unload'); }
 });
 
 // ── §4: Error Bombs ──────────────────────────────────────────────────────────
@@ -398,8 +404,8 @@ function throwReferenceError() {
 }
 function throwUnhandledPromise() {
   Promise.reject(new Error('SMOKE_UNHANDLED_REJECTION_' + Date.now()));
+  // setErrResult already calls incError() — no extra call needed here.
   setErrResult('UnhandledPromiseRejection fired — check observe(errors)');
-  incError();
 }
 function throwDeepStack() {
   function a() { b(); }

--- a/cmd/dev-console/testpages/telemetry.html
+++ b/cmd/dev-console/testpages/telemetry.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Noise Factory — Gasoline Test Harness</title>
+  <link rel="stylesheet" href="gasoline.css">
+</head>
+<body>
+
+<header class="gh-header">
+  <a href="index.html" class="gh-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="28" height="28">
+      <defs>
+        <linearGradient id="fl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#f97316"/>
+          <stop offset="50%"  style="stop-color:#fb923c"/>
+          <stop offset="100%" style="stop-color:#fbbf24"/>
+        </linearGradient>
+        <linearGradient id="ifl" x1="0%" y1="100%" x2="0%" y2="0%">
+          <stop offset="0%"   style="stop-color:#fbbf24"/>
+          <stop offset="100%" style="stop-color:#fef3c7"/>
+        </linearGradient>
+      </defs>
+      <circle cx="64" cy="64" r="60" fill="#1a1a1a"/>
+      <path d="M64 16 C40 40,28 60,28 80 C28 100,44 116,64 116 C84 116,100 100,100 80 C100 60,88 40,64 16 Z" fill="url(#fl)"/>
+      <path d="M64 48 C52 60,44 72,44 84 C44 96,52 104,64 104 C76 104,84 96,84 84 C84 72,76 60,64 48 Z" fill="url(#ifl)"/>
+    </svg>
+    <span class="gh-wordmark">Gasoline</span>
+  </a>
+  <span class="gh-badge gh-badge-red">Noise Factory</span>
+  <nav class="gh-nav">
+    <a href="index.html">Hub</a>
+    <a href="interact.html">Interact</a>
+    <a href="telemetry.html" class="active">Telemetry</a>
+    <a href="performance.html">Performance</a>
+    <a href="a11y.html">A11y</a>
+    <a href="recording.html">Recording</a>
+  </nav>
+</header>
+
+<main class="gh-main">
+  <div class="gh-hero">
+    <h1>📡 Noise Factory</h1>
+    <p>
+      Fires 100+ console messages on load, fetches /404 /500 and a CORS-blocked URL,
+      opens a WebSocket echo connection, and exposes one-click error bombs.
+      Tests observe(logs), observe(errors), observe(network_waterfall),
+      observe(websocket_status), and analyze(error_clusters).
+    </p>
+  </div>
+
+  <!-- Status row -->
+  <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;">
+    <div style="background:var(--bg-section);border:1px solid var(--border);border-radius:6px;padding:10px 14px;flex:1;min-width:160px;">
+      <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">Console messages</div>
+      <div style="font-size:20px;font-weight:700;color:var(--text-bright);" id="console-count">0</div>
+    </div>
+    <div style="background:var(--bg-section);border:1px solid var(--border);border-radius:6px;padding:10px 14px;flex:1;min-width:160px;">
+      <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">Network errors</div>
+      <div style="font-size:20px;font-weight:700;color:var(--red);" id="net-error-count">0</div>
+    </div>
+    <div style="background:var(--bg-section);border:1px solid var(--border);border-radius:6px;padding:10px 14px;flex:1;min-width:160px;">
+      <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">WebSocket</div>
+      <div style="display:flex;align-items:center;gap:6px;margin-top:2px;">
+        <span class="dot" id="ws-dot" style="background:var(--text-dim)"></span>
+        <span id="ws-status" style="font-size:13px;font-weight:600;color:var(--text-dim);">Connecting</span>
+      </div>
+    </div>
+    <div style="background:var(--bg-section);border:1px solid var(--border);border-radius:6px;padding:10px 14px;flex:1;min-width:160px;">
+      <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">JS errors</div>
+      <div style="font-size:20px;font-weight:700;color:var(--red);" id="error-count">0</div>
+    </div>
+  </div>
+
+  <!-- ── §1: Console Factory ─────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Console Factory</h2>
+      <span class="section-meta">Tests 2.1 · observe(logs) · observe(errors)</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+        100 messages fired on load (log / warn / error mix). Gasoline's console
+        monkey-patch captures them all for <code>observe(logs)</code> and
+        <code>observe(errors)</code>.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fireConsoleSpam(50)">+50 logs</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fireConsoleErrors(10)">+10 errors</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fireSmokeMarker()">Fire SMOKE_MARKER</button>
+      </div>
+      <div class="gh-log" id="console-log"></div>
+    </div>
+  </div>
+
+  <!-- ── §2: Network Chaos ──────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Network Chaos</h2>
+      <span class="section-meta">Test 4.2 · observe(network_waterfall) · observe(network_bodies)</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+        On load: fetches <code>/404</code>, <code>/500</code>, and
+        <code>https://api.example.com/cors-blocked</code> (guaranteed CORS block).
+        All appear in <code>observe(network_waterfall)</code>.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fetch404()">Fetch /404</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fetch500()">Fetch /500</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fetchCors()">Fetch CORS-blocked</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="fetchSlow()">Fetch /slow (3 s)</button>
+      </div>
+      <div class="gh-log" id="net-log"></div>
+    </div>
+  </div>
+
+  <!-- ── §3: WebSocket Arena ───────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot" id="ws-section-dot" style="background:var(--amber);animation:pulse 1.2s infinite"></span>
+      <h2>WebSocket Arena</h2>
+      <span class="section-meta">Test 4.1 · observe(websocket_status) · observe(websocket_events)</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+        Auto-connects to <code>ws://localhost:8080/ws</code> on load.
+        Gasoline's early-patch intercepts the <code>WebSocket</code> constructor.
+        Connection state and messages are visible in <code>observe(websocket_status)</code>.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-ghost btn-sm" id="ws-send-btn" onclick="wsSend()">Send message</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="wsSendBinary()">Send binary</button>
+        <button type="button" class="btn btn-danger btn-sm" onclick="wsAbnormalClose()">Abnormal close (1001)</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="wsReconnect()">Reconnect</button>
+      </div>
+      <div class="gh-log" id="ws-log"></div>
+    </div>
+  </div>
+
+  <!-- ── §4: Error Bombs ──────────────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-red"></span>
+      <h2>Error Bombs</h2>
+      <span class="section-meta">Tests 2.5 · analyze(error_clusters)</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
+        One-click triggers for common JS error types. Fire multiple times to build
+        clusters for <code>analyze(error_clusters)</code>.
+      </p>
+      <div class="btn-row">
+        <button type="button" class="btn btn-danger btn-sm" onclick="throwTypeError()">TypeError</button>
+        <button type="button" class="btn btn-danger btn-sm" onclick="throwReferenceError()">ReferenceError</button>
+        <button type="button" class="btn btn-danger btn-sm" onclick="throwUnhandledPromise()">UnhandledPromise</button>
+        <button type="button" class="btn btn-danger btn-sm" onclick="throwDeepStack()">Deep stack error</button>
+      </div>
+      <div class="gh-status" id="error-result">No error fired yet.</div>
+    </div>
+  </div>
+
+  <!-- ── §5: Action Capture Form ─────────────────────────────────────── -->
+  <div class="gh-section">
+    <div class="gh-section-header">
+      <span class="dot dot-green"></span>
+      <h2>Action Capture Lab</h2>
+      <span class="section-meta">Tests 2.2 / 2.3 · observe(actions)</span>
+    </div>
+    <div class="gh-section-body">
+      <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+        Fill these fields and click buttons — all interactions appear in
+        <code>observe(actions)</code>.
+      </p>
+      <div class="gh-form-grid">
+        <div class="gh-form-row">
+          <label>Text input <span class="tag tag-id">#action-text</span></label>
+          <input type="text" id="action-text" placeholder="Type to capture…">
+        </div>
+        <div class="gh-form-row">
+          <label>Select <span class="tag tag-id">#action-select</span></label>
+          <select id="action-select">
+            <option value="a">Option A</option>
+            <option value="b">Option B</option>
+            <option value="c">Option C</option>
+          </select>
+        </div>
+      </div>
+      <div class="gh-form-row">
+        <div class="gh-form-inline">
+          <label><input type="checkbox" id="action-check"> Checkbox</label>
+          <label style="margin-left:16px;"><input type="radio" name="action-radio" value="x"> Radio X</label>
+          <label style="margin-left:8px;"><input type="radio" name="action-radio" value="y"> Radio Y</label>
+        </div>
+      </div>
+      <div class="btn-row">
+        <button id="action-btn-primary" type="button" class="btn btn-primary">Primary Action</button>
+        <button id="action-btn-secondary" type="button" class="btn btn-ghost">Secondary Action</button>
+      </div>
+      <div class="gh-status" id="action-result">Interact above to see captured actions…</div>
+    </div>
+  </div>
+</main>
+
+<script>
+// ── Global counters ──────────────────────────────────────────────────────────
+var consoleCount = 0;
+var netErrorCount = 0;
+var errorCount = 0;
+
+function incConsole() { document.getElementById('console-count').textContent = ++consoleCount; }
+function incNetError() { document.getElementById('net-error-count').textContent = ++netErrorCount; }
+function incError()    { document.getElementById('error-count').textContent = ++errorCount; }
+
+// ── Log helpers ──────────────────────────────────────────────────────────────
+function appendLog(el, msg, cls) {
+  var d = document.createElement('div');
+  d.className = 'log-line ' + (cls || 'log');
+  d.textContent = msg;
+  el.appendChild(d);
+  el.scrollTop = el.scrollHeight;
+}
+
+// ── §1: Console Factory ──────────────────────────────────────────────────────
+var clog = document.getElementById('console-log');
+
+function fireConsoleSpam(n) {
+  for (var i = 0; i < n; i++) {
+    var level = ['log','warn','info'][i % 3];
+    var msg   = '[HMR] update #' + (consoleCount + i) + ' — module chunk reloaded';
+    console[level](msg);
+    appendLog(clog, '[' + level + '] ' + msg, level === 'warn' ? 'warn' : 'log');
+  }
+  consoleCount += n;
+  document.getElementById('console-count').textContent = consoleCount;
+}
+
+function fireConsoleErrors(n) {
+  for (var i = 0; i < n; i++) {
+    var msg = 'SMOKE_ERROR_' + Date.now() + '_' + i;
+    console.error(msg);
+    appendLog(clog, '[error] ' + msg, 'error');
+    incError();
+  }
+}
+
+function fireSmokeMarker() {
+  var marker = 'SMOKE_' + Date.now();
+  console.log(marker + '_LOG');
+  console.error(marker + '_ERROR');
+  appendLog(clog, '[log]   ' + marker + '_LOG', 'log');
+  appendLog(clog, '[error] ' + marker + '_ERROR', 'error');
+  incError();
+  var el = document.getElementById('console-count');
+  consoleCount += 2;
+  el.textContent = consoleCount;
+}
+
+// Auto-fire on load: 100 messages to seed observe(logs) buffer
+window.addEventListener('load', function() {
+  // Stagger slightly to avoid blocking
+  setTimeout(function() { fireConsoleSpam(70); }, 100);
+  setTimeout(function() { fireConsoleErrors(30); }, 200);
+});
+
+// ── §2: Network Chaos ────────────────────────────────────────────────────────
+var nlog = document.getElementById('net-log');
+
+function doFetch(url, label) {
+  appendLog(nlog, 'fetching ' + label + '…', 'system');
+  return fetch(url)
+    .then(function(r) {
+      appendLog(nlog, '[' + r.status + '] ' + label, r.ok ? 'log' : 'error');
+      if (!r.ok) incNetError();
+    })
+    .catch(function(e) {
+      appendLog(nlog, '[error] ' + label + ': ' + e.message, 'error');
+      incNetError();
+    });
+}
+
+function fetch404() { doFetch('/tests/404', '/404'); }
+function fetch500() { doFetch('/tests/500', '/500'); }
+function fetchCors() { doFetch('https://api.example.com/cors-blocked', 'CORS external'); }
+function fetchSlow() { doFetch('/tests/slow', '/slow (3s)'); }
+
+// Auto-fire on load
+window.addEventListener('load', function() {
+  setTimeout(function() {
+    fetch404();
+    fetch500();
+    fetchCors();
+  }, 300);
+});
+
+// ── §3: WebSocket ─────────────────────────────────────────────────────────────
+var ws    = null;
+var wslog = document.getElementById('ws-log');
+
+function setWsStatus(state, color) {
+  var dot    = document.getElementById('ws-dot');
+  var sdot   = document.getElementById('ws-section-dot');
+  var status = document.getElementById('ws-status');
+  status.textContent = state;
+  status.style.color = color;
+  dot.style.background  = color;
+  sdot.style.background = color;
+  sdot.style.animation  = state === 'Connecting' ? 'pulse 1.2s infinite' : '';
+  if (color === 'var(--green)') {
+    dot.className = 'dot dot-green';
+  }
+}
+
+function wsConnect() {
+  var host = window.location.host || 'localhost:8080';
+  setWsStatus('Connecting', 'var(--amber)');
+  appendLog(wslog, 'Connecting to ws://' + host + '/ws…', 'system');
+  ws = new WebSocket('ws://' + host + '/tests/ws');
+
+  ws.onopen = function() {
+    setWsStatus('Connected', 'var(--green)');
+    appendLog(wslog, 'Connected — ws://' + host + '/tests/ws', 'ws');
+    ws.send(JSON.stringify({ hello: 'gasoline-harness', ts: Date.now() }));
+  };
+  ws.onmessage = function(e) {
+    appendLog(wslog, 'recv: ' + e.data.slice(0, 120), 'ws');
+  };
+  ws.onclose = function(e) {
+    setWsStatus('Closed (' + e.code + ')', 'var(--text-dim)');
+    appendLog(wslog, 'Closed — code=' + e.code + ' reason=' + (e.reason || '(none)'), 'system');
+  };
+  ws.onerror = function() {
+    setWsStatus('Error', 'var(--red)');
+    appendLog(wslog, 'WebSocket error — is server.py running?', 'error');
+  };
+}
+
+function wsSend() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) { wsConnect(); return; }
+  var msg = JSON.stringify({ ping: 'smoke', ts: Date.now() });
+  ws.send(msg);
+  appendLog(wslog, 'sent: ' + msg, 'log');
+}
+function wsSendBinary() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) { wsConnect(); return; }
+  var buf = new Uint8Array([0xDE,0xAD,0xBE,0xEF,0x00,0x01,0x02,0x03]);
+  ws.send(buf.buffer);
+  appendLog(wslog, 'sent binary: 8 bytes', 'log');
+}
+function wsAbnormalClose() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    appendLog(wslog, 'Not connected', 'warn'); return;
+  }
+  ws.close(1001, 'abnormal-test-close');
+  appendLog(wslog, 'Closing with code 1001…', 'warn');
+}
+function wsReconnect() {
+  if (ws) ws.close(1000);
+  setTimeout(wsConnect, 300);
+}
+
+window.addEventListener('load', function() {
+  setTimeout(wsConnect, 500);
+});
+
+// ── §4: Error Bombs ──────────────────────────────────────────────────────────
+var errResult = document.getElementById('error-result');
+
+function setErrResult(msg) {
+  errResult.textContent = msg;
+  errResult.className = 'gh-status err';
+  incError();
+}
+
+function throwTypeError() {
+  try {
+    var x = null;
+    x.foo.bar.baz;
+  } catch(e) {
+    console.error('TypeError:', e.message, e.stack);
+    setErrResult('TypeError: ' + e.message);
+  }
+}
+function throwReferenceError() {
+  try {
+    (function deep1() {
+      (function deep2() {
+        undeclaredVariable.access; // eslint-disable-line
+      })();
+    })();
+  } catch(e) {
+    console.error('ReferenceError:', e.message, e.stack);
+    setErrResult('ReferenceError: ' + e.message);
+  }
+}
+function throwUnhandledPromise() {
+  Promise.reject(new Error('SMOKE_UNHANDLED_REJECTION_' + Date.now()));
+  setErrResult('UnhandledPromiseRejection fired — check observe(errors)');
+  incError();
+}
+function throwDeepStack() {
+  function a() { b(); }
+  function b() { c(); }
+  function c() { throw new Error('SMOKE_DEEP_STACK_' + Date.now()); }
+  try { a(); } catch(e) {
+    console.error('DeepStack:', e.message, e.stack);
+    setErrResult('DeepStack: ' + e.message);
+  }
+}
+
+// ── §5: Action Capture feedback ──────────────────────────────────────────────
+var actionResult = document.getElementById('action-result');
+function showAction(msg) {
+  actionResult.textContent = msg;
+  actionResult.className = 'gh-status ok';
+}
+document.getElementById('action-text').addEventListener('input', function(e) {
+  showAction('input event on #action-text — value="' + e.target.value + '"');
+});
+document.getElementById('action-select').addEventListener('change', function(e) {
+  showAction('change event on #action-select — value="' + e.target.value + '"');
+});
+document.getElementById('action-btn-primary').addEventListener('click', function() {
+  showAction('click on #action-btn-primary');
+});
+document.getElementById('action-btn-secondary').addEventListener('click', function() {
+  showAction('click on #action-btn-secondary');
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Replaces the Python dev server with Go-embedded test pages served by the daemon at `/tests/` — zero external setup needed for smoke tests
- Adds a zero-dependency WebSocket echo server at `/tests/ws` (RFC 6455, stdlib only, using `http.Hijacker`)
- Adds deterministic error endpoints: `/tests/404`, `/tests/500`, `/tests/cors-test`, `/tests/slow`
- Five purpose-built pages cover all harness test cases: Interaction Gauntlet, Noise Factory, Performance Nightmare, Accessibility Disaster, Recording Test Page
- Shared `gasoline.css` dark-theme design system across all pages

## Pages

| Page | Purpose | Tests |
|------|---------|-------|
| `index.html` | Hub + live WS status probe | — |
| `interact.html` | All DOM primitives, ambiguous targets, delayed elements, React-style input, overlay trap | 5.x |
| `telemetry.html` | 100+ console events, network chaos (404/500/CORS), WS arena, error bombs | 2.x |
| `performance.html` | Delayed LCP, CLS bomb at 1.5s, 800ms long task, User Timing marks | 9.x |
| `a11y.html` | WCAG violations: contrast, missing ARIA, broken labels, heading order, no landmarks | axe/SARIF |
| `recording.html` | YouTube embed + watermark detection for tab recording tests | 10.x |

## Code quality

All issues from a principal engineer + QA review were addressed in the second commit:

**WebSocket codec (correctness):**
- DoS via unbounded frame allocation — capped at 1 MiB (`maxWSPayload`)
- 8-byte length encoding was wrong (only low 4 bytes) — fixed per RFC 6455 §5.2
- Continuation frames (opcode `0x0`) were silently dropped — full fragmentation reassembly implemented
- Hard 60s wall-clock deadline → per-read idle timeout (`SetReadDeadline` refreshed each frame)
- `fs.Sub` error was silently ignored → `panic` with descriptive message

**HTML/JS fixes:**
- `throwUnhandledPromise` double-incremented `errorCount` — removed extra call
- `ltCount` double-incremented in `performance.html` — PerformanceObserver is now sole source of truth
- LCP `data:` URI → `blob:` URL (Chrome excludes `data:` images from LCP candidates)
- `.cls-box` CSS transition removed — animated shifts don't register as CLS entries
- `a11y.html` contrast ratio for `.v-contrast-fail-1` was actually passing AA (~6.6:1); fixed to `#777777` (~3.5:1, correctly fails)
- Stale "is server.py running?" error messages replaced with daemon reference
- `sf-link` href aligned with injected form (`https://example.com/test`)
- `pagehide` handlers added to all pages with WebSocket connections

## Test plan

- [ ] `go build ./cmd/dev-console/...` passes (verified)
- [ ] `go vet ./cmd/dev-console/...` passes (verified)
- [ ] Navigate to `http://localhost:7890/tests/` — index page loads with live WS dot turning green
- [ ] `/tests/interact.html` — all smoke form IDs present, scroll target at 2000px
- [ ] `/tests/telemetry.html` — 100 console messages fire on load, WS connects, error bombs work
- [ ] `/tests/performance.html` — LCP image appears at ~2s, CLS shifts at 1.5s, long task blocks
- [ ] `/tests/a11y.html` — `analyze(accessibility)` flags contrast, missing ARIA, heading order
- [ ] `/tests/recording.html` — YouTube iframe loads, `checkWatermark()` returns correct sentinel
- [ ] `/tests/404`, `/tests/500`, `/tests/cors-test`, `/tests/slow` return correct status/headers
- [ ] `wscat ws://localhost:7890/tests/ws` — sends echo JSON response; large/fragmented frames handled

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)