### PR TITLE
feat: add cross-project annotation scope guardrails

### DIFF
--- a/cmd/dev-console/testdata/mcp-tools-list.golden.json
+++ b/cmd/dev-console/testdata/mcp-tools-list.golden.json
@@ -415,6 +415,14 @@
           "description": "Timeout ms (link_health, page_summary, annotations). For annotations with wait=true: default 15000 (15s), max 600000 (10 min).",
           "type": "number"
         },
+        "url": {
+          "description": "Annotation URL scope filter (annotations). Supports exact URL, project base URL, or wildcard patterns such as http://localhost:3000/*.",
+          "type": "string"
+        },
+        "url_pattern": {
+          "description": "Alias for annotation URL scope filter (annotations). Use either url or url_pattern.",
+          "type": "string"
+        },
         "urls": {
           "description": "URLs to validate (link_validation)",
           "items": {

--- a/cmd/dev-console/tools_analyze_annotations_handlers.go
+++ b/cmd/dev-console/tools_analyze_annotations_handlers.go
@@ -6,6 +6,8 @@ package main
 
 import (
 	"encoding/json"
+	"net/url"
+	"sort"
 	"strings"
 	"time"
 )
@@ -28,9 +30,16 @@ func (h *ToolHandler) toolGetAnnotations(req JSONRPCRequest, args json.RawMessag
 		Operation    string `json:"operation"`
 		Correlation  string `json:"correlation_id"`
 		TimeoutMs    int    `json:"timeout_ms"`
+		URL          string `json:"url"`
+		URLPattern   string `json:"url_pattern"`
 	}
 	if len(args) > 0 {
 		lenientUnmarshal(args, &params)
+	}
+
+	urlFilter, filterResp, hasFilterErr := resolveAnnotationURLFilter(req, params.URL, params.URLPattern)
+	if hasFilterErr {
+		return filterResp
 	}
 
 	operation := strings.ToLower(strings.TrimSpace(params.Operation))
@@ -47,9 +56,9 @@ func (h *ToolHandler) toolGetAnnotations(req JSONRPCRequest, args json.RawMessag
 
 	waitTimeout := annotationBlockingWaitDuration(params.TimeoutMs)
 	if params.AnnotSession != "" {
-		return h.getNamedAnnotations(req, params.AnnotSession, params.Wait, waitTimeout)
+		return h.getNamedAnnotations(req, params.AnnotSession, params.Wait, waitTimeout, urlFilter)
 	}
-	return h.getAnonymousAnnotations(req, params.Wait, waitTimeout)
+	return h.getAnonymousAnnotations(req, params.Wait, waitTimeout, urlFilter)
 }
 
 func annotationBlockingWaitDuration(timeoutMs int) time.Duration {
@@ -63,25 +72,26 @@ func annotationBlockingWaitDuration(timeoutMs int) time.Duration {
 	return waitDuration
 }
 
-func (h *ToolHandler) getAnonymousAnnotations(req JSONRPCRequest, wait bool, waitTimeout time.Duration) JSONRPCResponse {
+func (h *ToolHandler) getAnonymousAnnotations(req JSONRPCRequest, wait bool, waitTimeout time.Duration, urlFilter string) JSONRPCResponse {
 	if wait {
 		if session := h.annotationStore.GetLatestSessionSinceDraw(); session != nil {
-			return h.formatAnnotationSession(req, session)
+			return h.formatAnnotationSession(req, session, urlFilter)
 		}
 
 		if session, _ := h.annotationStore.WaitForSession(waitTimeout); session != nil {
-			return h.formatAnnotationSession(req, session)
+			return h.formatAnnotationSession(req, session, urlFilter)
 		}
 
 		corrID := newCorrelationID("ann")
 		h.capture.RegisterCommand(corrID, "", annotationWaitCommandTTL)
-		h.annotationStore.RegisterWaiter(corrID, "")
+		h.annotationStore.RegisterWaiter(corrID, "", urlFilter)
 
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Waiting for annotations", map[string]any{
 			"status":         "waiting_for_user",
 			"correlation_id": corrID,
 			"annotations":    []any{},
 			"count":          0,
+			"filter_applied": annotationFilterAppliedValue(urlFilter),
 			"message":        "Draw mode is active. The user is drawing annotations. Poll with observe({what: 'command_result', correlation_id: '" + corrID + "'}) to check for results.",
 		})}
 	}
@@ -89,32 +99,33 @@ func (h *ToolHandler) getAnonymousAnnotations(req JSONRPCRequest, wait bool, wai
 	session := h.annotationStore.GetLatestSession()
 	if session == nil {
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("No annotations", map[string]any{
-			"annotations": []any{},
-			"count":       0,
-			"message":     "No annotation session found. Use interact({action: 'draw_mode_start'}) to activate draw mode, then the user draws annotations and presses ESC to finish.",
+			"annotations":    []any{},
+			"count":          0,
+			"filter_applied": annotationFilterAppliedValue(urlFilter),
+			"message":        "No annotation session found. Use interact({action: 'draw_mode_start'}) to activate draw mode, then the user draws annotations and presses ESC to finish.",
 		})}
 	}
-	return h.formatAnnotationSession(req, session)
+	return h.formatAnnotationSession(req, session, urlFilter)
 }
 
-func (h *ToolHandler) formatAnnotationSession(req JSONRPCRequest, session *AnnotationSession) JSONRPCResponse {
-	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Annotations retrieved", buildAnnotationSessionResult(session))}
+func (h *ToolHandler) formatAnnotationSession(req JSONRPCRequest, session *AnnotationSession, urlFilter string) JSONRPCResponse {
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Annotations retrieved", buildAnnotationSessionResult(session, urlFilter))}
 }
 
 // #lizard forgives
-func (h *ToolHandler) getNamedAnnotations(req JSONRPCRequest, sessionName string, wait bool, waitTimeout time.Duration) JSONRPCResponse {
+func (h *ToolHandler) getNamedAnnotations(req JSONRPCRequest, sessionName string, wait bool, waitTimeout time.Duration, urlFilter string) JSONRPCResponse {
 	if wait {
 		if ns := h.annotationStore.GetNamedSessionSinceDraw(sessionName); ns != nil {
-			return h.formatNamedAnnotationSession(req, ns)
+			return h.formatNamedAnnotationSession(req, ns, urlFilter)
 		}
 
 		if ns, _ := h.annotationStore.WaitForNamedSession(sessionName, waitTimeout); ns != nil {
-			return h.formatNamedAnnotationSession(req, ns)
+			return h.formatNamedAnnotationSession(req, ns, urlFilter)
 		}
 
 		corrID := newCorrelationID("ann")
 		h.capture.RegisterCommand(corrID, "", annotationWaitCommandTTL)
-		h.annotationStore.RegisterWaiter(corrID, sessionName)
+		h.annotationStore.RegisterWaiter(corrID, sessionName, urlFilter)
 
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Waiting for annotations", map[string]any{
 			"status":             "waiting_for_user",
@@ -123,6 +134,7 @@ func (h *ToolHandler) getNamedAnnotations(req JSONRPCRequest, sessionName string
 			"pages":              []any{},
 			"page_count":         0,
 			"total_count":        0,
+			"filter_applied":     annotationFilterAppliedValue(urlFilter),
 			"message":            "Draw mode is active. The user is drawing annotations. Poll with observe({what: 'command_result', correlation_id: '" + corrID + "'}) to check for results.",
 		})}
 	}
@@ -134,36 +146,54 @@ func (h *ToolHandler) getNamedAnnotations(req JSONRPCRequest, sessionName string
 			"pages":              []any{},
 			"page_count":         0,
 			"total_count":        0,
+			"filter_applied":     annotationFilterAppliedValue(urlFilter),
 			"message":            "Named session '" + sessionName + "' not found. Use interact({action: 'draw_mode_start', annot_session: '" + sessionName + "'}) to start.",
 		})}
 	}
 
-	return h.formatNamedAnnotationSession(req, ns)
+	return h.formatNamedAnnotationSession(req, ns, urlFilter)
 }
 
-func (h *ToolHandler) formatNamedAnnotationSession(req JSONRPCRequest, ns *NamedAnnotationSession) JSONRPCResponse {
-	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Annotations retrieved", buildNamedAnnotationSessionResult(ns))}
+func (h *ToolHandler) formatNamedAnnotationSession(req JSONRPCRequest, ns *NamedAnnotationSession, urlFilter string) JSONRPCResponse {
+	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Annotations retrieved", buildNamedAnnotationSessionResult(ns, urlFilter))}
 }
 
-func buildAnnotationSessionResult(session *AnnotationSession) map[string]any {
-	result := map[string]any{
-		"annotations": session.Annotations,
-		"count":       len(session.Annotations),
-		"page_url":    session.PageURL,
+func buildAnnotationSessionResult(session *AnnotationSession, urlFilter string) map[string]any {
+	matched := annotationURLMatches(urlFilter, session.PageURL)
+	annotations := session.Annotations
+	if !matched {
+		annotations = []Annotation{}
 	}
-	if session.ScreenshotPath != "" {
+
+	result := map[string]any{
+		"annotations":    annotations,
+		"count":          len(annotations),
+		"page_url":       session.PageURL,
+		"filter_applied": annotationFilterAppliedValue(urlFilter),
+	}
+	if session.ScreenshotPath != "" && matched {
 		result["screenshot"] = session.ScreenshotPath
 	}
-	if len(session.Annotations) > 0 {
+	projects := buildProjectSummaries([]*AnnotationSession{session})
+	if len(projects) > 0 {
+		result["projects"] = projects
+	}
+	if !matched && urlFilter != "" {
+		result["message"] = "No annotations match the requested url filter."
+	}
+	if len(annotations) > 0 {
 		result["hints"] = buildSessionHints(session.ScreenshotPath)
 	}
 	return result
 }
 
-func buildNamedAnnotationSessionResult(ns *NamedAnnotationSession) map[string]any {
+func buildNamedAnnotationSessionResult(ns *NamedAnnotationSession, urlFilter string) map[string]any {
+	allProjects := buildProjectSummaries(ns.Pages)
+	filteredPages := filterAnnotationPages(ns.Pages, urlFilter)
+
 	totalCount := 0
-	pages := make([]map[string]any, 0, len(ns.Pages))
-	for _, page := range ns.Pages {
+	pages := make([]map[string]any, 0, len(filteredPages))
+	for _, page := range filteredPages {
 		totalCount += len(page.Annotations)
 		p := map[string]any{
 			"page_url":    page.PageURL,
@@ -179,7 +209,7 @@ func buildNamedAnnotationSessionResult(ns *NamedAnnotationSession) map[string]an
 
 	// Find first screenshot for hints
 	var screenshotPath string
-	for _, page := range ns.Pages {
+	for _, page := range filteredPages {
 		if page.ScreenshotPath != "" {
 			screenshotPath = page.ScreenshotPath
 			break
@@ -189,13 +219,181 @@ func buildNamedAnnotationSessionResult(ns *NamedAnnotationSession) map[string]an
 	result := map[string]any{
 		"annot_session_name": ns.Name,
 		"pages":              pages,
-		"page_count":         len(ns.Pages),
+		"page_count":         len(filteredPages),
 		"total_count":        totalCount,
+		"filter_applied":     annotationFilterAppliedValue(urlFilter),
+	}
+	if len(allProjects) > 0 {
+		result["projects"] = allProjects
+	}
+	if len(allProjects) > 1 && urlFilter == "" {
+		result["scope_ambiguous"] = true
+		result["scope_warning"] = buildScopeWarning(allProjects)
+	}
+	if len(filteredPages) == 0 && urlFilter != "" {
+		result["message"] = "No pages in this annotation session match the requested url filter."
 	}
 	if totalCount > 0 {
 		result["hints"] = buildSessionHints(screenshotPath)
 	}
 	return result
+}
+
+func resolveAnnotationURLFilter(req JSONRPCRequest, urlValue, urlPatternValue string) (string, JSONRPCResponse, bool) {
+	urlValue = strings.TrimSpace(urlValue)
+	urlPatternValue = strings.TrimSpace(urlPatternValue)
+	if urlValue != "" && urlPatternValue != "" && urlValue != urlPatternValue {
+		return "", JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: mcpStructuredError(
+				ErrInvalidParam,
+				"Conflicting annotation scope filters: 'url' and 'url_pattern' differ",
+				"Provide only one annotation scope filter, or set both to the same value.",
+				withParam("url"),
+				withParam("url_pattern"),
+			),
+		}, true
+	}
+	if urlPatternValue != "" {
+		return urlPatternValue, JSONRPCResponse{}, false
+	}
+	return urlValue, JSONRPCResponse{}, false
+}
+
+func annotationFilterAppliedValue(urlFilter string) string {
+	if strings.TrimSpace(urlFilter) == "" {
+		return "none"
+	}
+	return urlFilter
+}
+
+func filterAnnotationPages(pages []*AnnotationSession, urlFilter string) []*AnnotationSession {
+	if strings.TrimSpace(urlFilter) == "" {
+		return pages
+	}
+	filtered := make([]*AnnotationSession, 0, len(pages))
+	for _, page := range pages {
+		if annotationURLMatches(urlFilter, page.PageURL) {
+			filtered = append(filtered, page)
+		}
+	}
+	return filtered
+}
+
+func annotationURLMatches(urlFilter, pageURL string) bool {
+	urlFilter = strings.TrimSpace(urlFilter)
+	if urlFilter == "" {
+		return true
+	}
+	pageURL = strings.TrimSpace(pageURL)
+	if pageURL == "" {
+		return false
+	}
+
+	if strings.Contains(urlFilter, "*") {
+		prefix := strings.ReplaceAll(urlFilter, "*", "")
+		return strings.HasPrefix(pageURL, prefix)
+	}
+
+	if strings.HasSuffix(urlFilter, "/") {
+		prefix := strings.TrimSuffix(urlFilter, "/")
+		return strings.HasPrefix(pageURL, prefix)
+	}
+
+	parsed, err := url.Parse(urlFilter)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Path == "" || parsed.Path == "/") {
+		base := strings.TrimSuffix(urlFilter, "/")
+		return strings.HasPrefix(pageURL, base)
+	}
+
+	return pageURL == urlFilter
+}
+
+func buildProjectSummaries(pages []*AnnotationSession) []map[string]any {
+	type projectAggregate struct {
+		pageSet         map[string]struct{}
+		annotationCount int
+	}
+	projects := make(map[string]*projectAggregate)
+	for _, page := range pages {
+		baseURL := annotationProjectBaseURL(page.PageURL)
+		if strings.TrimSpace(baseURL) == "" {
+			continue
+		}
+		agg, ok := projects[baseURL]
+		if !ok {
+			agg = &projectAggregate{
+				pageSet: make(map[string]struct{}),
+			}
+			projects[baseURL] = agg
+		}
+		agg.annotationCount += len(page.Annotations)
+		if strings.TrimSpace(page.PageURL) != "" {
+			agg.pageSet[page.PageURL] = struct{}{}
+		}
+	}
+
+	if len(projects) == 0 {
+		return nil
+	}
+	baseURLs := make([]string, 0, len(projects))
+	for baseURL := range projects {
+		baseURLs = append(baseURLs, baseURL)
+	}
+	sort.Strings(baseURLs)
+
+	summaries := make([]map[string]any, 0, len(baseURLs))
+	for _, baseURL := range baseURLs {
+		agg := projects[baseURL]
+		pageURLs := make([]string, 0, len(agg.pageSet))
+		for pageURL := range agg.pageSet {
+			pageURLs = append(pageURLs, pageURL)
+		}
+		sort.Strings(pageURLs)
+		summary := map[string]any{
+			"base_url":           baseURL,
+			"annotation_count":   agg.annotationCount,
+			"page_count":         len(pageURLs),
+			"recommended_filter": baseURL + "/*",
+		}
+		if len(pageURLs) > 0 {
+			summary["page_urls"] = pageURLs
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries
+}
+
+func buildScopeWarning(projects []map[string]any) map[string]any {
+	suggestedFilters := make([]string, 0, len(projects))
+	projectBaseURLs := make([]string, 0, len(projects))
+	for _, project := range projects {
+		if filter, ok := project["recommended_filter"].(string); ok && filter != "" {
+			suggestedFilters = append(suggestedFilters, filter)
+		}
+		if baseURL, ok := project["base_url"].(string); ok && baseURL != "" {
+			projectBaseURLs = append(projectBaseURLs, baseURL)
+		}
+	}
+	return map[string]any{
+		"warning":           "MULTI-PROJECT ANNOTATION SESSION DETECTED: annotations span multiple projects.",
+		"recommendation":    "Re-run analyze({what:'annotations'}) with 'url' or 'url_pattern' scoped to the active project before implementing changes.",
+		"suggested_filters": suggestedFilters,
+		"projects_detected": projectBaseURLs,
+	}
+}
+
+func annotationProjectBaseURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return rawURL
+	}
+	return parsed.Scheme + "://" + parsed.Host
 }
 
 // toolFlushAnnotations forces completion of a pending annotation waiter.
@@ -220,14 +418,14 @@ func (h *ToolHandler) toolFlushAnnotations(req JSONRPCRequest, correlationID str
 	}
 
 	// Remove waiter first so later session writes cannot re-complete the same flush target.
-	sessionName, _ := h.annotationStore.TakeWaiter(correlationID)
+	sessionName, waiterURLFilter, _ := h.annotationStore.TakeWaiter(correlationID)
 
 	// Idempotent behavior: if the command is already terminal, return current state.
 	if cmd, found := h.capture.GetCommandResult(correlationID); found && cmd != nil && cmd.Status != "pending" {
 		return h.formatCommandResult(req, *cmd, correlationID)
 	}
 
-	payload := h.buildFlushedAnnotationResult(sessionName)
+	payload := h.buildFlushedAnnotationResult(sessionName, waiterURLFilter)
 	h.capture.ApplyCommandResult(correlationID, "complete", payload, "")
 
 	// Normal path: return canonical command_result envelope.
@@ -246,10 +444,10 @@ func (h *ToolHandler) toolFlushAnnotations(req JSONRPCRequest, correlationID str
 	return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpJSONResponse("Annotation flush completed", data)}
 }
 
-func (h *ToolHandler) buildFlushedAnnotationResult(sessionName string) json.RawMessage {
+func (h *ToolHandler) buildFlushedAnnotationResult(sessionName string, urlFilter string) json.RawMessage {
 	if sessionName != "" {
 		if ns := h.annotationStore.GetNamedSession(sessionName); ns != nil {
-			data := buildNamedAnnotationSessionResult(ns)
+			data := buildNamedAnnotationSessionResult(ns, urlFilter)
 			data["status"] = "complete"
 			data["terminal_reason"] = "flushed"
 			encoded, _ := json.Marshal(data)
@@ -262,6 +460,7 @@ func (h *ToolHandler) buildFlushedAnnotationResult(sessionName string) json.RawM
 			"pages":              []any{},
 			"page_count":         0,
 			"total_count":        0,
+			"filter_applied":     annotationFilterAppliedValue(urlFilter),
 			"terminal_reason":    "abandoned",
 			"message":            "Annotation waiter flushed with no named-session annotations available.",
 		})
@@ -269,7 +468,7 @@ func (h *ToolHandler) buildFlushedAnnotationResult(sessionName string) json.RawM
 	}
 
 	if session := h.annotationStore.GetLatestSession(); session != nil {
-		data := buildAnnotationSessionResult(session)
+		data := buildAnnotationSessionResult(session, urlFilter)
 		data["status"] = "complete"
 		data["terminal_reason"] = "flushed"
 		encoded, _ := json.Marshal(data)
@@ -280,6 +479,7 @@ func (h *ToolHandler) buildFlushedAnnotationResult(sessionName string) json.RawM
 		"status":          "complete",
 		"annotations":     []any{},
 		"count":           0,
+		"filter_applied":  annotationFilterAppliedValue(urlFilter),
 		"terminal_reason": "abandoned",
 		"message":         "Annotation waiter flushed with no captured annotations available.",
 	})

--- a/cmd/dev-console/tools_analyze_annotations_handlers.go
+++ b/cmd/dev-console/tools_analyze_annotations_handlers.go
@@ -51,7 +51,7 @@ func (h *ToolHandler) toolGetAnnotations(req JSONRPCRequest, args json.RawMessag
 				Result:  mcpStructuredError(ErrInvalidParam, "Invalid annotations operation: "+params.Operation, "Use operation='flush' for annotation waiter recovery.", withParam("operation"), withHint("flush")),
 			}
 		}
-		return h.toolFlushAnnotations(req, params.Correlation)
+		return h.toolFlushAnnotations(req, params.Correlation, urlFilter)
 	}
 
 	waitTimeout := annotationBlockingWaitDuration(params.TimeoutMs)
@@ -291,20 +291,49 @@ func annotationURLMatches(urlFilter, pageURL string) bool {
 		return false
 	}
 
+	// Support wildcard suffix filters like http://localhost:3000/*.
+	if strings.HasSuffix(urlFilter, "/*") {
+		return annotationURLMatches(strings.TrimSuffix(urlFilter, "*"), pageURL)
+	}
 	if strings.Contains(urlFilter, "*") {
 		prefix := strings.ReplaceAll(urlFilter, "*", "")
 		return strings.HasPrefix(pageURL, prefix)
 	}
 
-	if strings.HasSuffix(urlFilter, "/") {
-		prefix := strings.TrimSuffix(urlFilter, "/")
-		return strings.HasPrefix(pageURL, prefix)
+	filterURL, filterErr := url.Parse(urlFilter)
+	page, pageErr := url.Parse(pageURL)
+	if filterErr == nil && pageErr == nil &&
+		filterURL.Scheme != "" && filterURL.Host != "" &&
+		page.Scheme != "" && page.Host != "" {
+		if !strings.EqualFold(filterURL.Scheme, page.Scheme) || !strings.EqualFold(filterURL.Host, page.Host) {
+			return false
+		}
+
+		filterPath := strings.TrimSpace(filterURL.Path)
+		switch {
+		case filterPath == "", filterPath == "/":
+			// Base URL filter: match any path on the same origin.
+			return true
+		case strings.HasSuffix(filterPath, "/"):
+			// Path prefix filter.
+			return strings.HasPrefix(page.Path, filterPath)
+		default:
+			// Exact path filter. Query/fragment are optional constraints when provided.
+			if page.Path != filterPath {
+				return false
+			}
+			if filterURL.RawQuery != "" && page.RawQuery != filterURL.RawQuery {
+				return false
+			}
+			if filterURL.Fragment != "" && page.Fragment != filterURL.Fragment {
+				return false
+			}
+			return true
+		}
 	}
 
-	parsed, err := url.Parse(urlFilter)
-	if err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Path == "" || parsed.Path == "/") {
-		base := strings.TrimSuffix(urlFilter, "/")
-		return strings.HasPrefix(pageURL, base)
+	if strings.HasSuffix(urlFilter, "/") {
+		return strings.HasPrefix(pageURL, urlFilter)
 	}
 
 	return pageURL == urlFilter
@@ -398,7 +427,7 @@ func annotationProjectBaseURL(rawURL string) string {
 
 // toolFlushAnnotations forces completion of a pending annotation waiter.
 // This is a recovery path for stuck waiters that would otherwise remain pending.
-func (h *ToolHandler) toolFlushAnnotations(req JSONRPCRequest, correlationID string) JSONRPCResponse {
+func (h *ToolHandler) toolFlushAnnotations(req JSONRPCRequest, correlationID string, fallbackURLFilter string) JSONRPCResponse {
 	correlationID = strings.TrimSpace(correlationID)
 	if correlationID == "" {
 		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(
@@ -425,7 +454,12 @@ func (h *ToolHandler) toolFlushAnnotations(req JSONRPCRequest, correlationID str
 		return h.formatCommandResult(req, *cmd, correlationID)
 	}
 
-	payload := h.buildFlushedAnnotationResult(sessionName, waiterURLFilter)
+	effectiveURLFilter := waiterURLFilter
+	if strings.TrimSpace(effectiveURLFilter) == "" {
+		effectiveURLFilter = fallbackURLFilter
+	}
+
+	payload := h.buildFlushedAnnotationResult(sessionName, effectiveURLFilter)
 	h.capture.ApplyCommandResult(correlationID, "complete", payload, "")
 
 	// Normal path: return canonical command_result envelope.

--- a/cmd/dev-console/tools_analyze_annotations_test.go
+++ b/cmd/dev-console/tools_analyze_annotations_test.go
@@ -929,6 +929,33 @@ func TestToolGetAnnotations_AnonymousURLFilterNoMatch(t *testing.T) {
 	}
 }
 
+func TestToolGetAnnotations_AnonymousBaseURLFilter_DoesNotCrossPortPrefix(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	h.annotationStore.StoreSession(1, &AnnotationSession{
+		TabID:       1,
+		Timestamp:   time.Now().UnixMilli(),
+		PageURL:     "http://localhost:30001/dashboard",
+		Annotations: []Annotation{{Text: "wrong project by port"}},
+	})
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","url":"http://localhost:3000"}`))
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	if data["count"] != float64(0) {
+		t.Fatalf("expected base-url filter to reject different port, got count %v", data["count"])
+	}
+}
+
 func TestToolGetAnnotations_ConflictingURLFilterParams(t *testing.T) {
 	h := createTestToolHandler(t)
 	h.annotationStore = NewAnnotationStore(10 * time.Minute)
@@ -940,6 +967,42 @@ func TestToolGetAnnotations_ConflictingURLFilterParams(t *testing.T) {
 
 	if !strings.Contains(text, "Conflicting annotation scope filters") {
 		t.Fatalf("expected conflicting filter validation error, got: %s", text)
+	}
+}
+
+func TestToolGetAnnotations_Flush_UsesExplicitURLFilterWhenWaiterMissing(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	h.annotationStore.StoreSession(1, &AnnotationSession{
+		TabID:       1,
+		Timestamp:   time.Now().UnixMilli(),
+		PageURL:     "http://localhost:5173/dashboard",
+		Annotations: []Annotation{{Text: "wrong project"}},
+	})
+
+	corrID := "ann_flush_filter_fallback"
+	h.capture.RegisterCommand(corrID, "", annotationWaitCommandTTL)
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","operation":"flush","correlation_id":"`+corrID+`","url":"http://localhost:3000/*"}`))
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		t.Fatalf("failed to parse flush response: %v", err)
+	}
+	resultPayload, ok := data["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result payload object, got: %T", data["result"])
+	}
+	if resultPayload["count"] != float64(0) {
+		t.Fatalf("expected explicit flush filter to scope result, got count %v", resultPayload["count"])
+	}
+	if resultPayload["filter_applied"] != "http://localhost:3000/*" {
+		t.Fatalf("expected filter_applied from explicit flush filter, got %v", resultPayload["filter_applied"])
 	}
 }
 

--- a/cmd/dev-console/tools_analyze_annotations_test.go
+++ b/cmd/dev-console/tools_analyze_annotations_test.go
@@ -412,6 +412,9 @@ func TestToolGetAnnotations_Flush_CompletesPendingCommand_WithEmptyResultReason(
 	if resultPayload["count"] != float64(0) {
 		t.Fatalf("result.count = %v, want 0", resultPayload["count"])
 	}
+	if resultPayload["filter_applied"] != "none" {
+		t.Fatalf("result.filter_applied = %v, want none", resultPayload["filter_applied"])
+	}
 
 	cmd, found := h.capture.GetCommandResult(corrID)
 	if !found || cmd == nil {
@@ -637,6 +640,95 @@ func TestToolGetAnnotations_WaitTrue_WaiterCompletedOnStore(t *testing.T) {
 	}
 }
 
+func TestToolGetAnnotations_WaitTrue_WaiterCompletedOnStore_UsesURLFilter(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	var completedResult json.RawMessage
+	h.annotationStore.SetCommandCompleter(func(_ string, result json.RawMessage) {
+		completedResult = result
+	})
+
+	h.annotationStore.MarkDrawStarted()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	args := json.RawMessage(`{"what":"annotations","wait":true,"timeout_ms":10,"url":"http://localhost:3000/*"}`)
+	resp := h.toolGetAnnotations(req, args)
+
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+	var data map[string]any
+	_ = json.Unmarshal([]byte(jsonText), &data)
+	if data["status"] != "waiting_for_user" {
+		t.Fatalf("expected waiting response, got %v", data["status"])
+	}
+
+	h.annotationStore.StoreSession(1, &AnnotationSession{
+		TabID:       1,
+		Timestamp:   time.Now().UnixMilli(),
+		PageURL:     "http://localhost:5173/dashboard",
+		Annotations: []Annotation{{Text: "not-in-scope"}},
+	})
+
+	var completed map[string]any
+	if err := json.Unmarshal(completedResult, &completed); err != nil {
+		t.Fatalf("failed to unmarshal completed result: %v", err)
+	}
+	if completed["count"] != float64(0) {
+		t.Fatalf("expected filtered async result count 0, got %v", completed["count"])
+	}
+	if completed["filter_applied"] != "http://localhost:3000/*" {
+		t.Fatalf("expected filter_applied in async result, got %v", completed["filter_applied"])
+	}
+}
+
+func TestToolGetAnnotations_WaitTrue_NamedWaiterCompletedOnStore_UsesURLFilter(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	var completedResult json.RawMessage
+	h.annotationStore.SetCommandCompleter(func(_ string, result json.RawMessage) {
+		completedResult = result
+	})
+
+	h.annotationStore.MarkDrawStarted()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	args := json.RawMessage(`{"what":"annotations","annot_session":"qa","wait":true,"timeout_ms":10,"url_pattern":"http://localhost:3000/*"}`)
+	resp := h.toolGetAnnotations(req, args)
+
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+	var data map[string]any
+	_ = json.Unmarshal([]byte(jsonText), &data)
+	if data["status"] != "waiting_for_user" {
+		t.Fatalf("expected waiting response, got %v", data["status"])
+	}
+
+	h.annotationStore.AppendToNamedSession("qa", &AnnotationSession{
+		TabID:       2,
+		Timestamp:   time.Now().UnixMilli(),
+		PageURL:     "http://localhost:5173/settings",
+		Annotations: []Annotation{{Text: "wrong-project"}},
+	})
+
+	var completed map[string]any
+	if err := json.Unmarshal(completedResult, &completed); err != nil {
+		t.Fatalf("failed to unmarshal completed result: %v", err)
+	}
+	if completed["page_count"] != float64(0) {
+		t.Fatalf("expected filtered named async page_count 0, got %v", completed["page_count"])
+	}
+	if completed["total_count"] != float64(0) {
+		t.Fatalf("expected filtered named async total_count 0, got %v", completed["total_count"])
+	}
+	if completed["filter_applied"] != "http://localhost:3000/*" {
+		t.Fatalf("expected filter_applied in named async result, got %v", completed["filter_applied"])
+	}
+}
+
 func TestToolGetAnnotations_WaitFalse_DefaultBehavior(t *testing.T) {
 	h := createTestToolHandler(t)
 	h.annotationStore = NewAnnotationStore(10 * time.Minute)
@@ -722,6 +814,132 @@ func TestToolGetAnnotations_NamedSession_NotFound(t *testing.T) {
 
 	if !strings.Contains(text, "not found") {
 		t.Errorf("expected not found message, got %q", text)
+	}
+}
+
+func TestToolGetAnnotations_NamedSession_MultiProjectScopeWarningWithoutFilter(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	h.annotationStore.AppendToNamedSession("qa", &AnnotationSession{
+		TabID:       1,
+		Timestamp:   100,
+		PageURL:     "http://localhost:3000/dashboard",
+		Annotations: []Annotation{{Text: "fix dashboard spacing"}},
+	})
+	h.annotationStore.AppendToNamedSession("qa", &AnnotationSession{
+		TabID:       2,
+		Timestamp:   200,
+		PageURL:     "http://localhost:5173/settings",
+		Annotations: []Annotation{{Text: "fix settings contrast"}},
+	})
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","annot_session":"qa"}`))
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	if data["scope_ambiguous"] != true {
+		t.Fatalf("expected scope_ambiguous=true, got %v", data["scope_ambiguous"])
+	}
+	if _, ok := data["scope_warning"].(map[string]any); !ok {
+		t.Fatalf("expected scope_warning object, got %T", data["scope_warning"])
+	}
+	projects, ok := data["projects"].([]any)
+	if !ok || len(projects) != 2 {
+		t.Fatalf("expected 2 project summaries, got %v", data["projects"])
+	}
+}
+
+func TestToolGetAnnotations_NamedSession_URLFilterScoped(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	h.annotationStore.AppendToNamedSession("qa", &AnnotationSession{
+		TabID:       1,
+		Timestamp:   100,
+		PageURL:     "http://localhost:3000/dashboard",
+		Annotations: []Annotation{{Text: "fix dashboard spacing"}},
+	})
+	h.annotationStore.AppendToNamedSession("qa", &AnnotationSession{
+		TabID:       2,
+		Timestamp:   200,
+		PageURL:     "http://localhost:5173/settings",
+		Annotations: []Annotation{{Text: "fix settings contrast"}, {Text: "fix settings tooltip"}},
+	})
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","annot_session":"qa","url":"http://localhost:5173/*"}`))
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	if data["filter_applied"] != "http://localhost:5173/*" {
+		t.Fatalf("expected filter_applied, got %v", data["filter_applied"])
+	}
+	if data["scope_ambiguous"] == true {
+		t.Fatalf("scope_ambiguous should be false when filter is applied")
+	}
+	if data["page_count"] != float64(1) {
+		t.Fatalf("expected page_count=1, got %v", data["page_count"])
+	}
+	if data["total_count"] != float64(2) {
+		t.Fatalf("expected total_count=2 for filtered page, got %v", data["total_count"])
+	}
+}
+
+func TestToolGetAnnotations_AnonymousURLFilterNoMatch(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	h.annotationStore.StoreSession(1, &AnnotationSession{
+		TabID:       1,
+		Timestamp:   time.Now().UnixMilli(),
+		PageURL:     "http://localhost:3000/dashboard",
+		Annotations: []Annotation{{Text: "fix dashboard spacing"}},
+	})
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","url":"http://localhost:5173/*"}`))
+	text := unmarshalMCPText(t, resp.Result)
+	jsonText := extractJSONFromText(text)
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	if data["count"] != float64(0) {
+		t.Fatalf("expected filtered count=0, got %v", data["count"])
+	}
+	if _, ok := data["message"].(string); !ok {
+		t.Fatalf("expected no-match message when url filter does not match")
+	}
+}
+
+func TestToolGetAnnotations_ConflictingURLFilterParams(t *testing.T) {
+	h := createTestToolHandler(t)
+	h.annotationStore = NewAnnotationStore(10 * time.Minute)
+	defer h.annotationStore.Close()
+
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: float64(1)}
+	resp := h.toolGetAnnotations(req, json.RawMessage(`{"what":"annotations","url":"http://localhost:3000/*","url_pattern":"http://localhost:5173/*"}`))
+	text := unmarshalMCPText(t, resp.Result)
+
+	if !strings.Contains(text, "Conflicting annotation scope filters") {
+		t.Fatalf("expected conflicting filter validation error, got: %s", text)
 	}
 }
 
@@ -881,10 +1099,10 @@ func TestToolGetAnnotationDetail_ErrorCorrelation(t *testing.T) {
 
 	// Store the detail
 	detail := AnnotationDetail{
-		CorrelationID: "detail_corr",
-		Selector:      "button.broken",
-		Tag:           "button",
-		Classes:       []string{"broken"},
+		CorrelationID:  "detail_corr",
+		Selector:       "button.broken",
+		Tag:            "button",
+		Classes:        []string{"broken"},
 		ComputedStyles: map[string]string{},
 	}
 	h.annotationStore.StoreDetail("detail_corr", detail)
@@ -894,7 +1112,7 @@ func TestToolGetAnnotationDetail_ErrorCorrelation(t *testing.T) {
 	h.server.entries = append(h.server.entries,
 		LogEntry{"level": "error", "message": "TypeError: Cannot read property 'click'", "ts": annotTS.Add(-2 * time.Second).UTC().Format(time.RFC3339)},
 		LogEntry{"level": "error", "message": "Uncaught ReferenceError: x is not defined", "ts": annotTS.Add(3 * time.Second).UTC().Format(time.RFC3339)},
-		LogEntry{"level": "info", "message": "page loaded", "ts": annotTS.Add(-1 * time.Second).UTC().Format(time.RFC3339)},          // not error
+		LogEntry{"level": "info", "message": "page loaded", "ts": annotTS.Add(-1 * time.Second).UTC().Format(time.RFC3339)},      // not error
 		LogEntry{"level": "error", "message": "far away error", "ts": annotTS.Add(-30 * time.Second).UTC().Format(time.RFC3339)}, // outside window
 	)
 	h.server.logAddedAt = append(h.server.logAddedAt,
@@ -935,10 +1153,10 @@ func TestToolGetAnnotationDetail_ErrorCorrelation_NoErrors(t *testing.T) {
 	h := createTestToolHandler(t)
 
 	detail := AnnotationDetail{
-		CorrelationID: "detail_no_err",
-		Selector:      "div.clean",
-		Tag:           "div",
-		Classes:       []string{},
+		CorrelationID:  "detail_no_err",
+		Selector:       "div.clean",
+		Tag:            "div",
+		Classes:        []string{},
 		ComputedStyles: map[string]string{},
 	}
 	h.annotationStore.StoreDetail("detail_no_err", detail)

--- a/docs/architecture/flow-maps/analyze-annotations-waiter-and-flush.md
+++ b/docs/architecture/flow-maps/analyze-annotations-waiter-and-flush.md
@@ -52,6 +52,7 @@ This map covers annotation retrieval through `analyze(what:"annotations")`, incl
    - exact URL
    - base URL (e.g. `http://localhost:3000`)
    - wildcard/prefix patterns (e.g. `http://localhost:3000/*`)
+   - origin-aware checks use parsed scheme/host equality, preventing prefix collisions (for example `:3000` does not match `:30001`)
 3. Server builds project grouping metadata (`projects`) from page URLs.
 4. If multiple projects are detected and no scope filter is provided:
    - response includes `scope_ambiguous: true`

--- a/docs/architecture/flow-maps/analyze-annotations-waiter-and-flush.md
+++ b/docs/architecture/flow-maps/analyze-annotations-waiter-and-flush.md
@@ -1,7 +1,7 @@
 ---
 doc_type: architecture_flow_map
 status: active
-last_reviewed: 2026-03-02
+last_reviewed: 2026-03-03
 owners:
   - Brenn
 feature_ids:
@@ -17,6 +17,7 @@ This map covers annotation retrieval through `analyze(what:"annotations")`, incl
 - Waiter registration (`wait:true`)
 - Command-result completion after draw-mode store callbacks
 - Recovery path for stuck pending waiters (`operation:"flush"`)
+- Cross-project scope safety (`url` / `url_pattern`)
 
 ## Entrypoints
 
@@ -44,6 +45,21 @@ This map covers annotation retrieval through `analyze(what:"annotations")`, incl
 8. Store callback completes matching `ann_*` command with session payload.
 9. Client polls `observe({what:"command_result", correlation_id})` and receives terminal result.
 
+## Scope Safety Flow
+
+1. Client may pass `url` or `url_pattern` to scope annotation retrieval.
+2. Server applies URL matching to returned annotation pages:
+   - exact URL
+   - base URL (e.g. `http://localhost:3000`)
+   - wildcard/prefix patterns (e.g. `http://localhost:3000/*`)
+3. Server builds project grouping metadata (`projects`) from page URLs.
+4. If multiple projects are detected and no scope filter is provided:
+   - response includes `scope_ambiguous: true`
+   - response includes `scope_warning` with recommended filters
+5. If both `url` and `url_pattern` are provided and differ:
+   - request is rejected with `invalid_param`
+   - caller must send a single unambiguous scope filter
+
 ## Error and Recovery Paths
 
 - Stuck waiter / no callback completion:
@@ -63,6 +79,10 @@ This map covers annotation retrieval through `analyze(what:"annotations")`, incl
   - `completed` (normal completion)
   - `flushed` (manual recovery completion with data)
   - `abandoned` (manual recovery completion with empty data)
+- Annotation session payload includes scope metadata:
+  - `filter_applied` (`none` when absent)
+  - `projects` (grouped by base URL with recommended filters)
+  - `scope_ambiguous` and `scope_warning` when cross-project risk is detected
 - Analyze schema `operation` values include `flush` for annotation recovery.
 
 ## Code Paths
@@ -71,6 +91,8 @@ This map covers annotation retrieval through `analyze(what:"annotations")`, incl
 - `cmd/dev-console/tools_analyze_annotations_handlers.go`
 - `cmd/dev-console/tools_async_observe_commands.go`
 - `cmd/dev-console/tools_async_formatting.go`
+- `internal/schema/analyze.go`
+- `internal/tools/configure/mode_specs_analyze.go`
 - `internal/annotation/store.go`
 - `internal/annotation/store_sessions.go`
 - `internal/annotation/store_named.go`

--- a/docs/features/feature/annotated-screenshots/flow-map.md
+++ b/docs/features/feature/annotated-screenshots/flow-map.md
@@ -11,4 +11,4 @@ last_reviewed: 2026-03-03
 This feature's canonical flow maps:
 
 - **Annotation Detail Enrichment:** [annotation-detail-enrichment.md](../../../architecture/flow-maps/annotation-detail-enrichment.md) — parent context, siblings, CSS framework detection, error correlation, LLM hints
-- **Annotation Waiter and Flush:** [analyze-annotations-waiter-and-flush.md](../../../architecture/flow-maps/analyze-annotations-waiter-and-flush.md) — blocking wait, async polling, flush recovery
+- **Annotation Waiter and Flush:** [analyze-annotations-waiter-and-flush.md](../../../architecture/flow-maps/analyze-annotations-waiter-and-flush.md) — blocking wait, async polling, flush recovery, and cross-project URL scoping safety

--- a/docs/features/feature/annotated-screenshots/index.md
+++ b/docs/features/feature/annotated-screenshots/index.md
@@ -10,6 +10,8 @@ code_paths:
   - internal/annotation/store.go
   - cmd/dev-console/tools_analyze_annotations_handlers.go
   - cmd/dev-console/annotation_store.go
+  - internal/schema/analyze.go
+  - internal/tools/configure/mode_specs_analyze.go
 test_paths:
   - tests/extension/draw-mode.test.js
   - internal/annotation/store_test.go
@@ -48,7 +50,8 @@ test_paths:
 
 ### Go (store + handler)
 - `internal/annotation/store.go` — `Detail` struct with ParentContext, Siblings, CSSFramework fields; session TTL = 2 hours
-- `cmd/dev-console/tools_analyze_annotations_handlers.go` — detail response enrichment, error correlation, LLM hints
+- `cmd/dev-console/tools_analyze_annotations_handlers.go` — detail response enrichment, error correlation, LLM hints, and cross-project scope safety metadata (`projects`, `scope_ambiguous`, `scope_warning`, `filter_applied`)
+- `internal/schema/analyze.go` + `internal/tools/configure/mode_specs_analyze.go` — analyze annotations schema/capability metadata for `url` / `url_pattern` filters
 
 ### Tests
 - `tests/extension/draw-mode.test.js` — "Element Detail Enrichment" describe block

--- a/internal/annotation/named_test.go
+++ b/internal/annotation/named_test.go
@@ -487,6 +487,27 @@ func TestBuildSessionResult_URLFilterNoMatch_ExcludesAnnotationsAndScreenshot(t 
 	}
 }
 
+func TestBuildSessionResult_BaseURLFilter_DoesNotCrossPortPrefix(t *testing.T) {
+	t.Parallel()
+	session := &Session{
+		Annotations: []Annotation{
+			{ID: "a1", Text: "wrong port"},
+		},
+		PageURL: "http://localhost:30001/page",
+	}
+
+	raw := BuildSessionResult(session, "http://localhost:3000")
+
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if result["count"] != float64(0) {
+		t.Errorf("expected host/port-aware base URL filter to reject non-matching origin, got %v", result["count"])
+	}
+}
+
 func TestBuildNamedSessionResult_URLFilterScopesPages(t *testing.T) {
 	t.Parallel()
 	ns := &NamedSession{

--- a/internal/annotation/named_test.go
+++ b/internal/annotation/named_test.go
@@ -175,7 +175,7 @@ func TestBuildNamedSessionResult_SinglePage(t *testing.T) {
 		},
 	}
 
-	raw := BuildNamedSessionResult(ns)
+	raw := BuildNamedSessionResult(ns, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -241,7 +241,7 @@ func TestBuildNamedSessionResult_MultiplePages(t *testing.T) {
 		},
 	}
 
-	raw := BuildNamedSessionResult(ns)
+	raw := BuildNamedSessionResult(ns, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -283,7 +283,7 @@ func TestBuildNamedSessionResult_EmptyPages(t *testing.T) {
 		Pages: []*Session{},
 	}
 
-	raw := BuildNamedSessionResult(ns)
+	raw := BuildNamedSessionResult(ns, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -318,7 +318,7 @@ func TestBuildNamedSessionResult_ZeroAnnotationsPage(t *testing.T) {
 		},
 	}
 
-	raw := BuildNamedSessionResult(ns)
+	raw := BuildNamedSessionResult(ns, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -353,7 +353,7 @@ func TestBuildNamedSessionResult_SnakeCaseFields(t *testing.T) {
 		},
 	}
 
-	raw := BuildNamedSessionResult(ns)
+	raw := BuildNamedSessionResult(ns, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -393,7 +393,7 @@ func TestBuildSessionResult_WithScreenshot(t *testing.T) {
 		PageURL:        "https://example.com/page",
 	}
 
-	raw := BuildSessionResult(session)
+	raw := BuildSessionResult(session, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -424,7 +424,7 @@ func TestBuildSessionResult_WithoutScreenshot(t *testing.T) {
 		PageURL: "https://example.com",
 	}
 
-	raw := BuildSessionResult(session)
+	raw := BuildSessionResult(session, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -447,7 +447,7 @@ func TestBuildSessionResult_EmptyAnnotations(t *testing.T) {
 		PageURL:     "https://example.com",
 	}
 
-	raw := BuildSessionResult(session)
+	raw := BuildSessionResult(session, "")
 
 	var result map[string]any
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -456,5 +456,83 @@ func TestBuildSessionResult_EmptyAnnotations(t *testing.T) {
 
 	if result["count"] != float64(0) {
 		t.Errorf("expected count 0, got %v", result["count"])
+	}
+}
+
+func TestBuildSessionResult_URLFilterNoMatch_ExcludesAnnotationsAndScreenshot(t *testing.T) {
+	t.Parallel()
+	session := &Session{
+		Annotations: []Annotation{
+			{ID: "a1", Text: "scoped"},
+		},
+		ScreenshotPath: "/tmp/scoped.png",
+		PageURL:        "http://localhost:3000/page",
+	}
+
+	raw := BuildSessionResult(session, "http://localhost:4000/*")
+
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if result["count"] != float64(0) {
+		t.Errorf("expected filtered count 0, got %v", result["count"])
+	}
+	if result["filter_applied"] != "http://localhost:4000/*" {
+		t.Errorf("expected filter_applied to be retained, got %v", result["filter_applied"])
+	}
+	if _, hasScreenshot := result["screenshot"]; hasScreenshot {
+		t.Errorf("expected screenshot to be omitted when filter does not match")
+	}
+}
+
+func TestBuildNamedSessionResult_URLFilterScopesPages(t *testing.T) {
+	t.Parallel()
+	ns := &NamedSession{
+		Name: "scoped-session",
+		Pages: []*Session{
+			{
+				Annotations: []Annotation{{ID: "a1", Text: "first"}},
+				PageURL:     "http://localhost:3000/page-a",
+				TabID:       1,
+			},
+			{
+				Annotations: []Annotation{
+					{ID: "a2", Text: "second"},
+					{ID: "a3", Text: "third"},
+				},
+				PageURL: "http://localhost:4000/page-b",
+				TabID:   2,
+			},
+		},
+	}
+
+	raw := BuildNamedSessionResult(ns, "http://localhost:3000/*")
+
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if result["page_count"] != float64(1) {
+		t.Errorf("expected filtered page_count 1, got %v", result["page_count"])
+	}
+	if result["total_count"] != float64(1) {
+		t.Errorf("expected filtered total_count 1, got %v", result["total_count"])
+	}
+	if result["filter_applied"] != "http://localhost:3000/*" {
+		t.Errorf("expected filter_applied to be retained, got %v", result["filter_applied"])
+	}
+	pages, ok := result["pages"].([]any)
+	if !ok {
+		t.Fatalf("expected pages array, got %T", result["pages"])
+	}
+	if len(pages) != 1 {
+		t.Fatalf("expected exactly one filtered page, got %d", len(pages))
+	}
+	page := pages[0].(map[string]any)
+	if page["page_url"] != "http://localhost:3000/page-a" {
+		t.Errorf("expected retained page_url to match filter, got %v", page["page_url"])
 	}
 }

--- a/internal/annotation/store.go
+++ b/internal/annotation/store.go
@@ -96,6 +96,7 @@ type namedSessionEntry struct {
 type waiter struct {
 	CorrelationID    string // command tracker correlation_id
 	AnnotSessionName string // "" for anonymous, non-empty for named session
+	URLFilter        string // optional URL scope filter applied at completion time
 }
 
 // Store manages annotation sessions and details in memory.
@@ -152,11 +153,13 @@ func (s *Store) SetCommandCompleter(fn func(correlationID string, result json.Ra
 
 // RegisterWaiter registers a correlation_id to be completed when annotations arrive.
 // sessionName is "" for anonymous sessions, or a name for named sessions.
-func (s *Store) RegisterWaiter(correlationID string, sessionName string) {
+// urlFilter is optional and scopes async completion payloads to a specific project/page URL.
+func (s *Store) RegisterWaiter(correlationID string, sessionName string, urlFilter string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.waiters = append(s.waiters, waiter{
 		CorrelationID:    correlationID,
 		AnnotSessionName: sessionName,
+		URLFilter:        urlFilter,
 	})
 }

--- a/internal/annotation/store_named.go
+++ b/internal/annotation/store_named.go
@@ -81,7 +81,7 @@ func (s *Store) AppendToNamedSession(name string, session *Session) {
 	// Complete async waiters outside the lock.
 	if plan.completeFn != nil {
 		for _, w := range plan.toComplete {
-			result := BuildNamedSessionResult(&plan.nsCopy)
+			result := BuildNamedSessionResult(&plan.nsCopy, w.URLFilter)
 			plan.completeFn(w.CorrelationID, result)
 		}
 	}

--- a/internal/annotation/store_results.go
+++ b/internal/annotation/store_results.go
@@ -94,20 +94,49 @@ func annotationURLMatches(urlFilter, pageURL string) bool {
 		return false
 	}
 
+	// Support wildcard suffix filters like http://localhost:3000/*.
+	if strings.HasSuffix(urlFilter, "/*") {
+		return annotationURLMatches(strings.TrimSuffix(urlFilter, "*"), pageURL)
+	}
 	if strings.Contains(urlFilter, "*") {
 		prefix := strings.ReplaceAll(urlFilter, "*", "")
 		return strings.HasPrefix(pageURL, prefix)
 	}
 
-	if strings.HasSuffix(urlFilter, "/") {
-		prefix := strings.TrimSuffix(urlFilter, "/")
-		return strings.HasPrefix(pageURL, prefix)
+	filterURL, filterErr := url.Parse(urlFilter)
+	page, pageErr := url.Parse(pageURL)
+	if filterErr == nil && pageErr == nil &&
+		filterURL.Scheme != "" && filterURL.Host != "" &&
+		page.Scheme != "" && page.Host != "" {
+		if !strings.EqualFold(filterURL.Scheme, page.Scheme) || !strings.EqualFold(filterURL.Host, page.Host) {
+			return false
+		}
+
+		filterPath := strings.TrimSpace(filterURL.Path)
+		switch {
+		case filterPath == "", filterPath == "/":
+			// Base URL filter: match any path on the same origin.
+			return true
+		case strings.HasSuffix(filterPath, "/"):
+			// Path prefix filter.
+			return strings.HasPrefix(page.Path, filterPath)
+		default:
+			// Exact path filter. Query/fragment are optional constraints when provided.
+			if page.Path != filterPath {
+				return false
+			}
+			if filterURL.RawQuery != "" && page.RawQuery != filterURL.RawQuery {
+				return false
+			}
+			if filterURL.Fragment != "" && page.Fragment != filterURL.Fragment {
+				return false
+			}
+			return true
+		}
 	}
 
-	parsed, err := url.Parse(urlFilter)
-	if err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Path == "" || parsed.Path == "/") {
-		base := strings.TrimSuffix(urlFilter, "/")
-		return strings.HasPrefix(pageURL, base)
+	if strings.HasSuffix(urlFilter, "/") {
+		return strings.HasPrefix(pageURL, urlFilter)
 	}
 
 	return pageURL == urlFilter

--- a/internal/annotation/store_results.go
+++ b/internal/annotation/store_results.go
@@ -4,18 +4,27 @@
 
 package annotation
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
 
 // BuildSessionResult serializes an annotation session for the CommandTracker.
-func BuildSessionResult(session *Session) json.RawMessage {
+func BuildSessionResult(session *Session, urlFilter string) json.RawMessage {
+	annotations := session.Annotations
+	if !annotationURLMatches(urlFilter, session.PageURL) {
+		annotations = []Annotation{}
+	}
 	result := map[string]any{
 		"status":          "complete",
-		"annotations":     session.Annotations,
-		"count":           len(session.Annotations),
+		"annotations":     annotations,
+		"count":           len(annotations),
 		"page_url":        session.PageURL,
 		"terminal_reason": "completed",
+		"filter_applied":  annotationFilterAppliedValue(urlFilter),
 	}
-	if session.ScreenshotPath != "" {
+	if session.ScreenshotPath != "" && len(annotations) > 0 {
 		result["screenshot"] = session.ScreenshotPath
 	}
 	// Error impossible: map of primitive types.
@@ -24,10 +33,11 @@ func BuildSessionResult(session *Session) json.RawMessage {
 }
 
 // BuildNamedSessionResult serializes a named session for the CommandTracker.
-func BuildNamedSessionResult(ns *NamedSession) json.RawMessage {
+func BuildNamedSessionResult(ns *NamedSession, urlFilter string) json.RawMessage {
 	totalCount := 0
-	pages := make([]map[string]any, 0, len(ns.Pages))
-	for _, page := range ns.Pages {
+	filteredPages := filterPagesByURL(ns.Pages, urlFilter)
+	pages := make([]map[string]any, 0, len(filteredPages))
+	for _, page := range filteredPages {
 		totalCount += len(page.Annotations)
 		p := map[string]any{
 			"page_url":    page.PageURL,
@@ -44,11 +54,61 @@ func BuildNamedSessionResult(ns *NamedSession) json.RawMessage {
 		"status":             "complete",
 		"annot_session_name": ns.Name,
 		"pages":              pages,
-		"page_count":         len(ns.Pages),
+		"page_count":         len(filteredPages),
 		"total_count":        totalCount,
 		"terminal_reason":    "completed",
+		"filter_applied":     annotationFilterAppliedValue(urlFilter),
 	}
 	// Error impossible: map of primitive types.
 	data, _ := json.Marshal(result)
 	return data
+}
+
+func annotationFilterAppliedValue(urlFilter string) string {
+	if strings.TrimSpace(urlFilter) == "" {
+		return "none"
+	}
+	return urlFilter
+}
+
+func filterPagesByURL(pages []*Session, urlFilter string) []*Session {
+	if strings.TrimSpace(urlFilter) == "" {
+		return pages
+	}
+	filtered := make([]*Session, 0, len(pages))
+	for _, page := range pages {
+		if annotationURLMatches(urlFilter, page.PageURL) {
+			filtered = append(filtered, page)
+		}
+	}
+	return filtered
+}
+
+func annotationURLMatches(urlFilter, pageURL string) bool {
+	urlFilter = strings.TrimSpace(urlFilter)
+	if urlFilter == "" {
+		return true
+	}
+	pageURL = strings.TrimSpace(pageURL)
+	if pageURL == "" {
+		return false
+	}
+
+	if strings.Contains(urlFilter, "*") {
+		prefix := strings.ReplaceAll(urlFilter, "*", "")
+		return strings.HasPrefix(pageURL, prefix)
+	}
+
+	if strings.HasSuffix(urlFilter, "/") {
+		prefix := strings.TrimSuffix(urlFilter, "/")
+		return strings.HasPrefix(pageURL, prefix)
+	}
+
+	parsed, err := url.Parse(urlFilter)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Path == "" || parsed.Path == "/") {
+		base := strings.TrimSuffix(urlFilter, "/")
+		return strings.HasPrefix(pageURL, base)
+	}
+
+	return pageURL == urlFilter
 }

--- a/internal/annotation/store_sessions.go
+++ b/internal/annotation/store_sessions.go
@@ -60,8 +60,8 @@ func (s *Store) StoreSession(tabID int, session *Session) {
 
 	// Complete async waiters outside the lock.
 	if plan.completeFn != nil {
-		result := BuildSessionResult(session)
 		for _, w := range plan.toComplete {
+			result := BuildSessionResult(session, w.URLFilter)
 			plan.completeFn(w.CorrelationID, result)
 		}
 	}

--- a/internal/annotation/store_test.go
+++ b/internal/annotation/store_test.go
@@ -1458,18 +1458,21 @@ func TestStore_TakeWaiter_RemovesAndReturnsSessionName(t *testing.T) {
 	store := NewStore(10 * time.Minute)
 	defer store.Close()
 
-	store.RegisterWaiter("ann_1", "qa")
-	store.RegisterWaiter("ann_2", "")
+	store.RegisterWaiter("ann_1", "qa", "")
+	store.RegisterWaiter("ann_2", "", "")
 
-	sessionName, found := store.TakeWaiter("ann_1")
+	sessionName, urlFilter, found := store.TakeWaiter("ann_1")
 	if !found {
 		t.Fatal("expected waiter ann_1 to be found")
 	}
 	if sessionName != "qa" {
 		t.Fatalf("sessionName = %q, want qa", sessionName)
 	}
+	if urlFilter != "" {
+		t.Fatalf("urlFilter = %q, want empty", urlFilter)
+	}
 
-	_, found = store.TakeWaiter("ann_1")
+	_, _, found = store.TakeWaiter("ann_1")
 	if found {
 		t.Fatal("expected waiter ann_1 to be removed after first take")
 	}

--- a/internal/annotation/store_wait.go
+++ b/internal/annotation/store_wait.go
@@ -7,8 +7,8 @@ package annotation
 import "time"
 
 // TakeWaiter removes and returns a pending async annotation waiter by correlation_id.
-// Returns (sessionName, true) when found, or ("", false) when missing.
-func (s *Store) TakeWaiter(correlationID string) (string, bool) {
+// Returns (sessionName, urlFilter, true) when found, or ("", "", false) when missing.
+func (s *Store) TakeWaiter(correlationID string) (string, string, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, w := range s.waiters {
@@ -16,9 +16,9 @@ func (s *Store) TakeWaiter(correlationID string) (string, bool) {
 			continue
 		}
 		s.waiters = append(s.waiters[:i], s.waiters[i+1:]...)
-		return w.AnnotSessionName, true
+		return w.AnnotSessionName, w.URLFilter, true
 	}
-	return "", false
+	return "", "", false
 }
 
 // waitForCondition blocks until checker returns non-nil, timeout, or store close.

--- a/internal/schema/analyze.go
+++ b/internal/schema/analyze.go
@@ -120,6 +120,14 @@ func AnalyzeToolSchema() mcp.MCPTool {
 					"type":        "string",
 					"description": "Named session for multi-page annotation review (applies to annotations). Accumulates annotations across pages.",
 				},
+				"url": map[string]any{
+					"type":        "string",
+					"description": "Annotation URL scope filter (annotations). Supports exact URL, project base URL, or wildcard patterns such as http://localhost:3000/*.",
+				},
+				"url_pattern": map[string]any{
+					"type":        "string",
+					"description": "Alias for annotation URL scope filter (annotations). Use either url or url_pattern.",
+				},
 				"urls": map[string]any{
 					"type":        "array",
 					"description": "URLs to validate (link_validation)",

--- a/internal/tools/configure/mode_specs_analyze.go
+++ b/internal/tools/configure/mode_specs_analyze.go
@@ -42,7 +42,7 @@ var analyzeModeSpecs = map[string]modeParamSpec{
 	},
 	"annotations": {
 		Hint:     "List annotations from a draw/annotation session",
-		Optional: []string{"annot_session", "wait", "timeout_ms"},
+		Optional: []string{"annot_session", "wait", "timeout_ms", "url", "url_pattern"},
 	},
 	"annotation_detail": {
 		Hint:     "Full DOM/style details for a specific annotation",


### PR DESCRIPTION
## Summary
- add url/url_pattern scoping for analyze(what:annotations)
- surface mixed-project safety metadata (projects, scope_ambiguous, scope_warning)
- propagate scope filters through async waiter completion and operation:flush
- update analyze schema/capability metadata and golden snapshot
- add regression tests for scope filtering in sync and async paths
- update canonical and feature flow-map docs

## Validation
- go test ./internal/annotation
- go test ./cmd/dev-console -run 'TestToolGetAnnotations_.*|TestSchemaParity_AnalyzeWhatEnumMatchesHandlers|TestToolsAnalyzeSchema_HasFrameParam|TestGoldenToolsList'

Closes #423