### PR TITLE
fix: throttle push screenshots — dedup, cap, and clear

### DIFF
--- a/cmd/dev-console/tools_configure_handler_test.go
+++ b/cmd/dev-console/tools_configure_handler_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/push"
 )
 
 // ============================================
@@ -299,7 +301,7 @@ func TestToolsConfigureClear_SpecificBuffers(t *testing.T) {
 	t.Parallel()
 	h, _, _ := makeToolHandler(t)
 
-	buffers := []string{"network", "websocket", "actions", "logs"}
+	buffers := []string{"network", "websocket", "actions", "logs", "inbox"}
 	for _, buffer := range buffers {
 		t.Run(buffer, func(t *testing.T) {
 			resp := callConfigureRaw(h, `{"what":"clear","buffer":"`+buffer+`"}`)
@@ -318,6 +320,67 @@ func TestToolsConfigureClear_SpecificBuffers(t *testing.T) {
 
 			assertSnakeCaseFields(t, string(resp.Result))
 		})
+	}
+}
+
+func TestToolsConfigureClear_AllDrainsInbox(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	// Enqueue a push event into the inbox.
+	h.server.pushInbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot", PageURL: "https://example.com"})
+	if h.server.pushInbox.Len() != 1 {
+		t.Fatal("precondition: inbox should have 1 event")
+	}
+
+	resp := callConfigureRaw(h, `{"what":"clear","buffer":"all"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("clear all should succeed, got: %s", result.Content[0].Text)
+	}
+
+	if h.server.pushInbox.Len() != 0 {
+		t.Fatalf("inbox should be empty after clear all, got %d", h.server.pushInbox.Len())
+	}
+
+	data := extractResultJSON(t, result)
+	cleared, _ := data["cleared"].(map[string]any)
+	if cleared == nil {
+		t.Fatal("cleared should be a map")
+	}
+	if _, ok := cleared["push_events_drained"]; !ok {
+		t.Error("cleared should report push_events_drained count")
+	}
+}
+
+func TestToolsConfigureClear_InboxBuffer(t *testing.T) {
+	t.Parallel()
+	h, _, _ := makeToolHandler(t)
+
+	h.server.pushInbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot"})
+	h.server.pushInbox.Enqueue(push.PushEvent{ID: "ss-2", Type: "chat"})
+
+	resp := callConfigureRaw(h, `{"what":"clear","buffer":"inbox"}`)
+	result := parseToolResult(t, resp)
+	if result.IsError {
+		t.Fatalf("clear inbox should succeed, got: %s", result.Content[0].Text)
+	}
+
+	if h.server.pushInbox.Len() != 0 {
+		t.Fatalf("inbox should be empty, got %d", h.server.pushInbox.Len())
+	}
+
+	data := extractResultJSON(t, result)
+	if data["buffer"] != "inbox" {
+		t.Errorf("buffer = %v, want 'inbox'", data["buffer"])
+	}
+	cleared, _ := data["cleared"].(map[string]any)
+	if cleared == nil {
+		t.Fatal("cleared should be a map")
+	}
+	count, _ := cleared["push_events"].(float64) // JSON numbers are float64
+	if count != 2 {
+		t.Errorf("push_events = %v, want 2", count)
 	}
 }
 

--- a/cmd/dev-console/tools_configure_state_impl.go
+++ b/cmd/dev-console/tools_configure_state_impl.go
@@ -126,7 +126,7 @@ func (h *ToolHandler) configureClearImpl(req JSONRPCRequest, args json.RawMessag
 
 	cleared, ok := h.clearConfiguredBuffer(buffer)
 	if !ok {
-		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Unknown buffer: "+buffer, "Use a valid buffer value", withParam("buffer"), withHint("all, network, websocket, actions, logs"))}
+		return JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: mcpStructuredError(ErrInvalidParam, "Unknown buffer: "+buffer, "Use a valid buffer value", withParam("buffer"), withHint("all, network, websocket, actions, logs, inbox"))}
 	}
 
 	responseData := map[string]any{"status": "ok", "buffer": buffer, "cleared": cleared}
@@ -143,6 +143,10 @@ func (h *ToolHandler) clearConfiguredBuffer(buffer string) (any, bool) {
 		cleared := map[string]any{
 			"buffers":                "all",
 			"extension_logs_cleared": h.capture.ClearExtensionLogs(),
+		}
+		if h.server.pushInbox != nil {
+			drained := h.server.pushInbox.DrainAll()
+			cleared["push_events_drained"] = len(drained)
 		}
 		if h.annotationStore != nil {
 			annotationCleared := h.annotationStore.ClearAll()
@@ -167,6 +171,12 @@ func (h *ToolHandler) clearConfiguredBuffer(buffer string) (any, bool) {
 		logCount := h.server.getEntryCount()
 		h.server.clearEntries()
 		return map[string]int{"logs": logCount}, true
+	case "inbox":
+		if h.server.pushInbox != nil {
+			drained := h.server.pushInbox.DrainAll()
+			return map[string]int{"push_events": len(drained)}, true
+		}
+		return map[string]int{"push_events": 0}, true
 	default:
 		return nil, false
 	}

--- a/cmd/dev-console/tools_observe_inbox.go
+++ b/cmd/dev-console/tools_observe_inbox.go
@@ -4,6 +4,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/push"
 )
 
 // toolObserveInbox drains the push inbox and returns pending events.
@@ -46,21 +48,22 @@ func (h *ToolHandler) appendPushPiggyback(resp JSONRPCResponse) JSONRPCResponse 
 		return resp
 	}
 
-	for _, ev := range events {
+	// Separate screenshots from other events; only deliver the most recent screenshot.
+	var latestScreenshot *push.PushEvent
+	screenshotCount := 0
+	var otherEvents []push.PushEvent
+	for i := range events {
+		if events[i].Type == "screenshot" {
+			screenshotCount++
+			latestScreenshot = &events[i]
+		} else {
+			otherEvents = append(otherEvents, events[i])
+		}
+	}
+
+	// Append non-screenshot events first (all pass through).
+	for _, ev := range otherEvents {
 		switch ev.Type {
-		case "screenshot":
-			label := fmt.Sprintf("\n\n_push_screenshot: captured from %s", ev.PageURL)
-			if ev.Note != "" {
-				label += " — " + ev.Note
-			}
-			result.Content = append(result.Content, MCPContentBlock{Type: "text", Text: label})
-			if ev.ScreenshotB64 != "" {
-				result.Content = append(result.Content, MCPContentBlock{
-					Type:     "image",
-					Data:     ev.ScreenshotB64,
-					MimeType: "image/jpeg",
-				})
-			}
 		case "annotations":
 			label := fmt.Sprintf("\n\n_push_annotations: from %s", ev.PageURL)
 			if ev.AnnotSession != "" {
@@ -79,6 +82,28 @@ func (h *ToolHandler) appendPushPiggyback(resp JSONRPCResponse) JSONRPCResponse 
 			result.Content = append(result.Content, MCPContentBlock{
 				Type: "text",
 				Text: fmt.Sprintf("\n\n_push_%s: event from %s", ev.Type, ev.PageURL),
+			})
+		}
+	}
+
+	// Append at most 1 screenshot (the most recent), with a skip summary if needed.
+	if latestScreenshot != nil {
+		if screenshotCount > 1 {
+			result.Content = append(result.Content, MCPContentBlock{
+				Type: "text",
+				Text: fmt.Sprintf("\n\n_push_screenshot: %d earlier screenshots skipped (showing most recent only)", screenshotCount-1),
+			})
+		}
+		label := fmt.Sprintf("\n\n_push_screenshot: captured from %s", latestScreenshot.PageURL)
+		if latestScreenshot.Note != "" {
+			label += " — " + latestScreenshot.Note
+		}
+		result.Content = append(result.Content, MCPContentBlock{Type: "text", Text: label})
+		if latestScreenshot.ScreenshotB64 != "" {
+			result.Content = append(result.Content, MCPContentBlock{
+				Type:     "image",
+				Data:     latestScreenshot.ScreenshotB64,
+				MimeType: "image/jpeg",
 			})
 		}
 	}

--- a/cmd/dev-console/tools_observe_inbox_test.go
+++ b/cmd/dev-console/tools_observe_inbox_test.go
@@ -15,6 +15,20 @@ func newPushTestToolHandler(inbox *push.PushInbox) *ToolHandler {
 	return &ToolHandler{MCPHandler: mcp}
 }
 
+// piggybackTestResponse creates a base tool response, runs appendPushPiggyback, and returns the parsed result.
+func piggybackTestResponse(t *testing.T, h *ToolHandler, baseText string) MCPToolResult {
+	t.Helper()
+	result := MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: baseText}}}
+	resultJSON, _ := json.Marshal(result)
+	resp := JSONRPCResponse{JSONRPC: "2.0", Result: json.RawMessage(resultJSON)}
+	out := h.appendPushPiggyback(resp)
+	var outResult MCPToolResult
+	if err := json.Unmarshal(out.Result, &outResult); err != nil {
+		t.Fatal(err)
+	}
+	return outResult
+}
+
 func TestToolObserveInbox_Empty(t *testing.T) {
 	h := newPushTestToolHandler(push.NewPushInbox(10))
 
@@ -67,16 +81,7 @@ func TestToolObserveInbox_NilInbox(t *testing.T) {
 
 func TestAppendPushPiggyback_Empty(t *testing.T) {
 	h := newPushTestToolHandler(push.NewPushInbox(10))
-
-	result := MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: "hello"}}}
-	resultJSON, _ := json.Marshal(result)
-	resp := JSONRPCResponse{JSONRPC: "2.0", Result: json.RawMessage(resultJSON)}
-
-	out := h.appendPushPiggyback(resp)
-	var outResult MCPToolResult
-	if err := json.Unmarshal(out.Result, &outResult); err != nil {
-		t.Fatal(err)
-	}
+	outResult := piggybackTestResponse(t, h, "hello")
 	// Empty inbox should not add piggyback
 	if len(outResult.Content) != 1 {
 		t.Fatalf("expected 1 content block, got %d", len(outResult.Content))
@@ -88,18 +93,108 @@ func TestAppendPushPiggyback_WithEvents(t *testing.T) {
 	inbox.Enqueue(push.PushEvent{ID: "1", Type: "chat", Message: "pending"})
 
 	h := newPushTestToolHandler(inbox)
-
-	result := MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: "hello"}}}
-	resultJSON, _ := json.Marshal(result)
-	resp := JSONRPCResponse{JSONRPC: "2.0", Result: json.RawMessage(resultJSON)}
-
-	out := h.appendPushPiggyback(resp)
-	var outResult MCPToolResult
-	if err := json.Unmarshal(out.Result, &outResult); err != nil {
-		t.Fatal(err)
-	}
+	outResult := piggybackTestResponse(t, h, "hello")
 	if len(outResult.Content) != 2 {
 		t.Fatalf("expected 2 content blocks (original + piggyback), got %d", len(outResult.Content))
+	}
+}
+
+func TestAppendPushPiggyback_CapsScreenshotsToOne(t *testing.T) {
+	inbox := push.NewPushInbox(10)
+	inbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot", PageURL: "https://a.com", ScreenshotB64: "old", TabID: 1})
+	inbox.Enqueue(push.PushEvent{ID: "ss-2", Type: "screenshot", PageURL: "https://b.com", ScreenshotB64: "new", TabID: 2})
+
+	h := newPushTestToolHandler(inbox)
+	outResult := piggybackTestResponse(t, h, "hello")
+
+	// Expect: original text + summary text + label text + image = 4 blocks
+	imageCount := 0
+	for _, block := range outResult.Content {
+		if block.Type == "image" {
+			imageCount++
+			if block.Data != "new" {
+				t.Fatal("expected only the most recent screenshot")
+			}
+		}
+	}
+	if imageCount != 1 {
+		t.Fatalf("expected exactly 1 image (most recent), got %d", imageCount)
+	}
+}
+
+func TestAppendPushPiggyback_NonScreenshotEventsPassThrough(t *testing.T) {
+	inbox := push.NewPushInbox(10)
+	inbox.Enqueue(push.PushEvent{ID: "c-1", Type: "chat", Message: "msg1"})
+	inbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot", PageURL: "https://a.com", ScreenshotB64: "img1"})
+	inbox.Enqueue(push.PushEvent{ID: "c-2", Type: "chat", Message: "msg2"})
+	inbox.Enqueue(push.PushEvent{ID: "ss-2", Type: "screenshot", PageURL: "https://b.com", ScreenshotB64: "img2"})
+
+	h := newPushTestToolHandler(inbox)
+	outResult := piggybackTestResponse(t, h, "base")
+
+	// Count chat blocks (should be 2 — all non-screenshot events pass through)
+	chatCount := 0
+	imageCount := 0
+	for _, block := range outResult.Content {
+		if block.Type == "text" && len(block.Text) > 0 {
+			if contains(block.Text, "_push_chat:") {
+				chatCount++
+			}
+		}
+		if block.Type == "image" {
+			imageCount++
+		}
+	}
+	if chatCount != 2 {
+		t.Fatalf("expected 2 chat events to pass through, got %d", chatCount)
+	}
+	if imageCount != 1 {
+		t.Fatalf("expected 1 screenshot (capped), got %d", imageCount)
+	}
+}
+
+func TestAppendPushPiggyback_SkippedCountInSummary(t *testing.T) {
+	inbox := push.NewPushInbox(10)
+	inbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot", PageURL: "https://a.com", ScreenshotB64: "a", TabID: 1})
+	inbox.Enqueue(push.PushEvent{ID: "ss-2", Type: "screenshot", PageURL: "https://b.com", ScreenshotB64: "b", TabID: 2})
+	inbox.Enqueue(push.PushEvent{ID: "ss-3", Type: "screenshot", PageURL: "https://c.com", ScreenshotB64: "c", TabID: 3})
+
+	h := newPushTestToolHandler(inbox)
+	outResult := piggybackTestResponse(t, h, "base")
+
+	// Look for summary mentioning skipped screenshots
+	found := false
+	for _, block := range outResult.Content {
+		if block.Type == "text" && contains(block.Text, "2 earlier") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected summary mentioning 2 earlier screenshots skipped")
+	}
+}
+
+func TestAppendPushPiggyback_SingleScreenshotNoSkipSummary(t *testing.T) {
+	inbox := push.NewPushInbox(10)
+	inbox.Enqueue(push.PushEvent{ID: "ss-1", Type: "screenshot", PageURL: "https://a.com", ScreenshotB64: "data"})
+
+	h := newPushTestToolHandler(inbox)
+	outResult := piggybackTestResponse(t, h, "base")
+
+	for _, block := range outResult.Content {
+		if block.Type == "text" && contains(block.Text, "earlier") {
+			t.Fatal("single screenshot should not produce a skip summary")
+		}
+	}
+
+	imageCount := 0
+	for _, block := range outResult.Content {
+		if block.Type == "image" {
+			imageCount++
+		}
+	}
+	if imageCount != 1 {
+		t.Fatalf("expected 1 image, got %d", imageCount)
 	}
 }
 

--- a/docs/architecture/flow-maps/README.md
+++ b/docs/architecture/flow-maps/README.md
@@ -64,3 +64,4 @@ Each flow map should include:
 - [Framework Selector Resilience Smoke Flow](./framework-selector-resilience-smoke.md)
 - [Request Session Client Registry and `/clients` Routes](./request-session-client-registry-and-clients-routes.md)
 - [Push Alert Notification Emission](./push-alert-notification-emission.md)
+- [Push Inbox Screenshot Throttle](./push-inbox-screenshot-throttle.md)

--- a/docs/architecture/flow-maps/push-inbox-screenshot-throttle.md
+++ b/docs/architecture/flow-maps/push-inbox-screenshot-throttle.md
@@ -1,0 +1,73 @@
+---
+doc_type: flow_map
+flow_id: push-inbox-screenshot-throttle
+status: active
+last_reviewed: 2026-03-04
+owners:
+  - Brenn
+entrypoints:
+  - internal/push/inbox.go:Enqueue
+  - cmd/dev-console/tools_observe_inbox.go:appendPushPiggyback
+  - cmd/dev-console/tools_configure_state_impl.go:clearConfiguredBuffer
+code_paths:
+  - internal/push/inbox.go
+  - internal/push/types.go
+  - cmd/dev-console/tools_observe_inbox.go
+  - cmd/dev-console/tools_configure_state_impl.go
+test_paths:
+  - internal/push/inbox_test.go
+  - cmd/dev-console/tools_observe_inbox_test.go
+  - cmd/dev-console/tools_configure_handler_test.go
+---
+
+# Push Inbox Screenshot Throttle
+
+## Scope
+
+Covers screenshot deduplication at the inbox level and screenshot capping at the piggyback delivery level. Also covers `configure(clear, buffer=all|inbox)` draining the push inbox.
+
+## Entrypoints
+
+1. `PushInbox.Enqueue` — Deduplicates consecutive screenshots from the same tab+URL on enqueue.
+2. `appendPushPiggyback` — Caps piggybacked screenshots to the most recent one per tool response.
+3. `clearConfiguredBuffer` — Drains the push inbox on `buffer=all` or `buffer=inbox`.
+
+## Primary Flow
+
+1. Extension pushes a screenshot via `POST /push/screenshot`.
+2. Daemon creates a `PushEvent` and calls `PushInbox.Enqueue`.
+3. **Dedup check**: If the last event in the queue is also a screenshot with the same `TabID` and `PageURL`, the new event replaces it instead of appending. This prevents rapid-fire identical screenshots from flooding the inbox.
+4. On the next MCP tool response, `appendPushPiggyback` drains all inbox events.
+5. **Cap check**: Only the most recent screenshot is included in the response. If earlier screenshots were skipped, a summary text block notes the count.
+6. Non-screenshot events (chat, annotations) always pass through fully.
+
+## Error and Recovery Paths
+
+1. If inbox is nil, both piggyback and clear operations are no-ops.
+2. If all events are non-screenshot, no capping occurs — all events pass through.
+3. `configure(clear, buffer=all)` always drains the inbox regardless of content type.
+
+## State and Contracts
+
+1. Dedup is positional (last-event only), not content-hash based. If a non-screenshot event intervenes, no dedup occurs.
+2. Screenshot cap is per-response, not per-session. Each tool call gets at most 1 screenshot.
+3. The `inbox` buffer option is standalone — it only clears push events, not capture buffers.
+4. DrainAll is destructive and atomic under mutex.
+
+## Code Paths
+
+- `internal/push/inbox.go` — Enqueue dedup logic
+- `cmd/dev-console/tools_observe_inbox.go` — Piggyback cap logic
+- `cmd/dev-console/tools_configure_state_impl.go` — Clear buffer inbox case
+
+## Test Paths
+
+- `internal/push/inbox_test.go` — TestInbox_ScreenshotDedup_* (6 tests)
+- `cmd/dev-console/tools_observe_inbox_test.go` — TestAppendPushPiggyback_Caps*, _NonScreenshot*, _Skipped*, _SingleScreenshotNoSkip* (4 tests)
+- `cmd/dev-console/tools_configure_handler_test.go` — TestToolsConfigureClear_AllDrainsInbox, _InboxBuffer, _SpecificBuffers/inbox (3 tests)
+
+## Edit Guardrails
+
+1. Dedup must only apply to consecutive screenshots with matching tab+URL. Never dedup across event types.
+2. Cap applies to piggyback only — explicit `observe({what: "inbox"})` returns all events unfiltered.
+3. Keep DrainAll as the single clear mechanism; do not add selective removal to the inbox.

--- a/docs/features/feature/buffer-clearing/tech-spec.md
+++ b/docs/features/feature/buffer-clearing/tech-spec.md
@@ -40,7 +40,7 @@ Add `buffer` parameter to configure tool schema:
 "buffer": map[string]interface{}{
   "type":        "string",
   "description": "Which buffer to clear (applies to action: \"clear\"). Valid values: \"network\" (network_waterfall + network_bodies), \"websocket\" (websocket_events + websocket_status), \"actions\" (user interactions), \"logs\" (console + extension logs), \"all\" (everything). Default: \"logs\" (backward compatible).",
-  "enum":        []string{"network", "websocket", "actions", "logs", "all"},
+  "enum":        []string{"network", "websocket", "actions", "logs", "inbox", "all"},
 },
 ```
 

--- a/docs/features/feature/push-alerts/index.md
+++ b/docs/features/feature/push-alerts/index.md
@@ -4,20 +4,25 @@ feature_id: feature-push-alerts
 status: shipped
 feature_type: feature
 owners: []
-last_reviewed: 2026-03-03
+last_reviewed: 2026-03-04
 code_paths:
   - cmd/dev-console/alerts.go
   - cmd/dev-console/streaming.go
   - cmd/dev-console/tools_configure_runtime_impl.go
+  - cmd/dev-console/tools_observe_inbox.go
+  - cmd/dev-console/tools_configure_state_impl.go
   - internal/streaming/stream.go
   - internal/streaming/stream_emit.go
   - internal/streaming/types.go
   - internal/streaming/alerts_buffer.go
   - internal/identity/mcp.go
+  - internal/push/inbox.go
 test_paths:
   - internal/streaming/stream_test.go
   - internal/streaming/alerts_test.go
   - cmd/dev-console/alerts_unit_test.go
+  - internal/push/inbox_test.go
+  - cmd/dev-console/tools_observe_inbox_test.go
 ---
 
 # Push Alerts
@@ -39,6 +44,7 @@ test_paths:
 ## Related Architecture
 
 - [Push Alert Notification Emission](../../../architecture/flow-maps/push-alert-notification-emission.md)
+- [Push Inbox Screenshot Throttle](../../../architecture/flow-maps/push-inbox-screenshot-throttle.md)
 
 ## Requirement IDs
 

--- a/internal/push/inbox.go
+++ b/internal/push/inbox.go
@@ -25,12 +25,23 @@ func NewPushInbox(maxLen int) *PushInbox {
 }
 
 // Enqueue adds an event, evicting oldest if full. Returns eviction count.
+// Consecutive screenshots from the same tab+URL are deduplicated: the newer
+// screenshot replaces the previous one instead of appending.
 func (q *PushInbox) Enqueue(ev PushEvent) int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	if ev.Timestamp.IsZero() {
 		ev.Timestamp = time.Now()
+	}
+
+	// Dedup: replace last event if both are screenshots from same tab+URL.
+	if ev.Type == "screenshot" && len(q.events) > 0 {
+		last := &q.events[len(q.events)-1]
+		if last.Type == "screenshot" && last.TabID == ev.TabID && last.PageURL == ev.PageURL {
+			*last = ev
+			return 0
+		}
 	}
 
 	q.events = append(q.events, ev)

--- a/internal/push/inbox_test.go
+++ b/internal/push/inbox_test.go
@@ -96,6 +96,78 @@ func TestInbox_PreserveExplicitTimestamp(t *testing.T) {
 	}
 }
 
+func TestInbox_ScreenshotDedup_ConsecutiveSameTabURL(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "ss-1", Type: "screenshot", TabID: 1, PageURL: "https://example.com", ScreenshotB64: "old"})
+	q.Enqueue(PushEvent{ID: "ss-2", Type: "screenshot", TabID: 1, PageURL: "https://example.com", ScreenshotB64: "new"})
+
+	if q.Len() != 1 {
+		t.Fatalf("expected 1 (deduped), got %d", q.Len())
+	}
+	events := q.DrainAll()
+	if events[0].ID != "ss-2" {
+		t.Fatalf("expected replacement event ss-2, got %s", events[0].ID)
+	}
+	if events[0].ScreenshotB64 != "new" {
+		t.Fatal("expected new screenshot data to replace old")
+	}
+}
+
+func TestInbox_ScreenshotDedup_DifferentURL(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "ss-1", Type: "screenshot", TabID: 1, PageURL: "https://a.com"})
+	q.Enqueue(PushEvent{ID: "ss-2", Type: "screenshot", TabID: 1, PageURL: "https://b.com"})
+
+	if q.Len() != 2 {
+		t.Fatalf("different URLs should not dedup, got %d", q.Len())
+	}
+}
+
+func TestInbox_ScreenshotDedup_DifferentTab(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "ss-1", Type: "screenshot", TabID: 1, PageURL: "https://example.com"})
+	q.Enqueue(PushEvent{ID: "ss-2", Type: "screenshot", TabID: 2, PageURL: "https://example.com"})
+
+	if q.Len() != 2 {
+		t.Fatalf("different tabs should not dedup, got %d", q.Len())
+	}
+}
+
+func TestInbox_ScreenshotDedup_NonScreenshotNotDeduped(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "c-1", Type: "chat", Message: "hello"})
+	q.Enqueue(PushEvent{ID: "c-2", Type: "chat", Message: "hello"})
+
+	if q.Len() != 2 {
+		t.Fatalf("chat events should never dedup, got %d", q.Len())
+	}
+}
+
+func TestInbox_ScreenshotDedup_InterruptedByOtherEvent(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "ss-1", Type: "screenshot", TabID: 1, PageURL: "https://example.com"})
+	q.Enqueue(PushEvent{ID: "c-1", Type: "chat", Message: "break"})
+	q.Enqueue(PushEvent{ID: "ss-2", Type: "screenshot", TabID: 1, PageURL: "https://example.com"})
+
+	if q.Len() != 3 {
+		t.Fatalf("screenshot after non-screenshot should not dedup, got %d", q.Len())
+	}
+}
+
+func TestInbox_ScreenshotDedup_PreservesNote(t *testing.T) {
+	q := NewPushInbox(10)
+	q.Enqueue(PushEvent{ID: "ss-1", Type: "screenshot", TabID: 1, PageURL: "https://example.com", Note: "old note"})
+	q.Enqueue(PushEvent{ID: "ss-2", Type: "screenshot", TabID: 1, PageURL: "https://example.com", Note: "new note"})
+
+	events := q.DrainAll()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 deduped event, got %d", len(events))
+	}
+	if events[0].Note != "new note" {
+		t.Fatalf("expected new note, got %q", events[0].Note)
+	}
+}
+
 func TestInbox_BulkEviction(t *testing.T) {
 	q := NewPushInbox(2)
 	q.Enqueue(PushEvent{ID: "1"})


### PR DESCRIPTION
## Summary

- **Inbox dedup**: Consecutive screenshots from the same tab+URL replace instead of appending, collapsing rapid-fire identical captures into one
- **Piggyback cap**: `appendPushPiggyback` delivers at most 1 screenshot (the most recent) per tool response, with a text summary of skipped count
- **Buffer clear**: `configure(clear, buffer=all)` now drains the push inbox; added `buffer=inbox` as a standalone option

## Context

During browser automation testing, push screenshots were flooding MCP tool responses with 8-15+ duplicate images per action, causing 16-25k+ token responses and output truncation. This three-layer fix addresses the problem at capture (dedup), delivery (cap), and management (clear).

## Test plan

- [x] 6 inbox dedup tests (consecutive same tab+URL, different URL, different tab, non-screenshot, interrupted, preserves note)
- [x] 4 piggyback cap tests (caps to one, non-screenshot passthrough, skipped count summary, single screenshot no summary)
- [x] 3 clear inbox tests (all drains inbox, inbox buffer standalone, specific buffers includes inbox)
- [x] All existing push/inbox/piggyback tests pass
- [x] Full `make test` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)