### PR TITLE
fix(build): make PTY session compile across release targets

### DIFF
--- a/internal/pty/pty_open_darwin.go
+++ b/internal/pty/pty_open_darwin.go
@@ -1,0 +1,56 @@
+// pty_open_darwin.go — Darwin PTY open/grant/unlock/name resolution helpers.
+// Why: macOS requires TIOCPTY* ioctls to unlock the slave PTY and resolve slave path.
+// Docs: docs/features/feature/terminal/index.md
+
+//go:build darwin
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// ptsname returns the slave PTY path for a master fd.
+// On macOS, TIOCPTYGNAME writes a null-terminated C string into a 128-byte buffer.
+func ptsname(f *os.File) (string, error) {
+	buf := make([]byte, 128)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&buf[0])))
+	if errno != 0 {
+		return "", fmt.Errorf("ptsname: %w", errno)
+	}
+	for i, b := range buf {
+		if b == 0 {
+			return string(buf[:i]), nil
+		}
+	}
+	return string(buf), nil
+}
+
+// openPTY opens a new PTY master/slave pair. Returns (master, slavePath, error).
+func openPTY() (*os.File, string, error) {
+	ptmx, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open /dev/ptmx: %w", err)
+	}
+
+	fd := ptmx.Fd()
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCPTYGRANT, 0); errno != 0 {
+		_ = ptmx.Close()
+		return nil, "", fmt.Errorf("grantpt: %w", errno)
+	}
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCPTYUNLK, 0); errno != 0 {
+		_ = ptmx.Close()
+		return nil, "", fmt.Errorf("unlockpt: %w", errno)
+	}
+
+	slavePath, err := ptsname(ptmx)
+	if err != nil {
+		_ = ptmx.Close()
+		return nil, "", err
+	}
+
+	return ptmx, slavePath, nil
+}

--- a/internal/pty/pty_open_linux.go
+++ b/internal/pty/pty_open_linux.go
@@ -1,0 +1,48 @@
+// pty_open_linux.go — Linux PTY open/unlock/name resolution helpers.
+// Why: Linux uses TIOCSPTLCK + TIOCGPTN ioctls for /dev/ptmx slave resolution.
+// Docs: docs/features/feature/terminal/index.md
+
+//go:build linux
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// openPTY opens a new PTY master/slave pair. Returns (master, slavePath, error).
+func openPTY() (*os.File, string, error) {
+	ptmx, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open /dev/ptmx: %w", err)
+	}
+
+	fd := ptmx.Fd()
+	var unlock int32 = 0
+	if _, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		uintptr(syscall.TIOCSPTLCK),
+		uintptr(unsafe.Pointer(&unlock)),
+	); errno != 0 {
+		_ = ptmx.Close()
+		return nil, "", fmt.Errorf("unlockpt: %w", errno)
+	}
+
+	var ptyNum uint32
+	if _, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		uintptr(syscall.TIOCGPTN),
+		uintptr(unsafe.Pointer(&ptyNum)),
+	); errno != 0 {
+		_ = ptmx.Close()
+		return nil, "", fmt.Errorf("ptsnum: %w", errno)
+	}
+
+	slavePath := fmt.Sprintf("/dev/pts/%d", ptyNum)
+	return ptmx, slavePath, nil
+}

--- a/internal/pty/pty_open_unsupported.go
+++ b/internal/pty/pty_open_unsupported.go
@@ -1,0 +1,17 @@
+// pty_open_unsupported.go — Fallback PTY opener for unsupported platforms.
+// Why: Keeps cross-platform builds compiling when PTY ioctls are unavailable.
+// Docs: docs/features/feature/terminal/index.md
+
+//go:build !darwin && !linux
+
+package pty
+
+import (
+	"errors"
+	"os"
+)
+
+// openPTY opens a PTY when supported by the target OS.
+func openPTY() (*os.File, string, error) {
+	return nil, "", errors.New("pty: unsupported platform")
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -1,3 +1,5 @@
+//go:build darwin || linux
+
 // session.go — PTY session: spawns a CLI subprocess in a pseudo-terminal.
 // Why: Isolates PTY lifecycle (open, I/O, resize, close) from session management and HTTP transport.
 // Docs: docs/features/feature/terminal/index.md
@@ -26,8 +28,8 @@ type Session struct {
 	mu         sync.Mutex
 	closed     bool
 	done       chan struct{} // closed before ptmx.Close to signal in-flight I/O
-	scrollback []byte       // ring buffer of recent PTY output for reconnect replay
-	scrollMu   sync.Mutex   // protects scrollback
+	scrollback []byte        // ring buffer of recent PTY output for reconnect replay
+	scrollMu   sync.Mutex    // protects scrollback
 }
 
 // winsize matches the C struct winsize for TIOCSWINSZ.
@@ -40,49 +42,6 @@ type winsize struct {
 
 // ErrSessionClosed is returned when operating on a closed session.
 var ErrSessionClosed = errors.New("pty: session closed")
-
-// ptsname returns the slave PTY path for a master fd.
-// On macOS, TIOCPTYGNAME writes a null-terminated C string into a 128-byte buffer.
-func ptsname(f *os.File) (string, error) {
-	buf := make([]byte, 128)
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&buf[0])))
-	if errno != 0 {
-		return "", fmt.Errorf("ptsname: %w", errno)
-	}
-	for i, b := range buf {
-		if b == 0 {
-			return string(buf[:i]), nil
-		}
-	}
-	return string(buf), nil
-}
-
-// openPTY opens a new PTY master/slave pair. Returns (master, slavePath, error).
-func openPTY() (*os.File, string, error) {
-	ptmx, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	if err != nil {
-		return nil, "", fmt.Errorf("open /dev/ptmx: %w", err)
-	}
-
-	// Grant and unlock the slave.
-	fd := ptmx.Fd()
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCPTYGRANT, 0); errno != 0 {
-		ptmx.Close()
-		return nil, "", fmt.Errorf("grantpt: %w", errno)
-	}
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, syscall.TIOCPTYUNLK, 0); errno != 0 {
-		ptmx.Close()
-		return nil, "", fmt.Errorf("unlockpt: %w", errno)
-	}
-
-	slavePath, err := ptsname(ptmx)
-	if err != nil {
-		ptmx.Close()
-		return nil, "", err
-	}
-
-	return ptmx, slavePath, nil
-}
 
 // SpawnConfig configures a new PTY session.
 type SpawnConfig struct {

--- a/internal/pty/session_unsupported.go
+++ b/internal/pty/session_unsupported.go
@@ -1,0 +1,84 @@
+//go:build !darwin && !linux
+
+// session_unsupported.go — PTY session stubs for unsupported platforms.
+// Why: Keep non-Unix targets (for example, Windows) compiling without PTY ioctl support.
+// Docs: docs/features/feature/terminal/index.md
+
+package pty
+
+import "errors"
+
+// maxScrollback keeps API parity with Unix session implementation.
+const maxScrollback = 256 * 1024
+
+// Session is a stub PTY session on unsupported platforms.
+type Session struct {
+	ID string
+}
+
+// SpawnConfig configures a new PTY session.
+type SpawnConfig struct {
+	ID   string
+	Cmd  string
+	Args []string
+	Dir  string
+	Env  []string
+	Cols uint16
+	Rows uint16
+}
+
+// ErrSessionClosed is returned when operating on a closed session.
+var ErrSessionClosed = errors.New("pty: session closed")
+
+var errUnsupportedPTY = errors.New("pty: unsupported platform")
+
+// Spawn returns unsupported on non-Unix platforms.
+func Spawn(cfg SpawnConfig) (*Session, error) {
+	return nil, errUnsupportedPTY
+}
+
+// Read is unsupported on non-Unix platforms.
+func (s *Session) Read(buf []byte) (int, error) {
+	return 0, errUnsupportedPTY
+}
+
+// Write is unsupported on non-Unix platforms.
+func (s *Session) Write(data []byte) (int, error) {
+	return 0, errUnsupportedPTY
+}
+
+// Resize is unsupported on non-Unix platforms.
+func (s *Session) Resize(cols, rows uint16) error {
+	return errUnsupportedPTY
+}
+
+// Close is a no-op for unsupported platform stubs.
+func (s *Session) Close() error {
+	return nil
+}
+
+// Wait is a no-op for unsupported platform stubs.
+func (s *Session) Wait() error {
+	return nil
+}
+
+// AppendScrollback is a no-op for unsupported platform stubs.
+func (s *Session) AppendScrollback(data []byte) {}
+
+// Scrollback returns an empty buffer on unsupported platforms.
+func (s *Session) Scrollback() []byte {
+	return nil
+}
+
+// IsAlive reports false on unsupported platforms.
+func (s *Session) IsAlive() bool {
+	return false
+}
+
+// Pid returns 0 on unsupported platforms.
+func (s *Session) Pid() int {
+	return 0
+}
+
+// ForceRedraw is a no-op on unsupported platforms.
+func (s *Session) ForceRedraw() {}


### PR DESCRIPTION
## Summary\n- split PTY open/grant helpers by OS (darwin/linux/unsupported)\n- gate Unix PTY session implementation behind darwin/linux build tags\n- add unsupported-platform PTY session stubs so windows target compiles\n\n## Why\nRelease build for v0.8.0 failed in Build & Publish due darwin-only  symbols referenced during cross-platform builds.