### PR TITLE
docs(installer): note Windows xterm feature is disabled

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -363,3 +363,4 @@ if (-not (Test-Path $INSTALL_BIN)) {
 & $INSTALL_BIN --install
 [void](Stop-GasolineServerProcesses)
 Show-InstallWarnings
+Write-Host "ℹ️  Note: In-page xterm terminal support is currently disabled on Windows." -ForegroundColor Yellow


### PR DESCRIPTION
Add an explicit post-install note in scripts/install.ps1: in-page xterm terminal support is currently disabled on Windows.