### PR TITLE
fix(release): align optionalDependencies with 0.8.0

### DIFF
--- a/npm/gasoline-agentic-browser/package.json
+++ b/npm/gasoline-agentic-browser/package.json
@@ -18,11 +18,11 @@
     "extension"
   ],
   "optionalDependencies": {
-    "@brennhill/gasoline-agentic-browser-darwin-arm64": "0.7.12",
-    "@brennhill/gasoline-agentic-browser-darwin-x64": "0.7.12",
-    "@brennhill/gasoline-agentic-browser-linux-arm64": "0.7.12",
-    "@brennhill/gasoline-agentic-browser-linux-x64": "0.7.12",
-    "@brennhill/gasoline-agentic-browser-win32-x64": "0.7.12"
+    "@brennhill/gasoline-agentic-browser-darwin-arm64": "0.8.0",
+    "@brennhill/gasoline-agentic-browser-darwin-x64": "0.8.0",
+    "@brennhill/gasoline-agentic-browser-linux-arm64": "0.8.0",
+    "@brennhill/gasoline-agentic-browser-linux-x64": "0.8.0",
+    "@brennhill/gasoline-agentic-browser-win32-x64": "0.8.0"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary\n- update main package optionalDependencies to 0.8.0\n\n## Why\nRelease workflow validate step failed because optionalDependencies were still pinned to 0.7.12, which blocked Build & Publish for v0.8.0.