### PR TITLE
docs: sync analyze product-spec with current 27-mode surface

### DIFF
--- a/docs/features/feature/analyze-tool/index.md
+++ b/docs/features/feature/analyze-tool/index.md
@@ -58,4 +58,7 @@ Structured extraction modes:
 - `analyze({what:"form_state"})` returns current form values and field metadata.
 - `analyze({what:"data_table"})` returns parsed table headers/rows without `execute_js` string parsing.
 
+Aliases:
+- `history` → `navigation_patterns` (quiet alias, dispatches correctly but hidden from schema enum).
+
 Queue saturation for extension-dispatched analyze actions now fails fast with a structured `queue_full` response (via shared enqueue helper), instead of entering async wait/poll flow.

--- a/docs/features/feature/analyze-tool/product-spec.md
+++ b/docs/features/feature/analyze-tool/product-spec.md
@@ -2,10 +2,10 @@
 feature: analyze-tool
 status: shipped
 tool: analyze
-version: v7.0
+version: 0.7.12
 doc_type: product-spec
 feature_id: feature-analyze-tool
-last_reviewed: 2026-02-17
+last_reviewed: 2026-03-05
 ---
 
 # Analyze Product Spec (TARGET)
@@ -14,7 +14,7 @@ last_reviewed: 2026-02-17
 Run analysis and command-driven browser inspection workflows that go beyond passive observation.
 
 ## Modes (`what`)
-`dom`, `performance`, `accessibility`, `error_clusters`, `history`, `security_audit`, `third_party_audit`, `link_health`, `link_validation`, `page_summary`, `annotations`, `annotation_detail`, `api_validation`, `draw_history`, `draw_session`
+`dom`, `performance`, `accessibility`, `error_clusters`, `navigation_patterns`, `security_audit`, `third_party_audit`, `link_health`, `link_validation`, `page_summary`, `annotations`, `annotation_detail`, `api_validation`, `draw_history`, `draw_session`, `computed_styles`, `forms`, `form_state`, `form_validation`, `data_table`, `visual_baseline`, `visual_diff`, `visual_baselines`, `navigation`, `page_structure`, `audit`, `feature_gates`
 
 ## Behavior Model
 - Sync by default.
@@ -23,13 +23,19 @@ Run analysis and command-driven browser inspection workflows that go beyond pass
 
 ## Mode Classes
 1. Extension-backed command modes
-- `dom`, `accessibility`, `link_health`, `page_summary`
+- `dom`, `accessibility`, `link_health`, `page_summary`, `computed_styles`, `forms`, `form_state`, `form_validation`, `data_table`, `navigation`, `page_structure`, `feature_gates`
 
 2. Server-side analysis modes
-- `performance`, `error_clusters`, `history`, `security_audit`, `third_party_audit`, `link_validation`, `api_validation`
+- `performance`, `error_clusters`, `navigation_patterns`, `security_audit`, `third_party_audit`, `link_validation`, `api_validation`, `audit`
 
 3. Annotation/session modes
 - `annotations`, `annotation_detail`, `draw_history`, `draw_session`
+
+4. Visual regression modes
+- `visual_baseline`, `visual_diff`, `visual_baselines`
+
+## Aliases
+- `history` → `navigation_patterns` (quiet alias, dispatches correctly but hidden from enum)
 
 ## Requirements
 - `ANALYZE_PROD_001`: `what` is required and enum-validated.


### PR DESCRIPTION
## Summary
- Sync analyze product-spec mode list with schema enum (27 modes, was 15)
- Rename `history` → `navigation_patterns` with quiet alias documentation
- Add missing mode classes: visual regression, structured extraction, audit
- Document `history` alias in both `index.md` and `product-spec.md`
- Update version to 0.7.12 and last_reviewed date

## Test plan
- [x] Docs-only change, no code modified
- [x] Mode list matches `internal/schema/analyze.go` enum exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)