### PR TITLE
smoke: harden annotation parity resume and transient retries

### DIFF
--- a/docs/architecture/flow-maps/annotation-parity-smoke-gate.md
+++ b/docs/architecture/flow-maps/annotation-parity-smoke-gate.md
@@ -23,6 +23,7 @@ This gate validates:
 2. `npm run smoke:annotation-parity`
 3. `npm run smoke:annotation-parity-suite`
 4. `npm run smoke:annotation-parity-benchmark`
+5. `bash scripts/smoke-test.sh --start-from 31`
 
 ## Primary Flow
 
@@ -35,13 +36,15 @@ This gate validates:
 4. Module calls `analyze({what:"annotations", annot_session, url:"http://localhost:3000/*"})` and verifies scoped reduction.
 5. Module calls `analyze({what:"annotation_detail", correlation_id})` and verifies selector/tag/framework/context fields.
 6. Module calls `generate` annotation formats and verifies expected outputs.
+7. Runner enforces daemon version parity (`VERSION` vs `/health.version`) before reusing a running daemon in `--only` / `--start-from` mode.
 
 ## Error and Recovery Paths
 
 1. Ingest failure (`/draw-mode/complete`) surfaces HTTP status + response body in failure output.
-2. MCP startup race on `generate` is retried with bounded attempts and delay.
-3. JSON parse failures in gate assertions are treated as hard failures with parse diagnostics.
-4. Scope filter mismatch failures include returned IDs and counts for triage.
+2. Transient startup or eventual-consistency states (`starting up`, `no_data`, `no annotations`) are retried with bounded attempts in module 31.
+3. Resume/version mismatch (`--only` / `--start-from`) triggers daemon restart before module execution.
+4. JSON parse failures in gate assertions are treated as hard failures with parse diagnostics.
+5. Scope filter mismatch failures include returned IDs and counts for triage.
 
 ## State and Contracts
 
@@ -67,6 +70,8 @@ This gate validates:
    - `visual_test` contains `test(` and `page.goto(`
    - `annotation_report` contains markdown report structure
    - `annotation_issues` contains `issues[]` and `total_count`.
+5. Runner contract checks:
+   - when `VERSION` and `/health.version` differ, stale daemon is not reused for resumed smoke runs.
 
 ## Code Paths
 
@@ -77,6 +82,7 @@ This gate validates:
 5. `cmd/dev-console/server_routes_media_draw_mode.go`
 6. `cmd/dev-console/tools_analyze_annotations_handlers.go`
 7. `cmd/dev-console/tools_generate_annotations.go`
+8. `scripts/tests/framework.sh`
 
 ## Test Paths
 

--- a/docs/features/feature/annotated-screenshots/flow-map.md
+++ b/docs/features/feature/annotated-screenshots/flow-map.md
@@ -12,4 +12,4 @@ This feature's canonical flow maps:
 
 - **Annotation Detail Enrichment:** [annotation-detail-enrichment.md](../../../architecture/flow-maps/annotation-detail-enrichment.md) — parent context, siblings, CSS framework detection, error correlation, LLM hints
 - **Annotation Waiter and Flush:** [analyze-annotations-waiter-and-flush.md](../../../architecture/flow-maps/analyze-annotations-waiter-and-flush.md) — blocking wait, async polling, flush recovery, and cross-project URL scoping safety
-- **Annotation Parity Smoke Gate:** [annotation-parity-smoke-gate.md](../../../architecture/flow-maps/annotation-parity-smoke-gate.md) — deterministic ingest/retrieval/generation gate for annotation workflows
+- **Annotation Parity Smoke Gate:** [annotation-parity-smoke-gate.md](../../../architecture/flow-maps/annotation-parity-smoke-gate.md) — deterministic ingest/retrieval/generation gate with resume version-parity enforcement

--- a/docs/features/feature/annotated-screenshots/index.md
+++ b/docs/features/feature/annotated-screenshots/index.md
@@ -74,5 +74,6 @@ test_paths:
 - `internal/annotation/store_test.go` — `TestStore_SessionTTL_Is2Hours`
 - `cmd/dev-console/tools_analyze_annotations_test.go` — enrichment fields (`selector_candidates`, `js_framework`, `component`), error correlation, hints tests
 - `cmd/dev-console/tools_generate_annotations_test.go` — resilient locator fallback generation tests
-- `scripts/smoke-tests/31-annotation-parity.sh` — deterministic end-to-end ingest/retrieval/generation gate
+- `scripts/smoke-tests/31-annotation-parity.sh` — deterministic end-to-end ingest/retrieval/generation gate with bounded retries for transient startup/no_data windows
 - `scripts/smoke-tests/annotation-parity-benchmark.sh` — repeated pass-rate benchmark with threshold enforcement
+- `scripts/smoke-test.sh` — resume-mode daemon version parity guard prevents stale-daemon false negatives in `--only/--start-from` runs

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -16,6 +16,32 @@ PORT="7890"
 START_FROM=""
 ONLY_MODULE=""
 
+normalize_semver() {
+    local raw="${1:-}"
+    raw="$(printf '%s' "$raw" | tr -d '[:space:]')"
+    raw="${raw#v}"
+
+    if [ -z "$raw" ] || [ "$raw" = "unknown" ] || [ "$raw" = "?" ]; then
+        echo ""
+        return 0
+    fi
+
+    local semver
+    semver="$(printf '%s' "$raw" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?).*/\1/p')"
+    if [ -n "$semver" ]; then
+        echo "$semver"
+    else
+        echo "$raw"
+    fi
+}
+
+versions_match() {
+    local left right
+    left="$(normalize_semver "${1:-}")"
+    right="$(normalize_semver "${2:-}")"
+    [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Parse args: positional port + optional --start-from
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -95,6 +121,9 @@ init_smoke "$PORT"
 # Note: init_smoke sets the EXIT trap (_smoke_master_cleanup).
 # Do NOT set another EXIT trap here — use register_cleanup instead.
 
+EXPECTED_VERSION="${VERSION:-unknown}"
+EXPECTED_VERSION_NORM="$(normalize_semver "$EXPECTED_VERSION")"
+
 # ── Module list ──────────────────────────────────────────
 MODULES=(
     "01-bootstrap.sh"
@@ -131,8 +160,13 @@ MODULES=(
 if lsof -ti :"$PORT" >/dev/null 2>&1; then
     existing_ver=$(curl -s --connect-timeout 2 --max-time 3 "http://localhost:${PORT}/health" 2>/dev/null | jq -r '.version // empty' 2>/dev/null)
     if [ -n "$existing_ver" ]; then
-        echo "  Reusing existing daemon on port $PORT (v${existing_ver})"
-        DAEMON_PID=$(lsof -ti :"$PORT" 2>/dev/null | head -1)
+        if [ -n "$EXPECTED_VERSION_NORM" ] && ! versions_match "$existing_ver" "$EXPECTED_VERSION"; then
+            echo "  Existing daemon version mismatch on port $PORT (have v${existing_ver}, expected v${EXPECTED_VERSION}). Restarting..."
+            kill_server 2>/dev/null || true
+        else
+            echo "  Reusing existing daemon on port $PORT (v${existing_ver})"
+            DAEMON_PID=$(lsof -ti :"$PORT" 2>/dev/null | head -1)
+        fi
     else
         echo "  Port $PORT occupied by non-Gasoline process. Killing..." >&2
         lsof -ti :"$PORT" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -141,12 +175,16 @@ if lsof -ti :"$PORT" >/dev/null 2>&1; then
 fi
 
 BINARY_VERSION=$("$WRAPPER" --version 2>/dev/null || echo "unknown")
+BINARY_VERSION_NORM="$(normalize_semver "$BINARY_VERSION")"
 echo ""
 echo "============================================================"
 echo "  GASOLINE SMOKE TEST SUITE"
 echo "  Port: $PORT | $(date)"
 echo "  Binary: $BINARY_VERSION"
-echo "  Expected: $(cat "$RUNNER_DIR/../VERSION" 2>/dev/null || echo "?")"
+echo "  Expected: $EXPECTED_VERSION"
+if [ -n "$BINARY_VERSION_NORM" ] && [ -n "$EXPECTED_VERSION_NORM" ] && ! versions_match "$BINARY_VERSION" "$EXPECTED_VERSION"; then
+    echo "  WARNING: Wrapper version (v${BINARY_VERSION_NORM}) differs from VERSION (v${EXPECTED_VERSION_NORM})."
+fi
 echo "  ${#MODULES[@]} modules"
 echo "============================================================"
 echo ""
@@ -179,6 +217,13 @@ if [ -n "$START_FROM" ]; then
 
     health_body=$(get_http_body "http://localhost:${PORT}/health" 2>/dev/null || echo "{}")
     daemon_ver=$(echo "$health_body" | jq -r '.version // "unknown"' 2>/dev/null || echo "unknown")
+    if [ -n "$EXPECTED_VERSION_NORM" ] && ! versions_match "$daemon_ver" "$EXPECTED_VERSION"; then
+        echo "  Resume daemon version mismatch (have v${daemon_ver}, expected v${EXPECTED_VERSION}). Restarting..."
+        start_daemon_with_flags --enable-os-upload-automation || true
+        sleep 2
+        health_body=$(get_http_body "http://localhost:${PORT}/health" 2>/dev/null || echo "{}")
+        daemon_ver=$(echo "$health_body" | jq -r '.version // "unknown"' 2>/dev/null || echo "unknown")
+    fi
     echo "  Daemon version: v${daemon_ver}"
     if echo "$health_body" | jq -e '.capture.extension_connected == true' >/dev/null 2>&1; then
         EXTENSION_CONNECTED=true

--- a/scripts/smoke-tests/31-annotation-parity.sh
+++ b/scripts/smoke-tests/31-annotation-parity.sh
@@ -91,20 +91,39 @@ post_parity_annotation() {
         "http://localhost:${PORT}/draw-mode/complete" 2>/dev/null
 }
 
-call_generate_with_startup_retry() {
-    local args="$1"
-    local max_attempts="${2:-5}"
+should_retry_annotation_response() {
+    local response="$1"
+    local text="$2"
+
+    if echo "$text" | grep -qiE "Server is starting up|retry this tool call in [0-9]+ seconds"; then
+        return 0
+    fi
+
+    if check_is_error "$response" && echo "$text" | grep -qiE "no_data|annotation.*not found|annot_session.*not found|no annotations"; then
+        return 0
+    fi
+
+    return 1
+}
+
+call_tool_with_annotation_retry() {
+    local tool_name="$1"
+    local args="$2"
+    local max_attempts="${3:-6}"
+    local sleep_seconds="${4:-1}"
     local response text
-    for _ in $(seq 1 "$max_attempts"); do
-        response=$(call_tool "generate" "$args")
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        response=$(call_tool "$tool_name" "$args")
         text=$(extract_content_text "$response")
-        if echo "$text" | grep -qi "Server is starting up"; then
-            sleep 2
+        if should_retry_annotation_response "$response" "$text" && [ "$attempt" -lt "$max_attempts" ]; then
+            sleep "$sleep_seconds"
             continue
         fi
         echo "$response"
         return 0
     done
+
     echo "$response"
     return 0
 }
@@ -263,7 +282,7 @@ begin_test "31.5" "[DAEMON ONLY] annotation_detail returns selector/tag/framewor
 
 run_test_31_5() {
     local response text verdict
-    response=$(call_tool "analyze" "{\"what\":\"annotation_detail\",\"correlation_id\":\"${PARITY_CORR_A}\"}")
+    response=$(call_tool_with_annotation_retry "analyze" "{\"what\":\"annotation_detail\",\"correlation_id\":\"${PARITY_CORR_A}\"}" 6 1)
     text=$(extract_content_text "$response")
 
     if check_is_error "$response"; then
@@ -311,7 +330,7 @@ begin_test "31.6" "[DAEMON ONLY] generate(visual_test) works from named session"
 
 run_test_31_6() {
     local response text
-    response=$(call_generate_with_startup_retry "{\"format\":\"visual_test\",\"annot_session\":\"${PARITY_SESSION_NAME}\",\"test_name\":\"annotation parity smoke\"}" 5)
+    response=$(call_tool_with_annotation_retry "generate" "{\"format\":\"visual_test\",\"annot_session\":\"${PARITY_SESSION_NAME}\",\"test_name\":\"annotation parity smoke\"}" 6 1)
     text=$(extract_content_text "$response")
 
     if check_matches "$text" "test\\(|page\\.goto\\(" ; then
@@ -329,7 +348,7 @@ begin_test "31.7" "[DAEMON ONLY] generate(annotation_report) returns markdown re
 
 run_test_31_7() {
     local response text
-    response=$(call_generate_with_startup_retry "{\"format\":\"annotation_report\",\"annot_session\":\"${PARITY_SESSION_NAME}\"}" 5)
+    response=$(call_tool_with_annotation_retry "generate" "{\"format\":\"annotation_report\",\"annot_session\":\"${PARITY_SESSION_NAME}\"}" 6 1)
     text=$(extract_content_text "$response")
 
     if check_matches "$text" "^# Annotation Report|## Page"; then
@@ -347,7 +366,7 @@ begin_test "31.8" "[DAEMON ONLY] generate(annotation_issues) returns structured 
 
 run_test_31_8() {
     local response text verdict
-    response=$(call_generate_with_startup_retry "{\"format\":\"annotation_issues\",\"annot_session\":\"${PARITY_SESSION_NAME}\"}" 5)
+    response=$(call_tool_with_annotation_retry "generate" "{\"format\":\"annotation_issues\",\"annot_session\":\"${PARITY_SESSION_NAME}\"}" 6 1)
     text=$(extract_content_text "$response")
 
     verdict=$(


### PR DESCRIPTION
## Summary
- enforce daemon version parity when smoke reuses/resumes existing daemon (prevents stale-daemon false failures)
- add bounded transient retry handling in annotation parity module for startup/no_data windows
- update annotation parity flow-map and feature docs to reflect startup/retry contract

## Validation
- NO_COLOR=1 CI=1 bash scripts/smoke-test.sh --only 31
- ANNOTATION_PARITY_REQUIRE_PILOT=false ANNOTATION_PARITY_BENCH_RUNS=1 FRAMEWORK_RESILIENCE_FULL_REPEATS=1 FRAMEWORK_SELECTOR_REFRESH_CYCLES=1 bash scripts/smoke-tests/annotation-parity-benchmark.sh
- npm run docs:check
- npm run docs:lint:integrity