### PR TITLE
Polish installer UX and harden direct binary MCP config

### DIFF
--- a/cmd/dev-console/native_install.go
+++ b/cmd/dev-console/native_install.go
@@ -22,6 +22,41 @@ var installerLegacyServerKeys = []string{
 	"gasoline",
 }
 
+func manualExtensionSetupChecklist(extDir string) []string {
+	return []string{
+		"BROWSER EXTENSION (MANUAL STEP REQUIRED):",
+		"   The installer staged extension files, but it cannot click browser UI controls for you.",
+		"   1) Open chrome://extensions (or brave://extensions)",
+		"   2) Enable Developer mode",
+		"   3) Click Load unpacked and select:",
+		fmt.Sprintf("      %s", extDir),
+		"   4) Pin Gasoline in the browser toolbar (recommended)",
+		"   5) Open the Gasoline popup and click Track This Tab",
+	}
+}
+
+func printManualExtensionSetupChecklist(extDir string) {
+	lines := manualExtensionSetupChecklist(extDir)
+	if len(lines) == 0 {
+		return
+	}
+	stderrf("\033[1;33m%s\033[0m\n", lines[0])
+	for _, line := range lines[1:] {
+		stderrf("%s\n", line)
+	}
+}
+
+func printInstallerPanel(title string, lines []string) {
+	const border = "+----------------------------------------------------------+"
+	stderrf("\033[1;36m%s\033[0m\n", border)
+	stderrf("\033[1;36m| \033[1m%-56s\033[1;36m |\033[0m\n", title)
+	stderrf("\033[1;36m%s\033[0m\n", border)
+	for _, line := range lines {
+		stderrf("\033[1;36m|\033[0m %-58s \033[1;36m|\033[0m\n", line)
+	}
+	stderrf("\033[1;36m%s\033[0m\n", border)
+}
+
 // runNativeInstall detects and configures all supported MCP clients.
 func runNativeInstall() {
 	// 1. Silent Reset (Kill stale instances)
@@ -119,15 +154,17 @@ func runNativeInstall() {
 
 	// 5. BIG SUCCESS MESSAGE
 	stderrf("\n\033[1;32m✅ GASOLINE INSTALLED & RUNNING!\033[0m\n")
-	stderrf("\033[1;34m--------------------------------------------------\033[0m\n")
-	stderrf("\033[1;33m1. INSTALL YOUR EXTENSION AT:\033[0m\n")
-	stderrf("   \033[1m%s\033[0m\n", extDir)
-	stderrf("   (Open chrome://extensions -> Developer mode -> Load unpacked)\n")
+	printInstallerPanel("INSTALL SUMMARY", []string{
+		"Gasoline server started in background on port 7890.",
+		"MCP clients are configured with direct binary path (no npx).",
+		fmt.Sprintf("Binary path: %s", exe),
+	})
 	stderrf("\n")
-	stderrf("\033[1;33m2. READY TO COOK:\033[0m\n")
+	printManualExtensionSetupChecklist(extDir)
+	stderrf("\033[1;33mREADY TO COOK:\033[0m\n")
 	stderrf("   The Gasoline server is active on port 7890.\n")
 	stderrf("   Your AI tool (Claude, Cursor, etc.) is now configured.\n")
-	stderrf("\033[1;34m--------------------------------------------------\033[0m\n")
+	stderrf("\033[1;36m+----------------------------------------------------------+\033[0m\n")
 }
 
 func startDaemonSilently(exe string) {

--- a/cmd/dev-console/native_install_test.go
+++ b/cmd/dev-console/native_install_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestManualExtensionSetupChecklist_IncludesRequiredSteps(t *testing.T) {
+	extPath := `C:\Users\tester\.gasoline\extension`
+	checklist := manualExtensionSetupChecklist(extPath)
+	joined := strings.Join(checklist, "\n")
+
+	required := []string{
+		"MANUAL STEP REQUIRED",
+		"cannot click browser UI controls",
+		"chrome://extensions (or brave://extensions)",
+		"Enable Developer mode",
+		"Load unpacked",
+		extPath,
+		"Pin Gasoline",
+		"Track This Tab",
+	}
+
+	for _, want := range required {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("checklist missing %q; got:\n%s", want, joined)
+		}
+	}
+}

--- a/docs/architecture/flow-maps/README.md
+++ b/docs/architecture/flow-maps/README.md
@@ -58,6 +58,7 @@ Each flow map should include:
 - [Binary Watcher Upgrade Detection](./binary-watcher-upgrade-detection.md)
 - [Feature Doc Frontmatter and Freshness Gates](./feature-doc-frontmatter-freshness-gates.md)
 - [LLM Fast Verify Gate](./llm-fast-verify-gate.md)
+- [Installer Binary Path and Manual Extension Handoff](./installer-binary-path-and-manual-extension-handoff.md)
 - [Interact Navigate and Document](./interact-navigate-and-document.md)
 - [Interact Action Toast Label Normalization](./interact-action-toast-label-normalization.md)
 - [Interact Action Surface Registry](./interact-action-surface-registry.md)

--- a/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
+++ b/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
@@ -1,0 +1,93 @@
+---
+doc_type: flow_map
+flow_id: installer-binary-path-and-manual-extension-handoff
+status: active
+last_reviewed: 2026-03-05
+owners:
+  - Brenn
+entrypoints:
+  - scripts/install.sh
+  - scripts/install.ps1
+  - cmd/dev-console/native_install.go:runNativeInstall
+  - npm/gasoline-agentic-browser/lib/install.js:executeInstall
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py:run_install
+code_paths:
+  - scripts/install.sh
+  - scripts/install.ps1
+  - server/scripts/install.js
+  - cmd/dev-console/native_install.go
+  - npm/gasoline-agentic-browser/lib/config.js
+  - npm/gasoline-agentic-browser/lib/install.js
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py
+  - docs/mcp-install-guide.md
+test_paths:
+  - cmd/dev-console/native_install_test.go
+  - npm/gasoline-agentic-browser/lib/install.test.js
+  - pypi/gasoline-agentic-browser/tests/test_install.py
+---
+
+# Installer Binary Path and Manual Extension Handoff
+
+## Scope
+
+Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper to ensure:
+
+1. MCP configs use a direct binary path when available.
+2. Installer output clearly states that extension loading is a manual browser action.
+3. Installer output uses a consistent, polished step-and-checklist presentation across entrypoints.
+
+## Entrypoints
+
+1. One-liner installers: `scripts/install.sh` and `scripts/install.ps1`.
+2. Native CLI install flow: `runNativeInstall`.
+3. Wrapper install commands: npm `executeInstall` and PyPI `run_install`.
+
+## Primary Flow
+
+1. Installer resolves platform and downloads/stages binary + extension artifacts.
+2. Wrapper/native install writes MCP client configs.
+3. Config entries prefer resolved binary paths over transient launchers.
+4. Installer prints explicit manual extension checklist:
+   - open extensions page
+   - enable developer mode
+   - load unpacked extension folder
+   - pin extension
+   - click Track This Tab
+5. Installer surfaces a branded panel-style summary at completion with the resolved binary path.
+
+## Error and Recovery Paths
+
+1. If platform binary cannot be resolved, wrappers fall back to command name for compatibility.
+2. If extension cannot be side-loaded automatically, installer still succeeds but instructs user on manual steps.
+3. Missing client config directories are skipped without aborting install.
+
+## State and Contracts
+
+1. MCP server key remains `gasoline-browser-devtools`.
+2. File-based clients must receive deterministic command entries (`command` + `args`).
+3. Installer output must never imply that browser extension installation is fully automatic.
+
+## Code Paths
+
+- `scripts/install.sh`
+- `scripts/install.ps1`
+- `server/scripts/install.js`
+- `cmd/dev-console/native_install.go`
+- `npm/gasoline-agentic-browser/lib/config.js`
+- `npm/gasoline-agentic-browser/lib/install.js`
+- `pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py`
+- `pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py`
+- `docs/mcp-install-guide.md`
+
+## Test Paths
+
+- `cmd/dev-console/native_install_test.go`
+- `npm/gasoline-agentic-browser/lib/install.test.js`
+- `pypi/gasoline-agentic-browser/tests/test_install.py`
+
+## Edit Guardrails
+
+1. Keep wrapper install outputs aligned across npm and PyPI.
+2. Do not regress to `npx`-only config entries for managed installs.
+3. Preserve manual-extension wording in installer output to avoid user confusion.

--- a/docs/features/feature/enhanced-cli-config/flow-map.md
+++ b/docs/features/feature/enhanced-cli-config/flow-map.md
@@ -1,0 +1,13 @@
+---
+doc_type: flow_map_pointer
+status: active
+last_reviewed: 2026-03-05
+canonical_flow_map: ../../../architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
+---
+
+# Enhanced CLI Config Flow Map Pointer
+
+Canonical flow map:
+
+- [Installer Binary Path and Manual Extension Handoff](../../../architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md)
+

--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -4,18 +4,22 @@ feature_id: feature-enhanced-cli-config
 status: proposed
 feature_type: feature
 owners: []
-last_reviewed: 2026-02-23
+last_reviewed: 2026-03-05
 code_paths:
-  - npm/gasoline-mcp/lib/cli.js
-  - npm/gasoline-mcp/lib/skills.js
-  - npm/gasoline-mcp/lib/postinstall-skills.js
-  - pypi/gasoline-mcp/gasoline_mcp/platform.py
-  - pypi/gasoline-mcp/gasoline_mcp/skills.py
-  - scripts/install-bundled-skills.sh
+  - cmd/dev-console/native_install.go
+  - scripts/install.sh
+  - scripts/install.ps1
+  - server/scripts/install.js
+  - npm/gasoline-agentic-browser/lib/config.js
+  - npm/gasoline-agentic-browser/lib/install.js
+  - npm/gasoline-agentic-browser/lib/cli.js
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py
+  - docs/mcp-install-guide.md
 test_paths:
-  - pypi/gasoline-mcp/tests/test_install.py
-  - pypi/gasoline-mcp/tests/test_skills.py
-  - tests/cli/cli-integration.test.cjs
+  - cmd/dev-console/native_install_test.go
+  - npm/gasoline-agentic-browser/lib/install.test.js
+  - pypi/gasoline-agentic-browser/tests/test_install.py
 ---
 
 # Enhanced Cli Config
@@ -32,6 +36,7 @@ test_paths:
 - Product Spec: [product-spec.md](./product-spec.md)
 - Tech Spec: [tech-spec.md](./tech-spec.md)
 - QA Plan: [qa-plan.md](./qa-plan.md)
+- Flow Map Pointer: [flow-map.md](./flow-map.md)
 
 ## Requirement IDs
 

--- a/docs/mcp-install-guide.md
+++ b/docs/mcp-install-guide.md
@@ -13,7 +13,13 @@ curl -sSL https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-d
 This script:
 1.  **Downloads** the latest stable binary.
 2.  **Installs** the browser extension files to `~/.gasoline/extension`.
-3.  **Auto-configures** all detected MCP clients listed below.
+3.  **Auto-configures** all detected MCP clients listed below to run the binary directly (no `npx`).
+4.  **Displays** a polished, step-by-step install UI with progress and a final checklist card.
+
+Important:
+- The installer **cannot** click browser UI for you.
+- You must manually open `chrome://extensions` (or `brave://extensions`), enable **Developer mode**, then click **Load unpacked** and select `~/.gasoline/extension`.
+- After loading, pin the extension (recommended) and click **Track This Tab** in the popup.
 
 ## Per-Tool Reference
 

--- a/npm/gasoline-agentic-browser/lib/config.js
+++ b/npm/gasoline-agentic-browser/lib/config.js
@@ -23,6 +23,48 @@ const MCP_SERVER_NAME = 'gasoline-browser-devtools';
 const LEGACY_MCP_SERVER_NAMES = ['gasoline-agentic-browser', 'gasoline'];
 
 /**
+ * Resolve the managed gasoline binary path from the installed npm package layout.
+ * Falls back to command name when an absolute binary path cannot be discovered.
+ * @returns {string} Absolute binary path when discoverable, else command name
+ */
+function resolveManagedBinaryPath() {
+  const envOverride = process.env.GASOLINE_BINARY_PATH;
+  if (envOverride && fs.existsSync(envOverride)) {
+    return path.resolve(envOverride);
+  }
+
+  const platformMap = { darwin: 'darwin', linux: 'linux', win32: 'win32' };
+  const archMap = { x64: 'x64', arm64: 'arm64' };
+  const platform = platformMap[process.platform];
+  const arch = archMap[process.arch];
+  if (!platform || !arch) {
+    return 'gasoline-agentic-browser';
+  }
+
+  const effectiveArch = platform === 'win32' ? 'x64' : arch;
+  const ext = platform === 'win32' ? '.exe' : '';
+  const platformKey = `${platform}-${effectiveArch}`;
+  const binaryName = `gasoline${ext}`;
+  const pkgName = `@brennhill/gasoline-agentic-browser-${platformKey}`;
+  const packageRoot = path.resolve(__dirname, '..');
+
+  const candidates = [
+    path.join(packageRoot, 'node_modules', pkgName, 'bin', binaryName),
+    path.join(packageRoot, '..', pkgName, 'bin', binaryName),
+    path.join(packageRoot, '..', '..', pkgName, 'bin', binaryName),
+    path.resolve(packageRoot, '..', '..', '..', 'dist', `gasoline-${platformKey}${ext}`),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return path.resolve(candidate);
+    }
+  }
+
+  return 'gasoline-agentic-browser';
+}
+
+/**
  * Client definitions for all supported AI assistant clients.
  * Each entry describes detection, config path, and install strategy.
  */
@@ -91,8 +133,8 @@ const CLIENT_DEFINITIONS = [
     configPath: { all: '~/.config/opencode/opencode.json' },
     detectDir: { all: '~/.config/opencode' },
     configKey: 'mcp',
-    buildEntry: (envVars) => {
-      const entry = { type: 'local', command: ['gasoline-agentic-browser'], enabled: true };
+    buildEntry: (envVars, binaryCommand = 'gasoline-agentic-browser') => {
+      const entry = { type: 'local', command: [binaryCommand], enabled: true };
       if (envVars && Object.keys(envVars).length > 0) entry.env = envVars;
       return entry;
     },
@@ -119,8 +161,8 @@ const CLIENT_DEFINITIONS = [
     configPath: { all: '~/.config/zed/settings.json' },
     detectDir: { all: '~/.config/zed' },
     configKey: 'context_servers',
-    buildEntry: (envVars) => {
-      const entry = { source: 'custom', command: 'gasoline-agentic-browser', args: [] };
+    buildEntry: (envVars, binaryCommand = 'gasoline-agentic-browser') => {
+      const entry = { source: 'custom', command: binaryCommand, args: [] };
       if (envVars && Object.keys(envVars).length > 0) entry.env = envVars;
       return entry;
     },
@@ -530,4 +572,5 @@ module.exports = {
   validateMCPConfig,
   mergeGassolineConfig,
   parseEnvVar,
+  resolveManagedBinaryPath,
 };

--- a/npm/gasoline-agentic-browser/lib/install.js
+++ b/npm/gasoline-agentic-browser/lib/install.js
@@ -19,17 +19,19 @@ const {
   readConfigFile,
   writeConfigFile,
   mergeGassolineConfig,
+  resolveManagedBinaryPath,
 } = require('./config');
 
 /**
  * Generate default MCP config for gasoline
  * @returns {Object} Default gasoline MCP config
  */
-function generateDefaultConfig() {
+function generateDefaultConfig(options = {}) {
+  const { binaryCommand = resolveManagedBinaryPath() } = options;
   return {
     mcpServers: {
       [MCP_SERVER_NAME]: {
-        command: 'gasoline-agentic-browser',
+        command: binaryCommand,
         args: [],
       },
     },
@@ -41,8 +43,9 @@ function generateDefaultConfig() {
  * @param {Object} [envVars] Optional env vars
  * @returns {string} JSON string of the gasoline MCP entry
  */
-function buildMcpEntry(envVars = {}) {
-  const entry = { command: 'gasoline-agentic-browser', args: [] };
+function buildMcpEntry(envVars = {}, options = {}) {
+  const { binaryCommand = resolveManagedBinaryPath() } = options;
+  const entry = { command: binaryCommand, args: [] };
   if (envVars && Object.keys(envVars).length > 0) {
     entry.env = envVars;
   }
@@ -56,8 +59,8 @@ function buildMcpEntry(envVars = {}) {
  * @returns {Object} {success, name, method, message}
  */
 function installViaCli(def, options) {
-  const { dryRun = false, envVars = {} } = options;
-  const entryJson = buildMcpEntry(envVars);
+  const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath() } = options;
+  const entryJson = buildMcpEntry(envVars, { binaryCommand });
   const cmd = def.detectCommand;
   const args = [...def.installArgs];
 
@@ -109,7 +112,7 @@ function installViaCli(def, options) {
  * @returns {Object} {success, name, method, path, isNew, message}
  */
 function installViaFile(def, options) {
-  const { dryRun = false, envVars = {} } = options;
+  const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath() } = options;
   const cfgPath = getClientConfigPath(def);
 
   if (!cfgPath) {
@@ -127,9 +130,9 @@ function installViaFile(def, options) {
   // Build entry in the right format for this client
   let gasolineEntry;
   if (def.buildEntry) {
-    gasolineEntry = def.buildEntry(envVars);
+    gasolineEntry = def.buildEntry(envVars, binaryCommand);
   } else {
-    gasolineEntry = { command: 'gasoline-agentic-browser', args: [] };
+    gasolineEntry = { command: binaryCommand, args: [] };
     if (envVars && Object.keys(envVars).length > 0) {
       gasolineEntry.env = envVars;
     }
@@ -188,7 +191,13 @@ function installToClient(def, options) {
  * @returns {Object} {success, installed, errors, total}
  */
 function executeInstall(options = {}) {
-  const { dryRun = false, envVars = {}, verbose = false, targetTool } = options;
+  const {
+    dryRun = false,
+    envVars = {},
+    verbose = false,
+    targetTool,
+    binaryCommand = resolveManagedBinaryPath(),
+  } = options;
 
   // Targeted install: filter to a single client by alias
   let clients;
@@ -219,7 +228,7 @@ function executeInstall(options = {}) {
 
   for (const def of clients) {
     try {
-      const installResult = installToClient(def, { dryRun, envVars });
+      const installResult = installToClient(def, { dryRun, envVars, binaryCommand });
 
       if (installResult.success) {
         result.installed.push(installResult);

--- a/npm/gasoline-agentic-browser/lib/install.test.js
+++ b/npm/gasoline-agentic-browser/lib/install.test.js
@@ -20,7 +20,12 @@ test('generateDefaultConfig returns valid MCP config', () => {
   const cfg = generateDefaultConfig();
   assert.ok(cfg.mcpServers);
   assert.ok(cfg.mcpServers['gasoline-browser-devtools']);
-  assert.equal(cfg.mcpServers['gasoline-browser-devtools'].command, 'gasoline-agentic-browser');
+  assert.ok(cfg.mcpServers['gasoline-browser-devtools'].command.length > 0);
+});
+
+test('generateDefaultConfig honors binaryCommand override', () => {
+  const cfg = generateDefaultConfig({ binaryCommand: '/tmp/gasoline-bin' });
+  assert.equal(cfg.mcpServers['gasoline-browser-devtools'].command, '/tmp/gasoline-bin');
 });
 
 // --- buildMcpEntry ---
@@ -28,7 +33,7 @@ test('generateDefaultConfig returns valid MCP config', () => {
 test('buildMcpEntry returns JSON string for MCP entry', () => {
   const entry = buildMcpEntry();
   const parsed = JSON.parse(entry);
-  assert.equal(parsed.command, 'gasoline-agentic-browser');
+  assert.ok(parsed.command.length > 0);
   assert.deepEqual(parsed.args, []);
 });
 
@@ -36,6 +41,12 @@ test('buildMcpEntry includes env vars when provided', () => {
   const entry = buildMcpEntry({ DEBUG: '1' });
   const parsed = JSON.parse(entry);
   assert.equal(parsed.env.DEBUG, '1');
+});
+
+test('buildMcpEntry honors binaryCommand override', () => {
+  const entry = buildMcpEntry({}, { binaryCommand: '/tmp/gasoline-bin' });
+  const parsed = JSON.parse(entry);
+  assert.equal(parsed.command, '/tmp/gasoline-bin');
 });
 
 // --- installToClient: file-type ---
@@ -52,14 +63,14 @@ test('installToClient creates new config for file-type client', () => {
     detectDir: { all: tmp },
   };
 
-  const result = installToClient(def, { dryRun: false, envVars: {} });
+  const result = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/gasoline-bin' });
   assert.equal(result.success, true);
   assert.equal(result.method, 'file');
   assert.equal(result.isNew, true);
 
   const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
   assert.ok(written.mcpServers['gasoline-browser-devtools']);
-  assert.equal(written.mcpServers['gasoline-browser-devtools'].command, 'gasoline-agentic-browser');
+  assert.equal(written.mcpServers['gasoline-browser-devtools'].command, '/tmp/gasoline-bin');
 
   fs.rmSync(tmp, { recursive: true });
 });
@@ -237,6 +248,7 @@ test('executeInstall with invalid targetTool returns error', () => {
 
 test('installToClient creates OpenCode-format config with mcp key', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const binaryCommand = '/tmp/gasoline-bin';
 
   const def = {
     id: 'test-opencode',
@@ -245,14 +257,14 @@ test('installToClient creates OpenCode-format config with mcp key', () => {
     configPath: { all: path.join(tmp, 'opencode.json') },
     detectDir: { all: tmp },
     configKey: 'mcp',
-    buildEntry: (envVars) => {
-      const entry = { type: 'local', command: ['gasoline-agentic-browser'], enabled: true };
+    buildEntry: (envVars, resolvedBinaryCommand) => {
+      const entry = { type: 'local', command: [resolvedBinaryCommand], enabled: true };
       if (envVars && Object.keys(envVars).length > 0) entry.env = envVars;
       return entry;
     },
   };
 
-  const result = installToClient(def, { dryRun: false, envVars: {} });
+  const result = installToClient(def, { dryRun: false, envVars: {}, binaryCommand });
   assert.equal(result.success, true);
   assert.equal(result.isNew, true);
 
@@ -260,7 +272,7 @@ test('installToClient creates OpenCode-format config with mcp key', () => {
   assert.ok(written.mcp, 'should have mcp key');
   assert.ok(written.mcp['gasoline-browser-devtools'], 'should have gasoline under mcp');
   assert.equal(written.mcp['gasoline-browser-devtools'].type, 'local');
-  assert.deepEqual(written.mcp['gasoline-browser-devtools'].command, ['gasoline-agentic-browser']);
+  assert.deepEqual(written.mcp['gasoline-browser-devtools'].command, [binaryCommand]);
   assert.equal(written.mcp['gasoline-browser-devtools'].enabled, true);
   assert.equal(written.mcpServers, undefined, 'should not have mcpServers');
 
@@ -270,6 +282,7 @@ test('installToClient creates OpenCode-format config with mcp key', () => {
 test('installToClient merges OpenCode config preserving existing entries', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
   const cfgPath = path.join(tmp, 'opencode.json');
+  const binaryCommand = '/tmp/gasoline-bin';
 
   // Pre-existing OpenCode config with another server
   fs.writeFileSync(cfgPath, JSON.stringify({
@@ -284,10 +297,10 @@ test('installToClient merges OpenCode config preserving existing entries', () =>
     configPath: { all: cfgPath },
     detectDir: { all: tmp },
     configKey: 'mcp',
-    buildEntry: () => ({ type: 'local', command: ['gasoline-agentic-browser'], enabled: true }),
+    buildEntry: (_envVars, resolvedBinaryCommand) => ({ type: 'local', command: [resolvedBinaryCommand], enabled: true }),
   };
 
-  const result = installToClient(def, { dryRun: false, envVars: {} });
+  const result = installToClient(def, { dryRun: false, envVars: {}, binaryCommand });
   assert.equal(result.success, true);
 
   const written = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
@@ -302,6 +315,7 @@ test('installToClient merges OpenCode config preserving existing entries', () =>
 
 test('installToClient creates Zed-format config with context_servers key', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gasoline-install-'));
+  const binaryCommand = '/tmp/gasoline-bin';
 
   const def = {
     id: 'test-zed',
@@ -310,21 +324,21 @@ test('installToClient creates Zed-format config with context_servers key', () =>
     configPath: { all: path.join(tmp, 'settings.json') },
     detectDir: { all: tmp },
     configKey: 'context_servers',
-    buildEntry: (envVars) => {
-      const entry = { source: 'custom', command: 'gasoline-agentic-browser', args: [] };
+    buildEntry: (envVars, resolvedBinaryCommand) => {
+      const entry = { source: 'custom', command: resolvedBinaryCommand, args: [] };
       if (envVars && Object.keys(envVars).length > 0) entry.env = envVars;
       return entry;
     },
   };
 
-  const result = installToClient(def, { dryRun: false, envVars: {} });
+  const result = installToClient(def, { dryRun: false, envVars: {}, binaryCommand });
   assert.equal(result.success, true);
 
   const written = JSON.parse(fs.readFileSync(path.join(tmp, 'settings.json'), 'utf8'));
   assert.ok(written.context_servers, 'should have context_servers key');
   assert.ok(written.context_servers['gasoline-browser-devtools']);
   assert.equal(written.context_servers['gasoline-browser-devtools'].source, 'custom');
-  assert.equal(written.context_servers['gasoline-browser-devtools'].command, 'gasoline-agentic-browser');
+  assert.equal(written.context_servers['gasoline-browser-devtools'].command, binaryCommand);
   assert.equal(written.mcpServers, undefined, 'should not have mcpServers');
 
   fs.rmSync(tmp, { recursive: true });

--- a/pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py
+++ b/pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py
@@ -10,21 +10,21 @@ import subprocess
 from . import config
 
 
-def generate_default_config():
+def generate_default_config(binary_path="gasoline-agentic-browser"):
     """Generate default MCP config for gasoline."""
     return {
         "mcpServers": {
             config.MCP_SERVER_NAME: {
-                "command": "gasoline-agentic-browser",
+                "command": binary_path,
                 "args": [],
             },
         },
     }
 
 
-def build_mcp_entry(env_vars=None):
+def build_mcp_entry(env_vars=None, binary_path="gasoline-agentic-browser"):
     """Build the MCP entry JSON string for CLI-based install."""
-    entry = {"command": "gasoline-agentic-browser", "args": []}
+    entry = {"command": binary_path, "args": []}
     if env_vars:
         entry["env"] = dict(env_vars)
     return json.dumps(entry)
@@ -34,7 +34,8 @@ def _install_via_cli(definition, options):
     """Install to a CLI-type client (e.g. Claude Code)."""
     dry_run = options.get("dryRun", False)
     env_vars = options.get("envVars", {})
-    entry_json = build_mcp_entry(env_vars)
+    binary_path = options.get("binaryPath", "gasoline-agentic-browser")
+    entry_json = build_mcp_entry(env_vars, binary_path=binary_path)
     cmd = definition["detectCommand"]
     args = list(definition["installArgs"])
 
@@ -84,6 +85,7 @@ def _install_via_file(definition, options):
     """Install to a file-type client (config file write)."""
     dry_run = options.get("dryRun", False)
     env_vars = options.get("envVars", {})
+    binary_path = options.get("binaryPath", "gasoline-agentic-browser")
     cfg_path = config.get_client_config_path(definition)
 
     if not cfg_path:
@@ -95,14 +97,14 @@ def _install_via_file(definition, options):
             "message": "No config path for this platform",
         }
 
-    gasoline_entry = {"command": "gasoline-agentic-browser", "args": []}
+    gasoline_entry = {"command": binary_path, "args": []}
 
     read_result = config.read_config_file(cfg_path)
     if read_result["valid"]:
         config_data = read_result["data"]
         is_new = False
     else:
-        config_data = generate_default_config()
+        config_data = generate_default_config(binary_path=binary_path)
         is_new = True
 
     merged = config.merge_gasoline_config(config_data, gasoline_entry, env_vars)
@@ -139,6 +141,7 @@ def execute_install(options=None):
     dry_run = options.get("dryRun", False)
     env_vars = options.get("envVars", {})
     verbose = options.get("verbose", False)
+    binary_path = options.get("binaryPath", "gasoline-agentic-browser")
 
     clients = (
         options["_clientOverrides"]
@@ -155,7 +158,11 @@ def execute_install(options=None):
 
     for definition in clients:
         try:
-            install_result = install_to_client(definition, {"dryRun": dry_run, "envVars": env_vars})
+            install_result = install_to_client(definition, {
+                "dryRun": dry_run,
+                "envVars": env_vars,
+                "binaryPath": binary_path,
+            })
 
             if install_result["success"]:
                 result["installed"].append(install_result)

--- a/pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py
+++ b/pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py
@@ -103,7 +103,12 @@ def show_config():
     from . import config as cfg_mod  # pylint: disable=import-outside-toplevel
     import json  # pylint: disable=import-outside-toplevel
 
-    mcp = install.generate_default_config()
+    try:
+        binary_path = get_binary_path()
+    except RuntimeError:
+        binary_path = "gasoline-agentic-browser"
+
+    mcp = install.generate_default_config(binary_path=binary_path)
 
     print("📋 Gasoline Agentic Browser Configuration\n")
     print("Add this to your AI assistant settings:\n")
@@ -173,10 +178,16 @@ def run_install(args):
     """Run install command."""
     from . import install  # pylint: disable=import-outside-toplevel
 
+    try:
+        binary_path = get_binary_path()
+    except RuntimeError:
+        binary_path = "gasoline-agentic-browser"
+
     options = {
         "dryRun": "--dry-run" in args,
         "envVars": _parse_env_args(args),
         "verbose": "--verbose" in args,
+        "binaryPath": binary_path,
     }
 
     try:

--- a/pypi/gasoline-agentic-browser/tests/test_install.py
+++ b/pypi/gasoline-agentic-browser/tests/test_install.py
@@ -25,6 +25,10 @@ class TestGenerateDefaultConfig(unittest.TestCase):
         self.assertIn(MCP_SERVER_NAME, cfg["mcpServers"])
         self.assertEqual(cfg["mcpServers"][MCP_SERVER_NAME]["command"], "gasoline-agentic-browser")
 
+    def test_honors_binary_path_override(self):
+        cfg = generate_default_config(binary_path="/tmp/gasoline-bin")
+        self.assertEqual(cfg["mcpServers"][MCP_SERVER_NAME]["command"], "/tmp/gasoline-bin")
+
 
 class TestBuildMcpEntry(unittest.TestCase):
     def test_returns_json_string(self):
@@ -37,6 +41,11 @@ class TestBuildMcpEntry(unittest.TestCase):
         parsed = json.loads(entry)
         self.assertEqual(parsed["env"]["DEBUG"], "1")
 
+    def test_honors_binary_path_override(self):
+        entry = build_mcp_entry(binary_path="/tmp/gasoline-bin")
+        parsed = json.loads(entry)
+        self.assertEqual(parsed["command"], "/tmp/gasoline-bin")
+
 
 class TestInstallToClient(unittest.TestCase):
     def test_creates_new_file_config(self):
@@ -48,13 +57,14 @@ class TestInstallToClient(unittest.TestCase):
                 "configPath": {"all": cfg_path},
                 "detectDir": {"all": tmp},
             }
-            result = install_to_client(d, {"dryRun": False, "envVars": {}})
+            result = install_to_client(d, {"dryRun": False, "envVars": {}, "binaryPath": "/tmp/gasoline-bin"})
             self.assertTrue(result["success"])
             self.assertTrue(result["isNew"])
 
             with open(cfg_path) as f:
                 written = json.load(f)
             self.assertIn(MCP_SERVER_NAME, written["mcpServers"])
+            self.assertEqual(written["mcpServers"][MCP_SERVER_NAME]["command"], "/tmp/gasoline-bin")
         finally:
             shutil.rmtree(tmp)
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,17 +19,68 @@ $EXT_DIR = Join-Path $INSTALL_DIR "extension"
 # Release version source of truth.
 $VERSION_URL = "https://raw.githubusercontent.com/$REPO/STABLE/VERSION"
 
-Write-Host "🔥 Gasoline Agentic Browser Installer" -ForegroundColor Cyan
-Write-Host "--------------------------------------------------" -ForegroundColor Cyan
+$TOTAL_STEPS = 7
+function Write-Panel([string]$Title, [string[]]$Lines) {
+    Write-Host "+----------------------------------------------------------+" -ForegroundColor Cyan
+    $titleLine = "{0,-56}" -f $Title
+    Write-Host ("| " + $titleLine + " |") -ForegroundColor Cyan
+    Write-Host "+----------------------------------------------------------+" -ForegroundColor Cyan
+    foreach ($line in $Lines) {
+        $content = "{0,-58}" -f $line
+        Write-Host ("|" + " " + $content + " |") -ForegroundColor Cyan
+    }
+    Write-Host "+----------------------------------------------------------+" -ForegroundColor Cyan
+}
+function Write-Banner() {
+    Write-Host ""
+    Write-Host '   ____                 _ _            ' -ForegroundColor Cyan
+    Write-Host '  / ___| __ _ ___  ___ | (_)_ __   ___ ' -ForegroundColor Cyan
+    Write-Host " | |  _ / _` / __|/ _ \| | | '_ \ / _ \\" -ForegroundColor Cyan
+    Write-Host ' | |_| | (_| \__ \ (_) | | | | | |  __/' -ForegroundColor Cyan
+    Write-Host '  \____|\__,_|___/\___/|_|_|_| |_|\___|' -ForegroundColor Cyan
+    Write-Host ""
+    Write-Panel -Title "GASOLINE INSTALLER" -Lines @(
+        "Polished one-shot setup for binary + extension + MCP config.",
+        "",
+        "Install flow:",
+        "  1) Resolve latest stable release",
+        "  2) Download + verify binary",
+        "  3) Stage extension files",
+        "  4) Configure MCP clients",
+        "  5) Show manual browser checklist"
+    )
+}
+function Write-Progress([int]$Number) {
+    $width = 28
+    $filled = [Math]::Floor(($Number / [double]$TOTAL_STEPS) * $width)
+    $bar = ("#" * $filled).PadRight($width, "-")
+    $pct = [Math]::Floor(($Number / [double]$TOTAL_STEPS) * 100)
+    Write-Host "   [$bar] $pct%" -ForegroundColor Yellow
+}
+function Write-Step([int]$Number, [string]$Message) {
+    Write-Host ""
+    Write-Host "[$Number/$TOTAL_STEPS] $Message" -ForegroundColor Cyan
+    Write-Progress $Number
+}
+function Write-StepOk([string]$Message) {
+    Write-Host "   ✓ $Message" -ForegroundColor Green
+}
+function Write-StepNote([string]$Message) {
+    Write-Host "   -> $Message" -ForegroundColor DarkGray
+}
+
+Write-Banner
 
 # 1. Fetch Version: Get the latest stable version tag from GitHub.
-Write-Host "🔍 Checking for updates..."
+Write-Step 1 "Resolving latest stable version"
 $VERSION = (Invoke-RestMethod -Uri $VERSION_URL).Trim()
-Write-Host "✨ Version: v$VERSION (win32-x64)"
+Write-StepOk "Version: v$VERSION (win32-x64)"
 
 # 2. Directory Setup: Ensure the target installation folders exist on the filesystem.
+Write-Step 2 "Preparing install directories"
 if (-not (Test-Path $BIN_DIR)) { New-Item -Path $BIN_DIR -ItemType Directory -Force }
 if (-not (Test-Path $EXT_DIR)) { New-Item -Path $EXT_DIR -ItemType Directory -Force }
+Write-StepOk "Install root: $INSTALL_DIR"
 
 # 3. Binary Installation: Download the Windows-native executable.
 $GASOLINE_BIN = Join-Path $BIN_DIR "gasoline-agentic-browser.exe"
@@ -37,7 +88,8 @@ $BINARY_NAME = "gasoline-agentic-browser-win32-x64.exe"
 $BINARY_URL = "https://github.com/$REPO/releases/download/v$VERSION/$BINARY_NAME"
 $CHECKSUM_URL = "https://github.com/$REPO/releases/download/v$VERSION/checksums.txt"
 
-Write-Host "⬇️  Downloading latest binary..."
+Write-Step 3 "Downloading and verifying binary"
+Write-StepNote "Downloading release artifact and validating integrity"
 # Download to a temporary '.tmp' file to ensure an atomic replacement later.
 Invoke-WebRequest -Uri $BINARY_URL -OutFile "$GASOLINE_BIN.tmp"
 
@@ -62,10 +114,12 @@ try {
 
 # Atomically replace the old binary with the newly downloaded and verified version.
 Move-Item -Path "$GASOLINE_BIN.tmp" -Destination $GASOLINE_BIN -Force
+Write-StepOk "Installed binary: $GASOLINE_BIN"
 
 # 5. Extension Staging: Refresh the browser extension files.
 # Tries the optimized release asset first, falling back to the full source zip if missing.
-Write-Host "⬇️  Refreshing browser extension..."
+Write-Step 4 "Staging browser extension files (manual browser load required)"
+Write-StepNote "Using extension zip when available; source zip fallback for older releases"
 $EXT_ZIP_NAME = "gasoline-extension-v$VERSION.zip"
 $EXT_ZIP_URL = "https://github.com/$REPO/releases/download/v$VERSION/$EXT_ZIP_NAME"
 $TEMP_ZIP = Join-Path $env:TEMP "gasoline-ext.zip"
@@ -89,6 +143,7 @@ try {
 }
 # Cleanup the temporary zip file.
 Remove-Item -Path $TEMP_ZIP -ErrorAction SilentlyContinue
+Write-StepOk "Staged extension directory: $EXT_DIR"
 
 # 6. Native Configuration: Execute the Go binary to handle complex client configuration.
 # The binary's --install flag will:
@@ -96,5 +151,20 @@ Remove-Item -Path $TEMP_ZIP -ErrorAction SilentlyContinue
 #   - Safely update JSON configuration files with Windows-aware paths.
 #   - Reset any running Gasoline processes.
 #   - Display final success message and extension instructions.
-Write-Host "🚀 Finalizing configuration..."
+Write-Step 5 "Configuring MCP clients with direct binary path (no npx)"
+Write-StepNote "Handing off to native installer for client-specific config merges"
 & $GASOLINE_BIN --install
+
+Write-Step 6 "Reminder: browser extension load is manual"
+Write-Panel -Title "MANUAL BROWSER CHECKLIST" -Lines @(
+    "The installer cannot click browser UI controls for you.",
+    "",
+    "1) Open chrome://extensions (or brave://extensions)",
+    "2) Enable Developer mode",
+    "3) Click Load unpacked and select: $EXT_DIR",
+    "4) Pin Gasoline in the toolbar (recommended)",
+    "5) Open popup and click Track This Tab"
+)
+
+Write-Step 7 "Install workflow complete"
+Write-StepOk "If you do not see data, click the extension popup and track the active tab"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,8 +25,10 @@ VERSION_URL="https://raw.githubusercontent.com/$REPO/STABLE/VERSION"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 BOLD='\033[1m'
+DIM='\033[2m'
 NC='\033[0m' # No Color (Reset)
 
 # Cleanup: Ensure temporary files are removed even if the script crashes or is interrupted.
@@ -37,10 +39,70 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo -e "${BLUE}${BOLD}🔥 Gasoline Agentic Browser Installer${NC}"
-echo -e "${BLUE}--------------------------------------------------${NC}"
+TOTAL_STEPS=7
+print_panel() {
+    local title="$1"
+    shift
+    echo -e "${CYAN}+----------------------------------------------------------+${NC}"
+    printf "${CYAN}| ${BOLD}%-56s${CYAN} |${NC}\n" "$title"
+    echo -e "${CYAN}+----------------------------------------------------------+${NC}"
+    for line in "$@"; do
+        printf "${CYAN}|${NC} %-58s ${CYAN}|${NC}\n" "$line"
+    done
+    echo -e "${CYAN}+----------------------------------------------------------+${NC}"
+}
+print_banner() {
+    echo -e "${BLUE}${BOLD}"
+    cat <<'EOF'
+   ____                 _ _            
+  / ___| __ _ ___  ___ | (_)_ __   ___ 
+ | |  _ / _` / __|/ _ \| | | '_ \ / _ \
+ | |_| | (_| \__ \ (_) | | | | | |  __/
+  \____|\__,_|___/\___/|_|_|_| |_|\___|
+EOF
+    echo -e "${NC}"
+    print_panel "GASOLINE INSTALLER" \
+      "Polished one-shot setup for binary + extension + MCP config." \
+      "" \
+      "Install flow:" \
+      "  1) Detect platform and release" \
+      "  2) Download + verify binary" \
+      "  3) Stage extension files" \
+      "  4) Configure MCP clients" \
+      "  5) Show manual browser checklist"
+}
+progress_bar() {
+    local index="$1"
+    local width=28
+    local filled=$(( index * width / TOTAL_STEPS ))
+    local empty=$(( width - filled ))
+    local fill_segment
+    local empty_segment
+    fill_segment=$(printf '%*s' "$filled" '' | tr ' ' '#')
+    empty_segment=$(printf '%*s' "$empty" '' | tr ' ' '-')
+    local pct=$(( index * 100 / TOTAL_STEPS ))
+    echo -e "   ${YELLOW}[${fill_segment}${empty_segment}]${NC} ${pct}%"
+}
+step() {
+    local index="$1"
+    local message="$2"
+    echo -e "\n${BLUE}${BOLD}[$index/$TOTAL_STEPS] $message${NC}"
+    progress_bar "$index"
+}
+step_ok() {
+    local message="$1"
+    echo -e "${GREEN}   ✓ $message${NC}"
+}
+
+step_note() {
+    local message="$1"
+    echo -e "${DIM}   -> $message${NC}"
+}
+
+print_banner
 
 # 1. Platform Detection: Identify the OS and CPU architecture to download the correct binary.
+step 1 "Detecting platform"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 
@@ -65,19 +127,22 @@ if [ "$PLATFORM" == "win32" ]; then
 else
     BINARY_EXT=""
 fi
+step_ok "Platform: $PLATFORM-$E_ARCH"
 
 # 2. Version Check: Fetch the latest stable version number from GitHub.
-echo -e "🔍 Checking for updates..."
+step 2 "Resolving latest stable version"
 VERSION=$(curl -sSL --fail "$VERSION_URL" | tr -d '[:space:]' || true)
 if [ -z "$VERSION" ]; then
     echo -e "${RED}❌ Failed to fetch latest version info.${NC}"
     exit 1
 fi
-echo -e "✨ Version: v$VERSION ($PLATFORM-$E_ARCH)"
+step_ok "Version: v$VERSION ($PLATFORM-$E_ARCH)"
 
 # 3. Directory Setup: Ensure the installation folders exist.
+step 3 "Preparing install directories"
 mkdir -p "$BIN_DIR"
 mkdir -p "$EXT_DIR"
+step_ok "Install root: $INSTALL_DIR"
 
 # 4. Binary Installation: Download the pre-compiled Go binary from GitHub Releases.
 GASOLINE_BIN="$BIN_DIR/gasoline-agentic-browser$BINARY_EXT"
@@ -85,7 +150,8 @@ BINARY_NAME="gasoline-agentic-browser-$PLATFORM-$E_ARCH$BINARY_EXT"
 BINARY_URL="https://github.com/$REPO/releases/download/v$VERSION/$BINARY_NAME"
 CHECKSUM_URL="https://github.com/$REPO/releases/download/v$VERSION/checksums.txt"
 
-echo -e "⬇️  Downloading latest binary..."
+step 4 "Downloading and verifying binary"
+step_note "Downloading release artifact and validating integrity"
 # Download to a temporary location first to ensure an atomic installation.
 if ! curl -fsSL "$BINARY_URL" -o "$TEMP_ROOT/gasoline_dl"; then
     echo -e "${RED}❌ Download failed.${NC}"
@@ -112,10 +178,12 @@ fi
 # Move the verified binary to its final path and set executable permissions.
 mv "$TEMP_ROOT/gasoline_dl" "$GASOLINE_BIN"
 chmod 755 "$GASOLINE_BIN"
+step_ok "Installed binary: $GASOLINE_BIN"
 
 # 6. Extension Staging: Download and extract the browser extension.
 # We try the optimized extension-only zip first, falling back to the full source zip if needed.
-echo -e "⬇️  Refreshing browser extension..."
+step 5 "Staging browser extension files (manual browser load required)"
+step_note "Using extension zip when available; source zip fallback for older releases"
 EXT_ZIP_NAME="gasoline-extension-v$VERSION.zip"
 EXT_ZIP_URL="https://github.com/$REPO/releases/download/v$VERSION/$EXT_ZIP_NAME"
 TEMP_ZIP="$TEMP_ROOT/extension.zip"
@@ -135,6 +203,7 @@ else
         cp -r "$EXTRACT_ROOT/extension/"* "$EXT_DIR/"
     fi
 fi
+step_ok "Staged extension directory: $EXT_DIR"
 
 # 7. Native Configuration: Hand off the complex logic to the Go binary.
 # The binary's --install flag handles:
@@ -142,5 +211,18 @@ fi
 #   - Detecting 9+ different MCP clients (Claude, Cursor, Zed, etc.).
 #   - Safely merging JSON configuration for each client.
 #   - Displaying final success message and extension instructions.
-echo -e "⚙️  Finalizing configuration..."
+step 6 "Configuring MCP clients with direct binary path (no npx)"
+step_note "Handing off to native installer for client-specific config merges"
 "$GASOLINE_BIN" --install
+
+step 7 "Reminder: browser extension load is manual"
+print_panel "MANUAL BROWSER CHECKLIST" \
+  "The installer cannot click browser UI controls for you." \
+  "" \
+  "1) Open chrome://extensions (or brave://extensions)" \
+  "2) Enable Developer mode" \
+  "3) Click Load unpacked and select: $EXT_DIR" \
+  "4) Pin Gasoline in the toolbar (recommended)" \
+  "5) Open popup and click Track This Tab"
+
+echo -e "${GREEN}${BOLD}Install flow complete.${NC}"

--- a/server/scripts/install.js
+++ b/server/scripts/install.js
@@ -9,11 +9,44 @@ const https = require('https')
 const http = require('http')
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 const { spawnSync, spawn } = require('child_process')
 
 const VERSION = require('../package.json').version
 const GITHUB_REPO = 'brennhill/gasoline-agentic-browser-devtools-mcp'
 const BINARY_NAME = 'gasoline'
+
+function printPanel(title, lines = []) {
+  const border = '+----------------------------------------------------------+'
+  console.log(border)
+  const safeTitle = title.padEnd(56, ' ').slice(0, 56)
+  console.log(`| ${safeTitle} |`)
+  console.log(border)
+  for (const line of lines) {
+    const safeLine = String(line).padEnd(58, ' ').slice(0, 58)
+    console.log(`| ${safeLine} |`)
+  }
+  console.log(border)
+}
+
+function printBanner() {
+  console.log('')
+  console.log('   ____                 _ _            ')
+  console.log('  / ___| __ _ ___  ___ | (_)_ __   ___ ')
+  console.log(" | |  _ / _` / __|/ _ \\| | | '_ \\ / _ \\")
+  console.log(' | |_| | (_| \\__ \\ (_) | | | | | |  __/')
+  console.log('  \\____|\\__,_|___/\\___/|_|_|_| |_|\\___|')
+  console.log('')
+  printPanel('GASOLINE INSTALLER', [
+    'Polished setup for binary + background server + extension guidance.',
+    '',
+    'Install flow:',
+    '  1) Clean up old processes',
+    '  2) Download + verify binary',
+    '  3) Start local server',
+    '  4) Show manual extension checklist'
+  ])
+}
 
 /**
  * Kill all running gasoline processes to ensure clean upgrade
@@ -249,6 +282,8 @@ function download(url, dest) {
 }
 
 async function main() {
+  printBanner()
+
   const binDir = path.join(__dirname, '..', 'bin')
   const binaryName = getBinaryName()
   const binaryPath = path.join(binDir, binaryName)
@@ -324,6 +359,16 @@ async function main() {
   await autoStartServer(binaryPath)
 
   console.log('gasoline installed successfully!')
+  const extensionDir = path.join(os.homedir(), '.gasoline', 'extension')
+  printPanel('MANUAL BROWSER CHECKLIST', [
+    'The installer cannot click browser UI controls for you.',
+    '',
+    '1) Open chrome://extensions (or brave://extensions)',
+    '2) Enable Developer mode',
+    `3) Click Load unpacked and select: ${extensionDir}`,
+    '4) Pin Gasoline in the toolbar (recommended)',
+    '5) Open popup and click Track This Tab'
+  ])
   return
 }
 


### PR DESCRIPTION
## Summary
- polish installer UX across shell, PowerShell, native install, and npm postinstall with branded panels/progress/checklists
- keep extension load expectations explicit as a manual browser step
- ensure managed npm/pypi installs prefer direct resolved binary paths (no `npx`) when writing MCP config
- add/update installer flow-map and feature docs to keep code/docs contract aligned

## Validation
- bash -n scripts/install.sh
- node --check server/scripts/install.js
- go test ./cmd/dev-console -run TestManualExtensionSetupChecklist_IncludesRequiredSteps -count=1
- node --test npm/gasoline-agentic-browser/lib/install.test.js
- PYTHONPATH=pypi/gasoline-agentic-browser python3 -m unittest pypi/gasoline-agentic-browser/tests/test_install.py

## Notes
- PowerShell parse check was not run in this environment because `pwsh` is not installed.
