### PR TITLE
fix(installer): point install scripts at renamed repository

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,18 +1,18 @@
 # Gasoline - Ultimate Windows Installer (PowerShell)
-# https://github.com/brennhill/gasoline-mcp-ai-devtools
+# https://github.com/brennhill/gasoline-agentic-browser-devtools-mcp
 #
 # PURPOSE:
 # This PowerShell script provides a native, one-liner installation for Windows users.
 # It avoids external dependencies like bash/curl by using built-in .NET/PowerShell features.
 #
 # USAGE:
-#   irm https://raw.githubusercontent.com/brennhill/gasoline-mcp-ai-devtools/STABLE/scripts/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtools-mcp/STABLE/scripts/install.ps1 | iex
 
 # Stop the script if any command results in an error. Equivalent to 'set -e'.
 $ErrorActionPreference = "Stop"
 
 # Configuration: Single source of truth for repository and local paths.
-$REPO = "brennhill/gasoline-mcp-ai-devtools"
+$REPO = "brennhill/gasoline-agentic-browser-devtools-mcp"
 $INSTALL_DIR = Join-Path $HOME ".gasoline"
 $BIN_DIR = Join-Path $INSTALL_DIR "bin"
 $EXT_DIR = Join-Path $INSTALL_DIR "extension"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 # Gasoline - The Ultimate One-liner Installer
-# https://github.com/brennhill/gasoline-mcp-ai-devtools
+# https://github.com/brennhill/gasoline-agentic-browser-devtools-mcp
 #
 # PURPOSE:
 # This script provides a zero-dependency, platform-aware installation flow for Gasoline.
 # It handles binary acquisition, extension staging, and native configuration in one go.
 #
 # USAGE:
-#   curl -sSL https://raw.githubusercontent.com/brennhill/gasoline-mcp-ai-devtools/STABLE/scripts/install.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtools-mcp/STABLE/scripts/install.sh | bash
 
 # Fail immediately if a command fails (-e), an unset variable is used (-u),
 # or a command in a pipeline fails (-o pipefail). This is critical for installer safety.
 set -euo pipefail
 
 # Configuration: Define the single source of truth for paths and repository metadata.
-REPO="brennhill/gasoline-mcp-ai-devtools"
+REPO="brennhill/gasoline-agentic-browser-devtools-mcp"
 INSTALL_DIR="$HOME/.gasoline"
 BIN_DIR="$INSTALL_DIR/bin"
 EXT_DIR="$INSTALL_DIR/extension"


### PR DESCRIPTION
Summary:\n- update bash installer repo slug to brennhill/gasoline-agentic-browser-devtools-mcp\n- update PowerShell installer repo slug to brennhill/gasoline-agentic-browser-devtools-mcp\n- align installer header/usage URLs with the renamed repo\n\nWhy:\nCurrent STABLE installer points at the old repo name, causing release binary download URLs to 404 during install.