### PR TITLE
fix(release): align asset names + add Windows terminal availability notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,11 +77,11 @@ jobs:
           mkdir -p npm/linux-arm64/bin
           mkdir -p npm/win32-x64/bin
 
-          cp dist/gasoline-darwin-arm64 npm/darwin-arm64/bin/gasoline
-          cp dist/gasoline-darwin-x64 npm/darwin-x64/bin/gasoline
-          cp dist/gasoline-linux-x64 npm/linux-x64/bin/gasoline
-          cp dist/gasoline-linux-arm64 npm/linux-arm64/bin/gasoline
-          cp dist/gasoline-win32-x64.exe npm/win32-x64/bin/gasoline.exe
+          cp dist/gasoline-agentic-browser-darwin-arm64 npm/darwin-arm64/bin/gasoline
+          cp dist/gasoline-agentic-browser-darwin-x64 npm/darwin-x64/bin/gasoline
+          cp dist/gasoline-agentic-browser-linux-x64 npm/linux-x64/bin/gasoline
+          cp dist/gasoline-agentic-browser-linux-arm64 npm/linux-arm64/bin/gasoline
+          cp dist/gasoline-agentic-browser-win32-x64.exe npm/win32-x64/bin/gasoline.exe
 
           chmod +x npm/*/bin/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,8 @@ jobs:
 
       - name: Verify binary version
         run: |
-          ./dist/gasoline-linux-x64 --version
-          BINARY_VERSION=$(./dist/gasoline-linux-x64 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          ./dist/gasoline-agentic-browser-linux-x64 --version
+          BINARY_VERSION=$(./dist/gasoline-agentic-browser-linux-x64 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           EXPECTED="${{ needs.verify-tag.outputs.version }}"
 
           if [ "$BINARY_VERSION" != "$EXPECTED" ]; then
@@ -140,11 +140,11 @@ jobs:
           mkdir -p npm/linux-x64/bin
           mkdir -p npm/win32-x64/bin
 
-          cp dist/gasoline-darwin-arm64 npm/darwin-arm64/bin/gasoline
-          cp dist/gasoline-darwin-x64 npm/darwin-x64/bin/gasoline
-          cp dist/gasoline-linux-arm64 npm/linux-arm64/bin/gasoline
-          cp dist/gasoline-linux-x64 npm/linux-x64/bin/gasoline
-          cp dist/gasoline-win32-x64.exe npm/win32-x64/bin/gasoline.exe
+          cp dist/gasoline-agentic-browser-darwin-arm64 npm/darwin-arm64/bin/gasoline
+          cp dist/gasoline-agentic-browser-darwin-x64 npm/darwin-x64/bin/gasoline
+          cp dist/gasoline-agentic-browser-linux-arm64 npm/linux-arm64/bin/gasoline
+          cp dist/gasoline-agentic-browser-linux-x64 npm/linux-x64/bin/gasoline
+          cp dist/gasoline-agentic-browser-win32-x64.exe npm/win32-x64/bin/gasoline.exe
 
       - name: Publish packages
         run: |
@@ -194,11 +194,11 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |
-            dist/gasoline-darwin-arm64
-            dist/gasoline-darwin-x64
-            dist/gasoline-linux-arm64
-            dist/gasoline-linux-x64
-            dist/gasoline-win32-x64.exe
+            dist/gasoline-agentic-browser-darwin-arm64
+            dist/gasoline-agentic-browser-darwin-x64
+            dist/gasoline-agentic-browser-linux-arm64
+            dist/gasoline-agentic-browser-linux-x64
+            dist/gasoline-agentic-browser-win32-x64.exe
             dist/gasoline-extension-v*.zip
           generate_release_notes: true
           draft: false

--- a/cookwithgasoline.com/src/content/docs/agent-install-guide.md
+++ b/cookwithgasoline.com/src/content/docs/agent-install-guide.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent-Assisted Installation"
 description: "Step-by-step instructions for LLM coding agents to install Gasoline with minimal human intervention."
-last_verified_version: 0.7.12
+last_verified_version: 0.8.0
 last_verified_date: 2026-03-05
 normalized_tags: ['agent', 'install', 'guide']
 ---
@@ -37,11 +37,6 @@ irm https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtool
 - Verifies SHA-256 checksum
 - Extracts the Chrome extension to `~/.gasoline/extension/`
 - Runs `--install` which auto-detects and configures: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Gemini CLI, OpenCode, Antigravity, Zed
-
-**If the install script is unavailable**, fall back to npm:
-```bash
-npm install -g gasoline-agentic-browser && gasoline-agentic-browser --install
-```
 
 ### Verify the install succeeded
 

--- a/cookwithgasoline.com/src/content/docs/downloads.md
+++ b/cookwithgasoline.com/src/content/docs/downloads.md
@@ -1,7 +1,7 @@
 ---
 title: Downloads
 description: Download Gasoline extension and tools for your platform
-last_verified_version: 0.7.12
+last_verified_version: 0.8.0
 last_verified_date: 2026-03-05
 normalized_tags: ['downloads']
 ---
@@ -30,6 +30,8 @@ irm https://raw.githubusercontent.com/brennhill/gasoline-agentic-browser-devtool
 - Extracts the Chrome extension to `~/.gasoline/extension/`
 - Runs `--install` which auto-detects and configures: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Gemini CLI, OpenCode, Antigravity, Zed
 
+> Terminal availability: the built-in terminal is supported on macOS and Linux. It is currently unavailable on Windows.
+
 After running the installer, load the extension in Chrome:
 1. Open `chrome://extensions/`
 2. Enable **Developer mode** (toggle in top right)
@@ -47,18 +49,10 @@ The extension captures browser telemetry and sends it to the local Gasoline serv
 - **Draw Mode & Visual Annotations** — Draw rectangles and type feedback directly on the page with multi-page sessions
 - **Test Healing & Classification** — Self-healing Playwright selectors and context-aware test generation
 - **Recording & Playback** — Full tab video recording with audio capture and log diff comparison
-- **Terminal Integration** — In-browser terminal with WebSocket relay and PTY session management
+- **Terminal Integration (macOS + Linux)** — In-browser terminal with WebSocket relay and PTY session management
 - **Multi-Client Support** — Multiple AI tools can connect to the same daemon
 
-## Alternative Install Methods
-
-### npm
-
-```bash
-npm install -g gasoline-agentic-browser && gasoline-agentic-browser --install
-```
-
-### From Source
+## From Source
 
 ```bash
 git clone https://github.com/brennhill/gasoline-agentic-browser-devtools-mcp.git
@@ -79,8 +73,8 @@ make build
 
 - **Browser:** Chrome/Chromium 120+ (for MV3 support)
 - **Runtime:** Native Go binary (no Node.js required for standalone binary installs)
-- **Node.js:** 18+ (optional, only if you install via npm)
 - **Platform:** macOS, Linux, Windows
+- **Terminal widget:** macOS + Linux only (not yet available on Windows)
 - **MCP Client:** Claude Code, Cursor, Windsurf, Claude Desktop, Zed, Gemini CLI, OpenCode, Antigravity, or any other MCP-compliant system/agent
 
 ## Verification

--- a/cookwithgasoline.com/src/content/docs/guides/annotation-skill-terminal-workflow.md
+++ b/cookwithgasoline.com/src/content/docs/guides/annotation-skill-terminal-workflow.md
@@ -14,6 +14,8 @@ This page walks through one practical loop:
 2. Use skills to structure what to do next.
 3. Validate and ship from the built-in terminal workflow.
 
+> Terminal availability: this workflow is supported on macOS and Linux. The built-in terminal is currently unavailable on Windows.
+
 ## Step 1: Capture Feedback with Annotations
 
 Use draw mode to mark real UI problems directly on the page.

--- a/docs/features/feature/terminal/index.md
+++ b/docs/features/feature/terminal/index.md
@@ -28,6 +28,7 @@ last_verified_date: 2026-03-05
 ## TL;DR
 - Status: shipped
 - In-browser terminal widget that embeds a PTY-backed shell via iframe
+- Availability: macOS + Linux only (Windows currently reports terminal unavailable / `terminal_port: 0`)
 - Runs on a **dedicated HTTP server** at `main_port + 1` (e.g., 7891) for isolation
 - Singleton session shared across all tabs via `chrome.storage.session`
 - Three UI states: **open**, **minimized**, **closed** — all persisted across page refreshes

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -230,7 +230,7 @@ Write-Host "📁 Install root: $INSTALL_DIR"
 
 # 3. Binary Installation: Download the Windows-native executable.
 $INSTALL_BIN = $GASOLINE_BIN
-$BINARY_NAME = "gasoline-win32-x64.exe"
+$BINARY_NAME = "gasoline-agentic-browser-win32-x64.exe"
 $BINARY_URL = "https://github.com/$REPO/releases/download/v$VERSION/$BINARY_NAME"
 $CHECKSUM_URL = "https://github.com/$REPO/releases/download/v$VERSION/checksums.txt"
 $STAGED_BIN = "$GASOLINE_BIN.tmp.$TEMP_TOKEN"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,7 +176,7 @@ echo -e "📁 Install root: $INSTALL_DIR"
 
 # 4. Binary Installation: Download the pre-compiled Go binary from GitHub Releases.
 GASOLINE_BIN="$BIN_DIR/gasoline$BINARY_EXT"
-BINARY_NAME="gasoline-$PLATFORM-$E_ARCH$BINARY_EXT"
+BINARY_NAME="gasoline-agentic-browser-$PLATFORM-$E_ARCH$BINARY_EXT"
 BINARY_URL="https://github.com/$REPO/releases/download/v$VERSION/$BINARY_NAME"
 CHECKSUM_URL="https://github.com/$REPO/releases/download/v$VERSION/checksums.txt"
 


### PR DESCRIPTION
## Summary\n- align installer and release workflow asset names to the current dist output prefix ()\n- update publish workflow copy paths to the same artifact names\n- document that built-in terminal is currently unavailable on Windows in repo docs and website docs\n- remove public npm fallback mentions from website install/download pages\n\n## Why\n- release pipeline failed at binary verify because it referenced old artifact names\n- installer 404 came from expecting old artifact names\n- users need clear docs that terminal support is macOS/Linux only today