### PR TITLE
Fix extension release zip packaging and installer staging validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,11 +269,8 @@ extension-zip:
 	@mkdir -p $(BUILD_DIR)
 	@rm -f $(BUILD_DIR)/gasoline-extension-v$(VERSION).zip
 	cd extension && zip -r ../$(BUILD_DIR)/gasoline-extension-v$(VERSION).zip \
-		manifest.json background.js content.js inject.js early-patch.js \
-		early-patch.bundled.js content.bundled.js inject.bundled.js \
-		popup.html popup.js options.html options.js \
-		icons/ lib/ \
-		-x "*.DS_Store" "package.json"
+		. \
+		-x "*.DS_Store" "package.json" "*__tests__/*" "*.test.js" "*.test.cjs"
 	@echo "Built $(BUILD_DIR)/gasoline-extension-v$(VERSION).zip"
 	@ls -lh $(BUILD_DIR)/gasoline-extension-v$(VERSION).zip
 

--- a/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
+++ b/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
@@ -1,0 +1,103 @@
+---
+doc_type: flow_map
+flow_id: installer-binary-path-and-manual-extension-handoff
+status: active
+last_reviewed: 2026-03-05
+owners:
+  - Brenn
+entrypoints:
+  - scripts/install.sh
+  - scripts/install.ps1
+  - cmd/dev-console/native_install.go:runNativeInstall
+  - npm/gasoline-agentic-browser/lib/install.js:executeInstall
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py:run_install
+code_paths:
+  - Makefile
+  - scripts/install.sh
+  - scripts/install.ps1
+  - server/scripts/install.js
+  - cmd/dev-console/native_install.go
+  - npm/gasoline-agentic-browser/lib/config.js
+  - npm/gasoline-agentic-browser/lib/install.js
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py
+  - pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py
+  - docs/mcp-install-guide.md
+test_paths:
+  - cmd/dev-console/native_install_test.go
+  - npm/gasoline-agentic-browser/lib/install.test.js
+  - pypi/gasoline-agentic-browser/tests/test_install.py
+  - tests/extension/release-extension-zip.test.js
+---
+
+# Installer Binary Path and Manual Extension Handoff
+
+## Scope
+
+Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper to ensure:
+
+1. MCP configs use a direct binary path when available.
+2. Installer output clearly states that extension loading is a manual browser action.
+3. Extension staging always includes required MV3 module files for service-worker registration.
+4. Installer output uses a consistent, polished step-and-checklist presentation across entrypoints.
+
+## Entrypoints
+
+1. One-liner installers: `scripts/install.sh` and `scripts/install.ps1`.
+2. Native CLI install flow: `runNativeInstall`.
+3. Wrapper install commands: npm `executeInstall` and PyPI `run_install`.
+
+## Primary Flow
+
+1. Installer resolves platform and downloads/stages binary + extension artifacts.
+2. Extension staging validates required module files (`manifest.json`, `background/init.js`, `content/script-injection.js`, `inject/index.js`).
+3. If the release extension zip is incomplete, installer falls back to source-zip extraction and validates again.
+4. Wrapper/native install writes MCP client configs.
+5. Config entries prefer resolved binary paths over transient launchers.
+6. Installer prints explicit manual extension checklist:
+   - open extensions page
+   - enable developer mode
+   - load unpacked extension folder
+   - pin extension
+   - click Track This Tab
+7. Installer surfaces a branded panel-style summary at completion with the resolved binary path.
+
+## Error and Recovery Paths
+
+1. If platform binary cannot be resolved, wrappers fall back to command name for compatibility.
+2. If release extension zip is missing required module files, installer falls back to source zip and revalidates staged files.
+3. If extension cannot be side-loaded automatically, installer still succeeds but instructs user on manual steps.
+4. Missing client config directories are skipped without aborting install.
+
+## State and Contracts
+
+1. MCP server key remains `gasoline-browser-devtools`.
+2. File-based clients must receive deterministic command entries (`command` + `args`).
+3. Release extension zip must include the full extension tree so MV3 module imports resolve at runtime.
+4. Installer output must never imply that browser extension installation is fully automatic.
+
+## Code Paths
+
+- `Makefile`
+- `scripts/install.sh`
+- `scripts/install.ps1`
+- `server/scripts/install.js`
+- `cmd/dev-console/native_install.go`
+- `npm/gasoline-agentic-browser/lib/config.js`
+- `npm/gasoline-agentic-browser/lib/install.js`
+- `pypi/gasoline-agentic-browser/gasoline_agentic_browser/install.py`
+- `pypi/gasoline-agentic-browser/gasoline_agentic_browser/platform.py`
+- `docs/mcp-install-guide.md`
+
+## Test Paths
+
+- `cmd/dev-console/native_install_test.go`
+- `npm/gasoline-agentic-browser/lib/install.test.js`
+- `pypi/gasoline-agentic-browser/tests/test_install.py`
+- `tests/extension/release-extension-zip.test.js`
+
+## Edit Guardrails
+
+1. Keep wrapper install outputs aligned across npm and PyPI.
+2. Do not regress to `npx`-only config entries for managed installs.
+3. Do not reintroduce allowlist-based extension zip packaging that can omit module directories.
+4. Preserve manual-extension wording in installer output to avoid user confusion.

--- a/docs/features/feature/enhanced-cli-config/flow-map.md
+++ b/docs/features/feature/enhanced-cli-config/flow-map.md
@@ -1,0 +1,16 @@
+---
+doc_type: flow_map_pointer
+status: active
+last_reviewed: 2026-03-05
+canonical_flow_map: ../../../architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
+---
+
+# Enhanced CLI Config Flow Map Pointer
+
+Canonical flow map:
+
+- [Installer Binary Path and Manual Extension Handoff](../../../architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md)
+
+Notable coverage:
+
+- Extension staging integrity checks and source-zip fallback for incomplete release extension artifacts.

--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -6,6 +6,9 @@ feature_type: feature
 owners: []
 last_reviewed: 2026-02-23
 code_paths:
+  - Makefile
+  - scripts/install.sh
+  - scripts/install.ps1
   - npm/gasoline-mcp/lib/cli.js
   - npm/gasoline-mcp/lib/skills.js
   - npm/gasoline-mcp/lib/postinstall-skills.js
@@ -15,6 +18,7 @@ code_paths:
 test_paths:
   - pypi/gasoline-mcp/tests/test_install.py
   - pypi/gasoline-mcp/tests/test_skills.py
+  - tests/extension/release-extension-zip.test.js
   - tests/cli/cli-integration.test.cjs
 ---
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,8 +19,37 @@ $EXT_DIR = Join-Path $INSTALL_DIR "extension"
 # Release version source of truth.
 $VERSION_URL = "https://raw.githubusercontent.com/$REPO/STABLE/VERSION"
 
-Write-Host "🔥 Gasoline Installer" -ForegroundColor Cyan
-Write-Host "--------------------------------------------------" -ForegroundColor Cyan
+Write-Host ""
+Write-Host '   ____                 _ _            ' -ForegroundColor DarkYellow
+Write-Host '  / ___| __ _ ___  ___ | (_)_ __   ___ ' -ForegroundColor DarkYellow
+Write-Host " | |  _ / _` / __|/ _ \| | | '_ \ / _ \\" -ForegroundColor DarkYellow
+Write-Host ' | |_| | (_| \__ \ (_) | | | | | |  __/' -ForegroundColor DarkYellow
+Write-Host '  \____|\__,_|___/\___/|_|_|_| |_|\___|' -ForegroundColor DarkYellow
+Write-Host ""
+Write-Host "🔥 Gasoline Installer" -ForegroundColor DarkYellow
+Write-Host "--------------------------------------------------" -ForegroundColor DarkYellow
+function Reset-ExtensionDir {
+    if (Test-Path $EXT_DIR) {
+        Remove-Item -Path (Join-Path $EXT_DIR '*') -Recurse -Force -ErrorAction SilentlyContinue
+    } else {
+        New-Item -Path $EXT_DIR -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Test-ExtensionStage {
+    $required = @(
+        (Join-Path $EXT_DIR "manifest.json"),
+        (Join-Path $EXT_DIR "background\init.js"),
+        (Join-Path $EXT_DIR "content\script-injection.js"),
+        (Join-Path $EXT_DIR "inject\index.js")
+    )
+    foreach ($path in $required) {
+        if (-not (Test-Path $path)) {
+            return $false
+        }
+    }
+    return $true
+}
 
 # 1. Fetch Version: Get the latest stable version tag from GitHub.
 Write-Host "🔍 Checking for updates..."
@@ -29,7 +58,8 @@ Write-Host "✨ Version: v$VERSION (win32-x64)"
 
 # 2. Directory Setup: Ensure the target installation folders exist on the filesystem.
 if (-not (Test-Path $BIN_DIR)) { New-Item -Path $BIN_DIR -ItemType Directory -Force }
-if (-not (Test-Path $EXT_DIR)) { New-Item -Path $EXT_DIR -ItemType Directory -Force }
+Reset-ExtensionDir
+Write-Host "📁 Install root: $INSTALL_DIR"
 
 # 3. Binary Installation: Download the Windows-native executable.
 $GASOLINE_BIN = Join-Path $BIN_DIR "gasoline.exe"
@@ -72,18 +102,28 @@ $TEMP_ZIP = Join-Path $env:TEMP "gasoline-ext.zip"
 
 try {
     Invoke-WebRequest -Uri $EXT_ZIP_URL -OutFile $TEMP_ZIP
-    # Native extraction to the local staging directory.
+    Reset-ExtensionDir
     Expand-Archive -Path $TEMP_ZIP -DestinationPath $EXT_DIR -Force
+    if (-not (Test-ExtensionStage)) {
+        throw "Release extension zip missing required module files"
+    }
+    Write-Host "✅ Staged extension directory: $EXT_DIR"
 } catch {
-    # Fallback logic for older releases that only have source zips.
-    Write-Host "📦 Falling back to source zip (this may take a moment)..." -ForegroundColor Yellow
+    # Fallback logic for older releases or bad extension zip assets.
+    Write-Host "⚠️  Falling back to source zip due to missing/incomplete extension zip" -ForegroundColor Yellow
     $SOURCE_ZIP_URL = "https://github.com/$REPO/archive/refs/tags/v$VERSION.zip"
     Invoke-WebRequest -Uri $SOURCE_ZIP_URL -OutFile $TEMP_ZIP
     $TEMP_EXTRACT = Join-Path $env:TEMP "gasoline-ext-src"
+    if (Test-Path $TEMP_EXTRACT) { Remove-Item -Path $TEMP_EXTRACT -Recurse -Force }
     Expand-Archive -Path $TEMP_ZIP -DestinationPath $TEMP_EXTRACT -Force
     # Find the extracted folder (named repo-version) and copy the extension subdirectory.
     $extractRoot = Get-ChildItem -Path $TEMP_EXTRACT | Select-Object -First 1
+    Reset-ExtensionDir
     Copy-Item -Path (Join-Path $extractRoot.FullName "extension\*") -Destination $EXT_DIR -Recurse -Force
+    if (-not (Test-ExtensionStage)) {
+        throw "Extension staging failed: required module files are missing."
+    }
+    Write-Host "✅ Staged extension directory: $EXT_DIR"
     # Clean up the deep source extraction.
     Remove-Item -Path $TEMP_EXTRACT -Recurse -Force
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
+ORANGE='\033[38;5;208m'
 BOLD='\033[1m'
 NC='\033[0m' # No Color (Reset)
 
@@ -37,8 +38,28 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo -e "${BLUE}${BOLD}🔥 Gasoline Installer${NC}"
+echo -e "${ORANGE}${BOLD}"
+cat <<'EOF'
+   ____                 _ _            
+  / ___| __ _ ___  ___ | (_)_ __   ___ 
+ | |  _ / _` / __|/ _ \| | | '_ \ / _ \
+ | |_| | (_| \__ \ (_) | | | | | |  __/
+  \____|\__,_|___/\___/|_|_|_| |_|\___|
+EOF
+echo -e "${NC}"
+echo -e "${ORANGE}${BOLD}🔥 Gasoline Installer${NC}"
 echo -e "${BLUE}--------------------------------------------------${NC}"
+reset_extension_dir() {
+    rm -rf "$EXT_DIR"
+    mkdir -p "$EXT_DIR"
+}
+
+validate_extension_stage() {
+    [ -f "$EXT_DIR/manifest.json" ] &&
+    [ -f "$EXT_DIR/background/init.js" ] &&
+    [ -f "$EXT_DIR/content/script-injection.js" ] &&
+    [ -f "$EXT_DIR/inject/index.js" ]
+}
 
 # 1. Platform Detection: Identify the OS and CPU architecture to download the correct binary.
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -77,7 +98,8 @@ echo -e "✨ Version: v$VERSION ($PLATFORM-$E_ARCH)"
 
 # 3. Directory Setup: Ensure the installation folders exist.
 mkdir -p "$BIN_DIR"
-mkdir -p "$EXT_DIR"
+reset_extension_dir
+echo -e "📁 Install root: $INSTALL_DIR"
 
 # 4. Binary Installation: Download the pre-compiled Go binary from GitHub Releases.
 GASOLINE_BIN="$BIN_DIR/gasoline$BINARY_EXT"
@@ -121,18 +143,50 @@ EXT_ZIP_URL="https://github.com/$REPO/releases/download/v$VERSION/$EXT_ZIP_NAME"
 TEMP_ZIP="$TEMP_ROOT/extension.zip"
 
 if curl -fsSL "$EXT_ZIP_URL" -o "$TEMP_ZIP"; then
-    # Dedicated extension zip exists (faster)
-    unzip -q -o "$TEMP_ZIP" -d "$EXT_DIR"
+    # Dedicated extension zip exists (faster); validate required module files after extract.
+    reset_extension_dir
+    if unzip -q -o "$TEMP_ZIP" -d "$EXT_DIR" && validate_extension_stage; then
+        echo -e "✅ Staged extension directory: $EXT_DIR"
+    else
+        echo -e "${YELLOW}⚠️  Release extension zip missing required modules; falling back to source zip...${NC}"
+        SOURCE_ZIP_URL="https://github.com/$REPO/archive/refs/tags/v$VERSION.zip"
+        TEMP_EXTRACT="$TEMP_ROOT/ext_extract"
+        mkdir -p "$TEMP_EXTRACT"
+        if curl -fsSL "$SOURCE_ZIP_URL" -o "$TEMP_ZIP"; then
+            reset_extension_dir
+            unzip -q "$TEMP_ZIP" -d "$TEMP_EXTRACT"
+            # The source zip root folder is typically 'repo-version'.
+            EXTRACT_ROOT=$(ls -d "$TEMP_EXTRACT"/* | head -n 1)
+            cp -r "$EXTRACT_ROOT/extension/"* "$EXT_DIR/"
+            if ! validate_extension_stage; then
+                echo -e "${RED}❌ Extension staging failed: required module files are missing.${NC}"
+                exit 1
+            fi
+            echo -e "✅ Staged extension directory: $EXT_DIR"
+        else
+            echo -e "${RED}❌ Failed to download extension source archive.${NC}"
+            exit 1
+        fi
+    fi
 else
-    # Fallback to source zip extraction (covers older releases)
+    # Fallback to source zip extraction (covers older releases and bad extension zip assets)
     SOURCE_ZIP_URL="https://github.com/$REPO/archive/refs/tags/v$VERSION.zip"
     TEMP_EXTRACT="$TEMP_ROOT/ext_extract"
     mkdir -p "$TEMP_EXTRACT"
     if curl -fsSL "$SOURCE_ZIP_URL" -o "$TEMP_ZIP"; then
+        reset_extension_dir
         unzip -q "$TEMP_ZIP" -d "$TEMP_EXTRACT"
         # The source zip root folder is typically 'repo-version'.
-        EXTRACT_ROOT=$(ls -d "$TEMP_EXTRACT"/*)
+        EXTRACT_ROOT=$(ls -d "$TEMP_EXTRACT"/* | head -n 1)
         cp -r "$EXTRACT_ROOT/extension/"* "$EXT_DIR/"
+        if ! validate_extension_stage; then
+            echo -e "${RED}❌ Extension staging failed: required module files are missing.${NC}"
+            exit 1
+        fi
+        echo -e "✅ Staged extension directory: $EXT_DIR"
+    else
+        echo -e "${RED}❌ Failed to download extension source archive.${NC}"
+        exit 1
     fi
 fi
 

--- a/tests/extension/release-extension-zip.test.js
+++ b/tests/extension/release-extension-zip.test.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Regression guard for release extension zip packaging.
+ * Ensures the extension-zip target archives the full extension tree so MV3 module imports resolve at runtime.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../..')
+const VERSION = fs.readFileSync(path.join(REPO_ROOT, 'VERSION'), 'utf8').trim()
+const ZIP_PATH = path.join(REPO_ROOT, 'dist', `gasoline-extension-v${VERSION}.zip`)
+
+function getMakeTargetBlock(makefileText, targetName) {
+  const start = makefileText.indexOf(`${targetName}:`)
+  assert.notStrictEqual(start, -1, `Makefile target "${targetName}" should exist`)
+  const rest = makefileText.slice(start)
+  const nextTarget = rest.match(/\n[A-Za-z0-9_.-]+:\n/)
+  if (!nextTarget || nextTarget.index === 0) return rest
+  return rest.slice(0, nextTarget.index)
+}
+
+test('extension-zip target archives full extension tree', () => {
+  const makefilePath = path.join(REPO_ROOT, 'Makefile')
+  const makefile = fs.readFileSync(makefilePath, 'utf8')
+  const block = getMakeTargetBlock(makefile, 'extension-zip')
+
+  assert.ok(
+    block.includes('cd extension && zip -r ../$(BUILD_DIR)/gasoline-extension-v$(VERSION).zip \\'),
+    'extension-zip target should invoke zip from extension/'
+  )
+  assert.match(
+    block,
+    /\n\s+\.\s+\\/m,
+    'extension-zip target must package "." to include module directories required by MV3 service worker imports'
+  )
+})
+
+test('extension-zip artifact includes module graph entrypoints', (t) => {
+  const makeResult = spawnSync('make', ['extension-zip'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8'
+  })
+  assert.strictEqual(
+    makeResult.status,
+    0,
+    `make extension-zip failed\nstdout:\n${makeResult.stdout || ''}\nstderr:\n${makeResult.stderr || ''}`
+  )
+  assert.ok(fs.existsSync(ZIP_PATH), `Expected extension zip at ${ZIP_PATH}`)
+
+  const unzipList = spawnSync('unzip', ['-Z', '-1', ZIP_PATH], { encoding: 'utf8' })
+  if (unzipList.error && unzipList.error.code === 'ENOENT') {
+    t.skip('unzip binary not available in this environment')
+    return
+  }
+  assert.strictEqual(
+    unzipList.status,
+    0,
+    `Failed to list extension zip\nstdout:\n${unzipList.stdout || ''}\nstderr:\n${unzipList.stderr || ''}`
+  )
+
+  const entries = new Set(
+    unzipList.stdout
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  )
+
+  const required = [
+    'manifest.json',
+    'background.js',
+    'background/init.js',
+    'content/script-injection.js',
+    'inject/index.js'
+  ]
+  for (const file of required) {
+    assert.ok(entries.has(file), `extension zip must include ${file}`)
+  }
+
+  for (const entry of entries) {
+    assert.ok(!entry.includes('__tests__/'), `extension zip must not include test folder: ${entry}`)
+    assert.ok(!entry.endsWith('.test.js'), `extension zip must not include JS test file: ${entry}`)
+    assert.ok(!entry.endsWith('.test.cjs'), `extension zip must not include CJS test file: ${entry}`)
+  }
+})


### PR DESCRIPTION
Summary:\n- fix extension-zip packaging to include full extension module tree\n- add installer validation/fallback so incomplete release zips cannot break extension startup\n- add regression tests for packaging strategy and built zip module entrypoints\n- add GASOLINE ASCII art with dark-orange accent in STABLE installers\n\nValidation:\n- node --test tests/extension/release-extension-zip.test.js\n- bash -n scripts/install.sh