### PR TITLE
fix(installer): support bundled extension layout + release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,9 @@ jobs:
       - name: Build extension zip
         run: make extension-zip
 
+      - name: Generate checksums manifest
+        run: make checksums
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -200,6 +203,7 @@ jobs:
             dist/gasoline-agentic-browser-linux-x64
             dist/gasoline-agentic-browser-win32-x64.exe
             dist/gasoline-extension-v*.zip
+            dist/checksums.txt
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -168,19 +168,13 @@ function Test-ExtensionStage {
         [string]$BaseDir = $EXT_DIR
     )
 
-    $required = @(
-        (Join-Path $BaseDir "manifest.json"),
-        (Join-Path $BaseDir "background\init.js"),
-        (Join-Path $BaseDir "content\script-injection.js"),
-        (Join-Path $BaseDir "inject\index.js"),
-        (Join-Path $BaseDir "theme-bootstrap.js")
-    )
-    foreach ($path in $required) {
-        if (-not (Test-Path $path)) {
-            return $false
-        }
-    }
-    return $true
+    $hasManifest = Test-Path (Join-Path $BaseDir "manifest.json")
+    $hasBackground = (Test-Path (Join-Path $BaseDir "background.js")) -or (Test-Path (Join-Path $BaseDir "background\init.js"))
+    $hasContent = (Test-Path (Join-Path $BaseDir "content.bundled.js")) -or (Test-Path (Join-Path $BaseDir "content\script-injection.js"))
+    $hasInject = (Test-Path (Join-Path $BaseDir "inject.bundled.js")) -or (Test-Path (Join-Path $BaseDir "inject\index.js"))
+    $hasBootstrap = (Test-Path (Join-Path $BaseDir "early-patch.bundled.js")) -or (Test-Path (Join-Path $BaseDir "theme-bootstrap.js"))
+
+    return ($hasManifest -and $hasBackground -and $hasContent -and $hasInject -and $hasBootstrap)
 }
 
 function Promote-ExtensionStage {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,11 +64,23 @@ prepare_extension_stage() {
 
 validate_extension_stage() {
     local base_dir="${1:-$EXT_DIR}"
-    [ -f "$base_dir/manifest.json" ] &&
-    [ -f "$base_dir/background/init.js" ] &&
-    [ -f "$base_dir/content/script-injection.js" ] &&
-    [ -f "$base_dir/inject/index.js" ] &&
-    [ -f "$base_dir/theme-bootstrap.js" ]
+    [ -f "$base_dir/manifest.json" ] || return 1
+
+    # Support both modern bundled extension layout and legacy modular layout.
+    local has_background=0
+    local has_content=0
+    local has_inject=0
+    local has_bootstrap=0
+
+    [ -f "$base_dir/background.js" ] || [ -f "$base_dir/background/init.js" ] && has_background=1
+    [ -f "$base_dir/content.bundled.js" ] || [ -f "$base_dir/content/script-injection.js" ] && has_content=1
+    [ -f "$base_dir/inject.bundled.js" ] || [ -f "$base_dir/inject/index.js" ] && has_inject=1
+    [ -f "$base_dir/early-patch.bundled.js" ] || [ -f "$base_dir/theme-bootstrap.js" ] && has_bootstrap=1
+
+    [ "$has_background" -eq 1 ] &&
+    [ "$has_content" -eq 1 ] &&
+    [ "$has_inject" -eq 1 ] &&
+    [ "$has_bootstrap" -eq 1 ]
 }
 
 promote_extension_stage() {


### PR DESCRIPTION
## Summary\n- update extension validation in bash/PowerShell installers to accept both legacy modular files and current bundled extension files\n- add checksums generation +  upload in release workflow\n\n## Fixes\n- removes repeated installer warning about extension zip validation fallback\n- removes repeated installer warning about missing checksum manifest