### PR TITLE
chore(release): deprecate PyPI release path and unblock binary publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish Packages
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-publish:
-    name: Build binaries and publish to NPM
+    name: Build binaries and publish packages
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -69,7 +69,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
 
-      - name: Copy binaries to npm packages
+      - name: Copy binaries to package directories
         run: |
           mkdir -p npm/darwin-arm64/bin
           mkdir -p npm/darwin-x64/bin
@@ -85,7 +85,7 @@ jobs:
 
           chmod +x npm/*/bin/*
 
-          echo "✅ Binaries copied to npm packages"
+          echo "✅ Binaries staged for package publishing"
           ls -lh npm/*/bin/
 
       - name: Publish darwin-arm64
@@ -123,7 +123,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish gasoline-agentic-browser (main package)
+      - name: Publish aggregate package
         run: |
           cd npm/gasoline-agentic-browser
           npm publish --access public
@@ -133,15 +133,7 @@ jobs:
       - name: Summary
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "Published v${{ steps.version.outputs.VERSION }} to NPM"
+          echo "Published v${{ steps.version.outputs.VERSION }} package set"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "Packages published:"
-          echo "  - @brennhill/gasoline-agentic-browser-darwin-arm64@${{ steps.version.outputs.VERSION }}"
-          echo "  - @brennhill/gasoline-agentic-browser-darwin-x64@${{ steps.version.outputs.VERSION }}"
-          echo "  - @brennhill/gasoline-agentic-browser-linux-x64@${{ steps.version.outputs.VERSION }}"
-          echo "  - @brennhill/gasoline-agentic-browser-linux-arm64@${{ steps.version.outputs.VERSION }}"
-          echo "  - @brennhill/gasoline-agentic-browser-win32-x64@${{ steps.version.outputs.VERSION }}"
-          echo "  - gasoline-agentic-browser@${{ steps.version.outputs.VERSION }}"
-          echo ""
-          echo "Install with: npx gasoline-agentic-browser@${{ steps.version.outputs.VERSION }}"
+          echo "Platform and aggregate packages were published."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,6 @@ jobs:
         with:
           go-version: '1.24.13'
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.12'
-
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
@@ -110,42 +105,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       # CRX build removed (requires local Chrome signing key)
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade build setuptools wheel twine
       
       - name: Install Node dependencies
         run: npm ci
-
-      - name: Validate PyPI pyproject schema (pre-build)
-        run: node scripts/normalize-pypi-main-pyproject.js --check --validate
-
-      - name: Assert scripts metadata shape and log pyproject keys (pre-build)
-        run: |
-          python - <<'PY'
-          import sys
-          import tomllib
-
-          path = "pypi/gasoline-agentic-browser/pyproject.toml"
-          with open(path, "rb") as fh:
-              data = tomllib.load(fh)
-
-          project = data.get("project", {})
-          scripts = project.get("scripts", {})
-          if not isinstance(scripts, dict):
-              print("ERROR: [project.scripts] must be a TOML table")
-              sys.exit(1)
-          if "dependencies" in scripts:
-              print("ERROR: project.scripts.dependencies must not exist")
-              sys.exit(1)
-
-          print("PyPI pyproject forensics:")
-          print("  project keys:", sorted(project.keys()))
-          print("  project.scripts keys:", sorted(scripts.keys()))
-          print("  project.dependencies count:", len(project.get("dependencies", [])))
-          PY
 
       - name: Build all platform binaries
         run: make build
@@ -170,7 +132,7 @@ jobs:
 
       # CRX build removed (requires local Chrome signing key)
 
-      - name: Copy binaries to NPM packages
+      - name: Stage package binaries
         run: |
           mkdir -p npm/darwin-arm64/bin
           mkdir -p npm/darwin-x64/bin
@@ -184,13 +146,13 @@ jobs:
           cp dist/gasoline-linux-x64 npm/linux-x64/bin/gasoline
           cp dist/gasoline-win32-x64.exe npm/win32-x64/bin/gasoline.exe
 
-      - name: Publish NPM packages
+      - name: Publish packages
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
 
           # Publish platform packages first
           for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
-            echo "Publishing @brennhill/gasoline-agentic-browser-$pkg..."
+            echo "Publishing platform package: $pkg"
             cd npm/$pkg
             set +e
             OUTPUT=$(npm publish --access public 2>&1)
@@ -199,7 +161,7 @@ jobs:
             echo "$OUTPUT"
             if [ $STATUS -ne 0 ]; then
               if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
-                echo "Already published @brennhill/gasoline-agentic-browser-$pkg; continuing."
+                echo "Platform package already published for $pkg; continuing."
               else
                 exit $STATUS
               fi
@@ -208,7 +170,7 @@ jobs:
           done
 
           # Publish main package last
-          echo "Publishing gasoline-agentic-browser..."
+          echo "Publishing aggregate package"
           cd npm/gasoline-agentic-browser
           set +e
           OUTPUT=$(npm publish --access public 2>&1)
@@ -217,34 +179,13 @@ jobs:
           echo "$OUTPUT"
           if [ $STATUS -ne 0 ]; then
             if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
-              echo "Already published gasoline-agentic-browser; continuing."
+              echo "Aggregate package already published; continuing."
             else
               exit $STATUS
             fi
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Build PyPI packages
-        run: make pypi-build
-
-      - name: Publish to PyPI
-        run: |
-          # Publish platform packages first
-          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
-            echo "Publishing gasoline-agentic-browser-$pkg to PyPI..."
-            cd pypi/gasoline-agentic-browser-$pkg
-            python -m twine upload --skip-existing dist/*
-            cd ../..
-          done
-
-          # Publish main package last
-          echo "Publishing gasoline-agentic-browser to PyPI..."
-          cd pypi/gasoline-agentic-browser
-          python -m twine upload --skip-existing dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Build extension zip
         run: make extension-zip
@@ -270,23 +211,9 @@ jobs:
           VERSION="${{ needs.verify-tag.outputs.version }}"
           echo "## 🚀 Release v$VERSION Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published Packages" >> $GITHUB_STEP_SUMMARY
+          echo "### Package Publication" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**npm:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@brennhill/gasoline-agentic-browser-darwin-arm64@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@brennhill/gasoline-agentic-browser-darwin-x64@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@brennhill/gasoline-agentic-browser-linux-arm64@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@brennhill/gasoline-agentic-browser-linux-x64@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@brennhill/gasoline-agentic-browser-win32-x64@$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PyPI:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser==$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser-darwin-arm64==$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser-darwin-x64==$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser-linux-arm64==$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser-linux-x64==$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`gasoline-agentic-browser-win32-x64==$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Platform and aggregate packages published for v$VERSION." >> $GITHUB_STEP_SUMMARY
 
   skip-nonstable-tag:
     name: Skip Non-STABLE Tags

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -21,43 +21,6 @@ jobs:
         with:
           node-version: "20"
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.12"
-
-      - name: Test PyPI pyproject normalizer
-        run: node --test scripts/normalize-pypi-main-pyproject.test.js
-
-      - name: Validate PyPI pyproject structure
-        run: |
-          node scripts/normalize-pypi-main-pyproject.js --check
-          node scripts/normalize-pypi-main-pyproject.js --validate
-
-      - name: Assert scripts metadata shape and log pyproject keys
-        run: |
-          python - <<'PY'
-          import sys
-          import tomllib
-
-          path = "pypi/gasoline-agentic-browser/pyproject.toml"
-          with open(path, "rb") as fh:
-              data = tomllib.load(fh)
-
-          project = data.get("project", {})
-          scripts = project.get("scripts", {})
-          if not isinstance(scripts, dict):
-              print("ERROR: [project.scripts] must be a TOML table")
-              sys.exit(1)
-          if "dependencies" in scripts:
-              print("ERROR: project.scripts.dependencies must not exist")
-              sys.exit(1)
-
-          print("PyPI pyproject forensics:")
-          print("  project keys:", sorted(project.keys()))
-          print("  project.scripts keys:", sorted(scripts.keys()))
-          print("  project.dependencies count:", len(project.get("dependencies", [])))
-          PY
-
       - name: Validate all versions match VERSION file
         run: |
           VERSION=$(cat VERSION)
@@ -77,12 +40,6 @@ jobs:
             ["npm/win32-x64/package.json"]="\"version\": \"$VERSION\""
             ["extension/manifest.json"]="\"version\": \"$VERSION\""
             ["extension/package.json"]="\"version\": \"$VERSION\""
-            ["pypi/gasoline-agentic-browser/pyproject.toml"]="version = \"$VERSION\""
-            ["pypi/gasoline-agentic-browser-darwin-arm64/pyproject.toml"]="version = \"$VERSION\""
-            ["pypi/gasoline-agentic-browser-darwin-x64/pyproject.toml"]="version = \"$VERSION\""
-            ["pypi/gasoline-agentic-browser-linux-arm64/pyproject.toml"]="version = \"$VERSION\""
-            ["pypi/gasoline-agentic-browser-linux-x64/pyproject.toml"]="version = \"$VERSION\""
-            ["pypi/gasoline-agentic-browser-win32-x64/pyproject.toml"]="version = \"$VERSION\""
             ["server/package.json"]="\"version\": \"$VERSION\""
           )
 

--- a/docs/agent-install-guide.md
+++ b/docs/agent-install-guide.md
@@ -31,11 +31,6 @@ irm https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtool
 - Extracts the Chrome extension to `~/.gasoline/extension/`
 - Runs `--install` which auto-detects and configures: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Gemini CLI, OpenCode, Antigravity, Zed
 
-**If the install script is unavailable**, fall back to npm:
-```bash
-npm install -g gasoline-agentic-browser && gasoline-agentic-browser --install
-```
-
 ### Verify the install succeeded
 
 Check the exit code was 0 and the binary exists:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: "Fire It Up"
 description: "Install and configure Gasoline in under 2 minutes. Start streaming browser logs to your autonomous coding agent with a single command."
-keywords: "install gasoline, gasoline agentic browser setup, npx gasoline-agentic-browser, browser extension install, MCP server setup"
+keywords: "install gasoline, gasoline agentic browser setup, browser extension install, MCP server setup"
 permalink: /getting-started/
 header:
   overlay_image: /assets/images/hero-banner.png

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,18 +1,18 @@
 # Gasoline - Ultimate Windows Installer (PowerShell)
-# https://github.com/brennhill/gasoline-mcp-ai-devtools
+# https://github.com/brennhill/gasoline-agentic-browser-devtools-mcp
 #
 # PURPOSE:
 # This PowerShell script provides a native, one-liner installation for Windows users.
 # It avoids external dependencies like bash/curl by using built-in .NET/PowerShell features.
 #
 # USAGE:
-#   irm https://raw.githubusercontent.com/brennhill/gasoline-mcp-ai-devtools/STABLE/scripts/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtools-mcp/STABLE/scripts/install.ps1 | iex
 
 # Stop the script if any command results in an error. Equivalent to 'set -e'.
 $ErrorActionPreference = "Stop"
 
 # Configuration: Single source of truth for repository and local paths.
-$REPO = "brennhill/gasoline-mcp-ai-devtools"
+$REPO = "brennhill/gasoline-agentic-browser-devtools-mcp"
 $INSTALL_DIR = Join-Path $HOME ".gasoline"
 $BIN_DIR = Join-Path $INSTALL_DIR "bin"
 $EXT_DIR = Join-Path $INSTALL_DIR "extension"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 # Gasoline - The Ultimate One-liner Installer
-# https://github.com/brennhill/gasoline-mcp-ai-devtools
+# https://github.com/brennhill/gasoline-agentic-browser-devtools-mcp
 #
 # PURPOSE:
 # This script provides a zero-dependency, platform-aware installation flow for Gasoline.
 # It handles binary acquisition, extension staging, and native configuration in one go.
 #
 # USAGE:
-#   curl -sSL https://raw.githubusercontent.com/brennhill/gasoline-mcp-ai-devtools/STABLE/scripts/install.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtools-mcp/STABLE/scripts/install.sh | bash
 
 # Fail immediately if a command fails (-e), an unset variable is used (-u),
 # or a command in a pipeline fails (-o pipefail). This is critical for installer safety.
 set -euo pipefail
 
 # Configuration: Define the single source of truth for paths and repository metadata.
-REPO="brennhill/gasoline-mcp-ai-devtools"
+REPO="brennhill/gasoline-agentic-browser-devtools-mcp"
 INSTALL_DIR="$HOME/.gasoline"
 BIN_DIR="$INSTALL_DIR/bin"
 EXT_DIR="$INSTALL_DIR/extension"


### PR DESCRIPTION
## Summary\n- remove PyPI validation and publish steps from release pipelines\n- keep package publishing path in place while removing public-facing package-name references\n- remove public npm fallback mention from install docs\n\n## Why\n- current v0.8.0 tag run is blocked before Build & Publish due PyPI gate mismatch\n- this hotfix ensures GitHub release binaries can publish without PyPI blockers\n- aligns docs with the current one-liner installer path