### PR TITLE
refactor: extract CommandBuilder for interact handlers (#501)

### DIFF
--- a/cmd/dev-console/tools_interact_browser_navigation_impl.go
+++ b/cmd/dev-console/tools_interact_browser_navigation_impl.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"encoding/json"
-
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 )
 
 func (h *interactActionHandler) handleBrowserActionNavigateImpl(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
@@ -31,15 +29,6 @@ func (h *interactActionHandler) handleBrowserActionNavigateImpl(req JSONRPCReque
 			withParam("url"))
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-
-	correlationID := newCorrelationID("nav")
-	h.armEvidenceForCommand(correlationID, "navigate", args, req.ClientID)
-
-	h.stashPerfSnapshotImpl(correlationID)
-
 	actionParams := make(map[string]any)
 	lenientUnmarshal(args, &actionParams)
 	actionParams["action"] = "navigate"
@@ -47,22 +36,20 @@ func (h *interactActionHandler) handleBrowserActionNavigateImpl(req JSONRPCReque
 	actionParams["url"] = resolvedURL
 	actionPayload := buildQueryParams(actionParams)
 
-	query := queries.PendingQuery{
-		Type:          "browser_action",
-		Params:        actionPayload,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("navigate", resolvedURL, map[string]any{
-		"target_url":    resolvedURL,
-		"requested_url": params.URL,
-	})
-
-	resp := h.parent.MaybeWaitForCommand(req, correlationID, args, "Navigate queued")
+	resp := h.newCommand("navigate").
+		correlationPrefix("nav").
+		reason("navigate").
+		queryType("browser_action").
+		queryParams(actionPayload).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension).
+		preEnqueue(h.stashPerfSnapshotImpl).
+		recordAction("navigate", resolvedURL, map[string]any{
+			"target_url":    resolvedURL,
+			"requested_url": params.URL,
+		}).
+		queuedMessage("Navigate queued").
+		execute(req, args)
 
 	// If include_content is requested and navigate succeeded, enrich with page content.
 	if params.IncludeContent {
@@ -84,31 +71,17 @@ func (h *interactActionHandler) handleBrowserActionRefreshImpl(req JSONRPCReques
 		return resp
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
-	correlationID := newCorrelationID("refresh")
-	h.armEvidenceForCommand(correlationID, "refresh", args, req.ClientID)
-
-	h.stashPerfSnapshotImpl(correlationID)
-
-	query := queries.PendingQuery{
-		Type:          "browser_action",
-		Params:        json.RawMessage(`{"action":"refresh"}`),
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("refresh", "", nil)
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, "Refresh queued")
+	return h.newCommand("refresh").
+		correlationPrefix("refresh").
+		reason("refresh").
+		queryType("browser_action").
+		buildParams(map[string]any{"action": "refresh"}).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		preEnqueue(h.stashPerfSnapshotImpl).
+		recordAction("refresh", "", nil).
+		queuedMessage("Refresh queued").
+		execute(req, args)
 }
 
 func (h *interactActionHandler) handleBrowserActionBackImpl(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {

--- a/cmd/dev-console/tools_interact_browser_script_impl.go
+++ b/cmd/dev-console/tools_interact_browser_script_impl.go
@@ -7,7 +7,6 @@ package main
 import (
 	"encoding/json"
 
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 	act "github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/tools/interact"
 )
 
@@ -31,31 +30,16 @@ func (h *interactActionHandler) handleHighlightImpl(req JSONRPCRequest, args jso
 		return resp
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
-	// Queue highlight command for extension.
-	correlationID := newCorrelationID("highlight")
-	h.armEvidenceForCommand(correlationID, "highlight", args, req.ClientID)
-
-	query := queries.PendingQuery{
-		Type:          "highlight",
-		Params:        args,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	// Record AI action.
-	h.parent.recordAIAction("highlight", "", map[string]any{"selector": params.Selector})
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, "Highlight queued")
+	return h.newCommand("highlight").
+		correlationPrefix("highlight").
+		reason("highlight").
+		queryType("highlight").
+		queryParams(args).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		recordAction("highlight", "", map[string]any{"selector": params.Selector}).
+		queuedMessage("Highlight queued").
+		execute(req, args)
 }
 
 func (h *interactActionHandler) handleExecuteJSImpl(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
@@ -80,30 +64,15 @@ func (h *interactActionHandler) handleExecuteJSImpl(req JSONRPCRequest, args jso
 		return fail(req, ErrInvalidParam, "Invalid 'world' value: "+params.World, "Use 'auto' (default, tries main then isolated), 'main' (page JS access), or 'isolated' (bypasses CSP, DOM only)", withParam("world"))
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireCSPClear(req, params.World); blocked {
-		return resp
-	}
-
-	correlationID := newCorrelationID("exec")
-	h.armEvidenceForCommand(correlationID, "execute_js", args, req.ClientID)
-
-	query := queries.PendingQuery{
-		Type:          "execute",
-		Params:        args,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("execute_js", "", map[string]any{"script_preview": truncateToLen(params.Script, 100)})
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, "Command queued")
+	return h.newCommand("execute_js").
+		correlationPrefix("exec").
+		reason("execute_js").
+		queryType("execute").
+		queryParams(args).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		cspGuard(params.World).
+		recordAction("execute_js", "", map[string]any{"script_preview": truncateToLen(params.Script, 100)}).
+		queuedMessage("Command queued").
+		execute(req, args)
 }

--- a/cmd/dev-console/tools_interact_browser_tabs.go
+++ b/cmd/dev-console/tools_interact_browser_tabs.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"encoding/json"
-
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 )
 
 func (h *interactActionHandler) handleBrowserActionNewTabImpl(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
@@ -18,9 +16,6 @@ func (h *interactActionHandler) handleBrowserActionNewTabImpl(req JSONRPCRequest
 		return resp
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
 	resolvedURL := params.URL
 	if params.URL != "" {
 		rewriteURL, err := h.resolveNavigateURLImpl(params.URL)
@@ -33,9 +28,6 @@ func (h *interactActionHandler) handleBrowserActionNewTabImpl(req JSONRPCRequest
 		resolvedURL = rewriteURL
 	}
 
-	correlationID := newCorrelationID("newtab")
-	h.armEvidenceForCommand(correlationID, "new_tab", args, req.ClientID)
-
 	actionParams := make(map[string]any)
 	lenientUnmarshal(args, &actionParams)
 	actionParams["action"] = "new_tab"
@@ -44,21 +36,18 @@ func (h *interactActionHandler) handleBrowserActionNewTabImpl(req JSONRPCRequest
 	}
 	actionPayload := buildQueryParams(actionParams)
 
-	query := queries.PendingQuery{
-		Type:          "browser_action",
-		Params:        actionPayload,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("new_tab", resolvedURL, map[string]any{
-		"target_url":    resolvedURL,
-		"requested_url": params.URL,
-	})
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, "New tab queued")
+	return h.newCommand("new_tab").
+		correlationPrefix("newtab").
+		reason("new_tab").
+		queryType("browser_action").
+		queryParams(actionPayload).
+		guards(h.parent.requirePilot, h.parent.requireExtension).
+		recordAction("new_tab", resolvedURL, map[string]any{
+			"target_url":    resolvedURL,
+			"requested_url": params.URL,
+		}).
+		queuedMessage("New tab queued").
+		execute(req, args)
 }
 
 func (h *interactActionHandler) handleBrowserActionSwitchTabImpl(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
@@ -87,36 +76,26 @@ func (h *interactActionHandler) handleBrowserActionSwitchTabImpl(req JSONRPCRequ
 	// Default set_tracked to true so subsequent commands target the new tab.
 	setTracked := params.SetTracked == nil || *params.SetTracked
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	// No requireTabTracking gate: switch_tab IS how you establish tracking
-	// for an existing tab. The handler calls applySwitchTabTracking on success.
-
-	correlationID := newCorrelationID("switchtab")
-	h.armEvidenceForCommand(correlationID, "switch_tab", args, req.ClientID)
-
 	actionParams := make(map[string]any)
 	lenientUnmarshal(args, &actionParams)
 	actionParams["action"] = "switch_tab"
 	actionPayload := buildQueryParams(actionParams)
 
-	query := queries.PendingQuery{
-		Type:          "browser_action",
-		Params:        actionPayload,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("switch_tab", "", map[string]any{
-		"tab_id":    params.TabID,
-		"tab_index": params.TabIndex,
-	})
-
-	resp := h.parent.MaybeWaitForCommand(req, correlationID, args, "Switch tab queued")
+	// No requireTabTracking gate: switch_tab IS how you establish tracking
+	// for an existing tab. The handler calls applySwitchTabTracking on success.
+	resp, correlationID := h.newCommand("switch_tab").
+		correlationPrefix("switchtab").
+		reason("switch_tab").
+		queryType("browser_action").
+		queryParams(actionPayload).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension).
+		recordAction("switch_tab", "", map[string]any{
+			"tab_id":    params.TabID,
+			"tab_index": params.TabIndex,
+		}).
+		queuedMessage("Switch tab queued").
+		executeWithCorrelation(req, args)
 
 	// After the command completes, update tracked tab state so subsequent
 	// commands target the newly activated tab. See issue #271.
@@ -124,7 +103,7 @@ func (h *interactActionHandler) handleBrowserActionSwitchTabImpl(req JSONRPCRequ
 	// extension-side persistTrackedTab via the next /sync heartbeat.
 	// Server-side update only occurs in sync mode because MaybeWaitForCommand
 	// returns immediately when sync=false, so GetCommandResult has no result yet.
-	if setTracked {
+	if setTracked && correlationID != "" {
 		h.applySwitchTabTracking(correlationID)
 	}
 

--- a/cmd/dev-console/tools_interact_browser_util_impl.go
+++ b/cmd/dev-console/tools_interact_browser_util_impl.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/capture"
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/tools/observe"
 )
 
@@ -80,42 +79,34 @@ type browserActionOpts struct {
 
 // queueBrowserAction is the shared helper for simple browser actions that follow
 // the guard → correlate → arm evidence → enqueue → record → wait pattern.
-// Eliminates the repeated 15+ line boilerplate in back, forward, refresh, activate_tab, close_tab, etc.
+// Uses commandBuilder to eliminate repeated boilerplate.
 func (h *interactActionHandler) queueBrowserAction(req JSONRPCRequest, args json.RawMessage, opts browserActionOpts) JSONRPCResponse {
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if !opts.skipTabGuard {
-		if resp, blocked := h.parent.requireTabTracking(req); blocked {
-			return resp
-		}
-	}
-
-	correlationID := newCorrelationID(opts.correlationPfx)
-	h.armEvidenceForCommand(correlationID, opts.action, args, req.ClientID)
-
 	actionParams := opts.params
 	if actionParams == nil {
 		actionParams = buildQueryParams(map[string]any{"action": opts.action})
-	}
-
-	query := queries.PendingQuery{
-		Type:          "browser_action",
-		Params:        actionParams,
-		TabID:         opts.tabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
 	}
 
 	recordAction := opts.recordAction
 	if recordAction == "" {
 		recordAction = opts.action
 	}
-	h.parent.recordAIAction(recordAction, opts.recordURL, opts.recordExtra)
 
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, opts.queuedMsg)
+	cmd := h.newCommand(opts.action).
+		correlationPrefix(opts.correlationPfx).
+		reason(opts.action).
+		queryType("browser_action").
+		queryParams(actionParams).
+		tabID(opts.tabID).
+		recordAction(recordAction, opts.recordURL, opts.recordExtra).
+		queuedMessage(opts.queuedMsg)
+
+	if opts.skipTabGuard {
+		cmd.guards(h.parent.requirePilot, h.parent.requireExtension)
+	} else {
+		cmd.guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking)
+	}
+
+	return cmd.execute(req, args)
 }
 
 // handleScreenshotAliasImpl provides backward compatibility for clients that call
@@ -136,22 +127,16 @@ func (h *interactActionHandler) handleSubtitleImpl(req JSONRPCRequest, args json
 		return fail(req, ErrMissingParam, "Required parameter 'text' is missing for subtitle action", "Add the 'text' parameter with subtitle text, or empty string to clear", withParam("text"))
 	}
 
-	correlationID := newCorrelationID("subtitle")
-	h.armEvidenceForCommand(correlationID, "subtitle", args, req.ClientID)
-
-	query := queries.PendingQuery{
-		Type:          "subtitle",
-		Params:        args,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
 	queuedMsg := "Subtitle set"
 	if *params.Text == "" {
 		queuedMsg = "Subtitle cleared"
 	}
 
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, queuedMsg)
+	return h.newCommand("subtitle").
+		correlationPrefix("subtitle").
+		reason("subtitle").
+		queryType("subtitle").
+		queryParams(args).
+		queuedMessage(queuedMsg).
+		execute(req, args)
 }

--- a/cmd/dev-console/tools_interact_command_builder.go
+++ b/cmd/dev-console/tools_interact_command_builder.go
@@ -1,0 +1,254 @@
+// tools_interact_command_builder.go — Fluent builder for interact command dispatch.
+// Why: Eliminates the repeated correlate→arm→guard→enqueue→wait boilerplate across 30+ interact handlers.
+// Docs: docs/core/common-patterns.md
+
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
+)
+
+// commandBuilder provides a fluent API for the common interact handler sequence:
+//  1. Run guard checks (requirePilot, requireExtension, requireTabTracking, etc.)
+//  2. Generate a correlation ID with a prefix
+//  3. Arm evidence for the command
+//  4. Build or set query params
+//  5. Enqueue a pending query
+//  6. Optionally record an AI action
+//  7. Wait for the command result via MaybeWaitForCommand
+//
+// Usage:
+//
+//	return h.newCommand("highlight").
+//	    correlationPrefix("highlight").
+//	    reason("highlight").
+//	    queryType("highlight").
+//	    queryParams(args).
+//	    tabID(params.TabID).
+//	    guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+//	    recordAction("highlight", "", map[string]any{"selector": params.Selector}).
+//	    queuedMessage("Highlight queued").
+//	    execute(req, args)
+type commandBuilder struct {
+	handler *interactActionHandler
+
+	// Identity
+	name string // descriptive name (for debugging; not used in output)
+
+	// Correlation
+	corrPrefix string // prefix for newCorrelationID
+	reasonStr  string // reason for armEvidenceForCommand
+
+	// Query
+	qType     string          // pending query type (e.g. "execute", "browser_action", "dom_action")
+	qParams   json.RawMessage // serialized query params; nil = use waitArgs from execute()
+	qTabID    int             // tab ID for the pending query
+	qTimeout  time.Duration   // enqueue timeout; zero = queries.AsyncCommandTimeout
+
+	// Guards
+	guardFns  []guardCheck
+	guardOpts []func(*StructuredError) // optional opts passed to checkGuardsWithOpts
+
+	// AI recording (optional)
+	doRecord     bool
+	recAction    string
+	recURL       string
+	recExtra     map[string]any
+
+	// CSP guard (optional)
+	cspWorld string // world value for requireCSPClear; empty = skip
+
+	// Pre-enqueue callback (optional). Called after correlation ID is generated
+	// but before the query is enqueued. Used for side effects that need the
+	// correlation ID (e.g. stashPerfSnapshotImpl).
+	preEnqueueFn func(correlationID string)
+
+	// Post-enqueue callback (optional). Called after the query is successfully
+	// enqueued but before MaybeWaitForCommand. Used for recording actions with
+	// non-standard signatures (e.g. recordDOMPrimitiveAction).
+	postEnqueueFn func()
+
+	// Response
+	queuedMsg string // message for MaybeWaitForCommand when command is async
+}
+
+// newCommand creates a new commandBuilder bound to the interactActionHandler.
+// The name is descriptive only (for debugging/logging).
+func (h *interactActionHandler) newCommand(name string) *commandBuilder {
+	return &commandBuilder{
+		handler: h,
+		name:    name,
+	}
+}
+
+// correlationPrefix sets the prefix for the generated correlation ID.
+func (b *commandBuilder) correlationPrefix(prefix string) *commandBuilder {
+	b.corrPrefix = prefix
+	return b
+}
+
+// reason sets the reason string passed to armEvidenceForCommand.
+func (b *commandBuilder) reason(r string) *commandBuilder {
+	b.reasonStr = r
+	return b
+}
+
+// queryType sets the PendingQuery.Type field.
+func (b *commandBuilder) queryType(t string) *commandBuilder {
+	b.qType = t
+	return b
+}
+
+// queryParams sets pre-serialized query parameters.
+func (b *commandBuilder) queryParams(p json.RawMessage) *commandBuilder {
+	b.qParams = p
+	return b
+}
+
+// buildParams constructs query parameters from a map (calls buildQueryParams).
+func (b *commandBuilder) buildParams(m map[string]any) *commandBuilder {
+	b.qParams = buildQueryParams(m)
+	return b
+}
+
+// tabID sets the tab ID for the pending query.
+func (b *commandBuilder) tabID(id int) *commandBuilder {
+	b.qTabID = id
+	return b
+}
+
+// timeout overrides the default enqueue timeout (queries.AsyncCommandTimeout).
+func (b *commandBuilder) timeout(d time.Duration) *commandBuilder {
+	b.qTimeout = d
+	return b
+}
+
+// guards adds guard checks that run before the command is enqueued.
+// Guards are run in order; the first blocking guard short-circuits.
+func (b *commandBuilder) guards(fns ...guardCheck) *commandBuilder {
+	b.guardFns = append(b.guardFns, fns...)
+	return b
+}
+
+// guardsWithOpts adds guard checks with StructuredError options.
+// This is used by handlers like handleDOMPrimitive that need to pass
+// contextOpts (action, selector) through to guard error responses.
+func (b *commandBuilder) guardsWithOpts(opts []func(*StructuredError), fns ...guardCheck) *commandBuilder {
+	b.guardOpts = opts
+	b.guardFns = append(b.guardFns, fns...)
+	return b
+}
+
+// preEnqueue registers a callback invoked after correlation ID generation but before enqueue.
+// Useful for side effects like stashPerfSnapshotImpl that need the correlation ID.
+func (b *commandBuilder) preEnqueue(fn func(correlationID string)) *commandBuilder {
+	b.preEnqueueFn = fn
+	return b
+}
+
+// postEnqueue registers a callback invoked after successful enqueue but before MaybeWaitForCommand.
+// Used for recording actions with non-standard signatures (e.g. recordDOMPrimitiveAction).
+func (b *commandBuilder) postEnqueue(fn func()) *commandBuilder {
+	b.postEnqueueFn = fn
+	return b
+}
+
+// cspGuard adds a CSP check for the given world after other guards.
+// Only world="main" is blocked — "auto" and "isolated" bypass page CSP.
+func (b *commandBuilder) cspGuard(world string) *commandBuilder {
+	b.cspWorld = world
+	return b
+}
+
+// recordAction configures AI action recording after the command is enqueued.
+func (b *commandBuilder) recordAction(action, url string, extra map[string]any) *commandBuilder {
+	b.doRecord = true
+	b.recAction = action
+	b.recURL = url
+	b.recExtra = extra
+	return b
+}
+
+// queuedMessage sets the message shown when the command is async (queued).
+func (b *commandBuilder) queuedMessage(msg string) *commandBuilder {
+	b.queuedMsg = msg
+	return b
+}
+
+// execute runs the full command sequence: guards → correlate → arm → enqueue → record → wait.
+// waitArgs is the original args passed to MaybeWaitForCommand for sync/background resolution.
+func (b *commandBuilder) execute(req JSONRPCRequest, waitArgs json.RawMessage) JSONRPCResponse {
+	resp, _ := b.executeWithCorrelation(req, waitArgs)
+	return resp
+}
+
+// executeWithCorrelation is like execute but also returns the generated correlation ID.
+// Useful for handlers that need the correlation ID for post-processing (e.g. element index).
+// Returns empty string if guards blocked before correlation ID generation.
+func (b *commandBuilder) executeWithCorrelation(req JSONRPCRequest, waitArgs json.RawMessage) (JSONRPCResponse, string) {
+	// 1. Run guards
+	if len(b.guardOpts) > 0 {
+		if resp, blocked := checkGuardsWithOpts(req, b.guardOpts, b.guardFns...); blocked {
+			return resp, ""
+		}
+	} else if len(b.guardFns) > 0 {
+		if resp, blocked := checkGuards(req, b.guardFns...); blocked {
+			return resp, ""
+		}
+	}
+
+	// 1b. Run CSP guard if configured
+	if b.cspWorld != "" {
+		if resp, blocked := b.handler.parent.requireCSPClear(req, b.cspWorld); blocked {
+			return resp, ""
+		}
+	}
+
+	// 2. Generate correlation ID and arm evidence
+	correlationID := newCorrelationID(b.corrPrefix)
+	b.handler.armEvidenceForCommand(correlationID, b.reasonStr, waitArgs, req.ClientID)
+
+	// 2b. Pre-enqueue callback (e.g. stash perf snapshot)
+	if b.preEnqueueFn != nil {
+		b.preEnqueueFn(correlationID)
+	}
+
+	// 3. Resolve query params
+	params := b.qParams
+	if params == nil {
+		params = waitArgs
+	}
+
+	// 4. Resolve timeout
+	timeout := b.qTimeout
+	if timeout == 0 {
+		timeout = queries.AsyncCommandTimeout
+	}
+
+	// 5. Enqueue pending query
+	query := queries.PendingQuery{
+		Type:          b.qType,
+		Params:        params,
+		TabID:         b.qTabID,
+		CorrelationID: correlationID,
+	}
+	if enqueueResp, blocked := b.handler.parent.enqueuePendingQuery(req, query, timeout); blocked {
+		return enqueueResp, correlationID
+	}
+
+	// 6. Record AI action (optional)
+	if b.doRecord {
+		b.handler.parent.recordAIAction(b.recAction, b.recURL, b.recExtra)
+	}
+
+	// 6b. Post-enqueue callback (e.g. recordDOMPrimitiveAction)
+	if b.postEnqueueFn != nil {
+		b.postEnqueueFn()
+	}
+
+	// 7. Wait for command
+	return b.handler.parent.MaybeWaitForCommand(req, correlationID, waitArgs, b.queuedMsg), correlationID
+}

--- a/cmd/dev-console/tools_interact_command_builder_test.go
+++ b/cmd/dev-console/tools_interact_command_builder_test.go
@@ -1,0 +1,373 @@
+// tools_interact_command_builder_test.go — Tests for the commandBuilder pattern.
+// Validates that the builder correctly produces the same behavior as hand-coded handlers.
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
+)
+
+// asyncArgs wraps args JSON with background=true to avoid sync extension wait in tests.
+func asyncArgs(raw string) json.RawMessage {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return json.RawMessage(raw)
+	}
+	m["background"] = true
+	out, _ := json.Marshal(m)
+	return json.RawMessage(out)
+}
+
+// TestCommandBuilder_BasicFlow verifies the standard correlate→arm→enqueue→wait flow.
+func TestCommandBuilder_BasicFlow(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	args := asyncArgs(`{"tab_id":42}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1, ClientID: "test"}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_flow").
+		correlationPrefix("test").
+		reason("test_action").
+		queryType("browser_action").
+		queryParams(args).
+		tabID(42).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("should create pending query")
+	}
+	if pq.Type != "browser_action" {
+		t.Fatalf("query type = %q, want browser_action", pq.Type)
+	}
+	if pq.TabID != 42 {
+		t.Fatalf("tab ID = %d, want 42", pq.TabID)
+	}
+	if pq.CorrelationID == "" {
+		t.Fatal("correlation ID should not be empty")
+	}
+	if !strings.HasPrefix(pq.CorrelationID, "test_") {
+		t.Fatalf("correlation ID = %q, want prefix test_", pq.CorrelationID)
+	}
+}
+
+// TestCommandBuilder_PilotDisabledBlocks verifies that the pilot guard blocks execution.
+func TestCommandBuilder_PilotDisabledBlocks(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	// pilot disabled by default
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_pilot").
+		correlationPrefix("test").
+		reason("test").
+		queryType("browser_action").
+		queryParams(args).
+		guards(h.parent.requirePilot, h.parent.requireExtension).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("pilot disabled should return error")
+	}
+	if !strings.Contains(strings.ToLower(result.Content[0].Text), "pilot") {
+		t.Errorf("error should mention pilot, got: %s", result.Content[0].Text)
+	}
+
+	// Verify no pending query was created
+	pq := env.capture.GetLastPendingQuery()
+	if pq != nil {
+		t.Fatal("pilot disabled should not create pending query")
+	}
+}
+
+// TestCommandBuilder_WithBuildParams verifies the builder can construct params from a map.
+func TestCommandBuilder_WithBuildParams(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_params").
+		correlationPrefix("exec").
+		reason("execute_js").
+		queryType("execute").
+		buildParams(map[string]any{
+			"script":     "console.log('hi')",
+			"timeout_ms": 5000,
+			"world":      "auto",
+			"reason":     "execute_js",
+		}).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		queuedMessage("Command queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("should create pending query")
+	}
+	if pq.Type != "execute" {
+		t.Fatalf("query type = %q, want execute", pq.Type)
+	}
+	// Verify built params contain expected fields
+	var params map[string]any
+	if err := json.Unmarshal(pq.Params, &params); err != nil {
+		t.Fatalf("params unmarshal: %v", err)
+	}
+	if params["script"] != "console.log('hi')" {
+		t.Fatalf("script = %v, want console.log('hi')", params["script"])
+	}
+}
+
+// TestCommandBuilder_WithTimeout verifies custom timeout is forwarded.
+func TestCommandBuilder_WithTimeout(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_timeout").
+		correlationPrefix("test").
+		reason("test").
+		queryType("browser_action").
+		queryParams(args).
+		timeout(queries.AsyncCommandTimeout).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("should not error, got: %s", result.Content[0].Text)
+	}
+}
+
+// TestCommandBuilder_WithRecordAction verifies AI action recording.
+func TestCommandBuilder_WithRecordAction(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_record").
+		correlationPrefix("test").
+		reason("test").
+		queryType("browser_action").
+		queryParams(args).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		recordAction("navigate", "https://example.com", map[string]any{"foo": "bar"}).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("should not error, got: %s", result.Content[0].Text)
+	}
+	// AI action recording is fire-and-forget; main assertion is no error
+}
+
+// TestCommandBuilder_WithGuardOpts verifies structured error opts are passed to guards.
+func TestCommandBuilder_WithGuardOpts(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	// pilot disabled to trigger guard
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	resp := h.newCommand("test_opts").
+		correlationPrefix("test").
+		reason("test").
+		queryType("browser_action").
+		queryParams(args).
+		guardsWithOpts(
+			[]func(*StructuredError){withAction("test_action")},
+			h.parent.requirePilot, h.parent.requireExtension,
+		).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("pilot disabled should return error")
+	}
+}
+
+// TestCommandBuilder_NoQueryParams_UsesEmptyArgs verifies that forgetting to set params
+// falls back to using the original args as query params.
+func TestCommandBuilder_NoQueryParams_UsesEmptyArgs(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	args := asyncArgs(`{}`)
+	req := JSONRPCRequest{JSONRPC: "2.0", ID: 1}
+	h := env.handler.interactAction()
+
+	// When no queryParams or buildParams is set, builder uses the original args
+	resp := h.newCommand("test_defaults").
+		correlationPrefix("test").
+		reason("test").
+		queryType("browser_action").
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		queuedMessage("Test queued").
+		execute(req, args)
+
+	var result MCPToolResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("should create pending query")
+	}
+}
+
+// TestCommandBuilder_MatchesQueueBrowserAction verifies the builder produces the same
+// result as the existing queueBrowserAction helper for back/forward.
+func TestCommandBuilder_MatchesQueueBrowserAction(t *testing.T) {
+	t.Parallel()
+
+	// Test with back action using builder
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	result, ok := env.callInteract(t, `{"what":"back"}`)
+	if !ok {
+		t.Fatal("back should return result")
+	}
+	if result.IsError {
+		t.Fatalf("back should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("back should create pending query")
+	}
+	if pq.Type != "browser_action" {
+		t.Fatalf("query type = %q, want browser_action", pq.Type)
+	}
+}
+
+// TestCommandBuilder_MatchesHighlight verifies builder produces same result as handleHighlightImpl.
+func TestCommandBuilder_MatchesHighlight(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	result, ok := env.callInteract(t, `{"what":"highlight","selector":"#main"}`)
+	if !ok {
+		t.Fatal("highlight should return result")
+	}
+	if result.IsError {
+		t.Fatalf("highlight should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("highlight should create pending query")
+	}
+	if pq.Type != "highlight" {
+		t.Fatalf("query type = %q, want highlight", pq.Type)
+	}
+}
+
+// TestCommandBuilder_MatchesContentExtraction verifies builder for get_readable.
+func TestCommandBuilder_MatchesContentExtraction(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	result, ok := env.callInteract(t, `{"what":"get_readable"}`)
+	if !ok {
+		t.Fatal("get_readable should return result")
+	}
+	if result.IsError {
+		t.Fatalf("get_readable should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("get_readable should create pending query")
+	}
+	if pq.Type != "get_readable" {
+		t.Fatalf("query type = %q, want get_readable", pq.Type)
+	}
+}
+
+// TestCommandBuilder_MatchesRefresh verifies builder for refresh action.
+func TestCommandBuilder_MatchesRefresh(t *testing.T) {
+	t.Parallel()
+	env := newInteractTestEnv(t)
+	env.capture.SetPilotEnabled(true)
+
+	result, ok := env.callInteract(t, `{"what":"refresh"}`)
+	if !ok {
+		t.Fatal("refresh should return result")
+	}
+	if result.IsError {
+		t.Fatalf("refresh should not error, got: %s", result.Content[0].Text)
+	}
+
+	pq := env.capture.GetLastPendingQuery()
+	if pq == nil {
+		t.Fatal("refresh should create pending query")
+	}
+	if pq.Type != "browser_action" {
+		t.Fatalf("query type = %q, want browser_action", pq.Type)
+	}
+}

--- a/cmd/dev-console/tools_interact_content.go
+++ b/cmd/dev-console/tools_interact_content.go
@@ -31,13 +31,6 @@ func (h *interactActionHandler) handleContentExtraction(req JSONRPCRequest, args
 	}
 	lenientUnmarshal(args, &params)
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
 	if params.TimeoutMs <= 0 {
 		params.TimeoutMs = 10_000
 	}
@@ -45,25 +38,17 @@ func (h *interactActionHandler) handleContentExtraction(req JSONRPCRequest, args
 		params.TimeoutMs = 30_000
 	}
 
-	correlationID := newCorrelationID(correlationPrefix)
-	h.armEvidenceForCommand(correlationID, queryType, args, req.ClientID)
-
-	// Structured params — no embedded script. The content script handles extraction directly.
-	queryParams := buildQueryParams(map[string]any{
-		"timeout_ms": params.TimeoutMs,
-	})
-
-	query := queries.PendingQuery{
-		Type:          queryType,
-		Params:        queryParams,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, queryType+" queued")
+	return h.newCommand(queryType).
+		correlationPrefix(correlationPrefix).
+		reason(queryType).
+		queryType(queryType).
+		buildParams(map[string]any{
+			"timeout_ms": params.TimeoutMs,
+		}).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		queuedMessage(queryType + " queued").
+		execute(req, args)
 }
 
 func (h *interactActionHandler) handleGetReadable(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {

--- a/cmd/dev-console/tools_interact_dom.go
+++ b/cmd/dev-console/tools_interact_dom.go
@@ -7,7 +7,6 @@ package main
 import (
 	"encoding/json"
 
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 	act "github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/tools/interact"
 )
 
@@ -101,27 +100,21 @@ func (h *interactActionHandler) handleDOMPrimitive(req JSONRPCRequest, args json
 		return errResp
 	}
 
-	contextOpts := domActionContextOptions(action, params.Selector)
-	if resp, blocked := checkGuardsWithOpts(req, contextOpts, h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking); blocked {
-		return resp
-	}
-
 	args = normalizeDOMActionArgs(args, action)
 
-	correlationID := newCorrelationID("dom_" + action)
-	h.armEvidenceForCommand(correlationID, action, args, req.ClientID)
-
-	query := queries.PendingQuery{
-		Type:          "dom_action",
-		Params:        args,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordDOMPrimitiveAction(action, params.Selector, params.Text, params.Value)
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, action+" queued")
+	return h.newCommand("dom_" + action).
+		correlationPrefix("dom_" + action).
+		reason(action).
+		queryType("dom_action").
+		queryParams(args).
+		tabID(params.TabID).
+		guardsWithOpts(
+			domActionContextOptions(action, params.Selector),
+			h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking,
+		).
+		postEnqueue(func() {
+			h.parent.recordDOMPrimitiveAction(action, params.Selector, params.Text, params.Value)
+		}).
+		queuedMessage(action + " queued").
+		execute(req, args)
 }

--- a/cmd/dev-console/tools_interact_dom_click.go
+++ b/cmd/dev-console/tools_interact_dom_click.go
@@ -6,8 +6,6 @@ package main
 
 import (
 	"encoding/json"
-
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 )
 
 // handleHardwareClick dispatches a coordinate-based click via CDP Input.dispatchMouseEvent.
@@ -30,36 +28,21 @@ func (h *interactActionHandler) handleHardwareClick(req JSONRPCRequest, args jso
 
 // handleCDPClick creates a cdp_action query for a hardware-level click at coordinates.
 func (h *interactActionHandler) handleCDPClick(req JSONRPCRequest, args json.RawMessage, action string, x, y float64, tabID int) JSONRPCResponse {
-	if resp, blocked := h.parent.requirePilot(req, withAction(action)); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireExtension(req, withAction(action)); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req, withAction(action)); blocked {
-		return resp
-	}
-
-	correlationID := newCorrelationID("cdp_click")
-	h.armEvidenceForCommand(correlationID, action, args, req.ClientID)
-
-	cdpParams := buildQueryParams(map[string]any{
-		"action": "click",
-		"x":      x,
-		"y":      y,
-	})
-
-	query := queries.PendingQuery{
-		Type:          "cdp_action",
-		Params:        cdpParams,
-		TabID:         tabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction(action, "", map[string]any{"x": x, "y": y, "method": "cdp"})
-
-	return h.parent.MaybeWaitForCommand(req, correlationID, args, action+" queued")
+	return h.newCommand("cdp_click").
+		correlationPrefix("cdp_click").
+		reason(action).
+		queryType("cdp_action").
+		buildParams(map[string]any{
+			"action": "click",
+			"x":      x,
+			"y":      y,
+		}).
+		tabID(tabID).
+		guardsWithOpts(
+			[]func(*StructuredError){withAction(action)},
+			h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking,
+		).
+		recordAction(action, "", map[string]any{"x": x, "y": y, "method": "cdp"}).
+		queuedMessage(action + " queued").
+		execute(req, args)
 }

--- a/cmd/dev-console/tools_interact_elements.go
+++ b/cmd/dev-console/tools_interact_elements.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 	act "github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/tools/interact"
 )
 
@@ -22,31 +21,18 @@ func (h *interactActionHandler) handleListInteractive(req JSONRPCRequest, args j
 		return resp
 	}
 
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
 	args = normalizeDOMActionArgs(args, "list_interactive")
 
-	correlationID := newCorrelationID("dom_list")
-	h.armEvidenceForCommand(correlationID, "list_interactive", args, req.ClientID)
-
-	query := queries.PendingQuery{
-		Type:          "dom_action",
-		Params:        args,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("dom_list_interactive", "", nil)
-
-	resp := h.parent.MaybeWaitForCommand(req, correlationID, args, "list_interactive queued")
+	resp, correlationID := h.newCommand("list_interactive").
+		correlationPrefix("dom_list").
+		reason("list_interactive").
+		queryType("dom_action").
+		queryParams(args).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		recordAction("dom_list_interactive", "", nil).
+		queuedMessage("list_interactive queued").
+		executeWithCorrelation(req, args)
 
 	// Post-process: extract elements from result and build index→selector store.
 	// IMPORTANT: index store is built from ALL elements before truncation.

--- a/cmd/dev-console/tools_interact_explore.go
+++ b/cmd/dev-console/tools_interact_explore.go
@@ -7,8 +7,6 @@ package main
 import (
 	"encoding/json"
 	"net/url"
-
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 )
 
 // handleExplorePage handles interact(what="explore_page").
@@ -17,13 +15,6 @@ import (
 // If url is provided, the extension navigates first before collecting data.
 // Screenshot is appended server-side after the extension returns.
 func (h *interactActionHandler) handleExplorePage(req JSONRPCRequest, args json.RawMessage) JSONRPCResponse {
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
 	var params struct {
 		URL         string `json:"url,omitempty"`
 		TabID       int    `json:"tab_id,omitempty"`
@@ -47,21 +38,16 @@ func (h *interactActionHandler) handleExplorePage(req JSONRPCRequest, args json.
 		}
 	}
 
-	correlationID := newCorrelationID("explore_page")
-
-	query := queries.PendingQuery{
-		Type:          "explore_page",
-		Params:        args,
-		TabID:         params.TabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
-	}
-
-	h.parent.recordAIAction("explore_page", params.URL, nil)
-
-	resp := h.parent.MaybeWaitForCommand(req, correlationID, args, "Explore page queued")
+	resp := h.newCommand("explore_page").
+		correlationPrefix("explore_page").
+		reason("explore_page").
+		queryType("explore_page").
+		queryParams(args).
+		tabID(params.TabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		recordAction("explore_page", params.URL, nil).
+		queuedMessage("Explore page queued").
+		execute(req, args)
 
 	// Append inline screenshot only if the command completed (not queued or error)
 	if !isErrorResponse(resp) && !isResponseQueued(resp) {

--- a/cmd/dev-console/tools_interact_storage.go
+++ b/cmd/dev-console/tools_interact_storage.go
@@ -6,8 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/queries"
 )
 
 var validStorageTypes = map[string]string{
@@ -173,47 +171,31 @@ func (h *interactActionHandler) queueExecuteScript(
 	tabID, timeoutMs int,
 	world, script, reason, queuedMsg string,
 ) JSONRPCResponse {
-	if resp, blocked := checkGuards(req, h.parent.requirePilot, h.parent.requireExtension); blocked {
-		return resp
-	}
-	if resp, blocked := h.parent.requireTabTracking(req); blocked {
-		return resp
-	}
-
 	if world == "" {
 		world = "auto"
-	}
-	if resp, blocked := h.parent.requireCSPClear(req, world); blocked {
-		return resp
-	}
-
-	if timeoutMs <= 0 {
-		timeoutMs = 5000
 	}
 	if !validWorldValues[world] {
 		return fail(req, ErrInvalidParam, "Invalid 'world' value: "+world, "Use 'auto' (default), 'main', or 'isolated'", withParam("world"))
 	}
-
-	correlationID := newCorrelationID(correlationPrefix)
-	h.armEvidenceForCommand(correlationID, reason, waitArgs, req.ClientID)
-	execParams := buildQueryParams(map[string]any{
-		"script":     script,
-		"timeout_ms": timeoutMs,
-		"world":      world,
-		"reason":     reason,
-	})
-
-	query := queries.PendingQuery{
-		Type:          "execute",
-		Params:        execParams,
-		TabID:         tabID,
-		CorrelationID: correlationID,
-	}
-	if enqueueResp, blocked := h.parent.enqueuePendingQuery(req, query, queries.AsyncCommandTimeout); blocked {
-		return enqueueResp
+	if timeoutMs <= 0 {
+		timeoutMs = 5000
 	}
 
-	return h.parent.MaybeWaitForCommand(req, correlationID, waitArgs, queuedMsg)
+	return h.newCommand(reason).
+		correlationPrefix(correlationPrefix).
+		reason(reason).
+		queryType("execute").
+		buildParams(map[string]any{
+			"script":     script,
+			"timeout_ms": timeoutMs,
+			"world":      world,
+			"reason":     reason,
+		}).
+		tabID(tabID).
+		guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+		cspGuard(world).
+		queuedMessage(queuedMsg).
+		execute(req, waitArgs)
 }
 
 func jsQuote(v string) string {

--- a/docs/core/common-patterns.md
+++ b/docs/core/common-patterns.md
@@ -43,6 +43,65 @@ Use this as a hard checklist during design, coding, and review.
   - one end-to-end/smoke assertion of payload shape and behavior.
 - If behavior changes, update/remove stale tests in the same PR; do not leave failing legacy assertions.
 
+## 7) CommandBuilder for Interact Handlers
+
+New interact handlers that follow the standard guard/correlate/arm/enqueue/wait sequence
+must use the `commandBuilder` pattern instead of repeating the boilerplate manually.
+
+- **File:** `cmd/dev-console/tools_interact_command_builder.go`
+- **Tests:** `cmd/dev-console/tools_interact_command_builder_test.go`
+
+### When to Use
+
+Use `commandBuilder` when a handler follows this sequence:
+1. Run guard checks (pilot, extension, tab tracking)
+2. Generate correlation ID
+3. Arm evidence for the command
+4. Enqueue a pending query
+5. Optionally record an AI action
+6. Wait for the command result
+
+### Usage
+
+```go
+return h.newCommand("highlight").
+    correlationPrefix("highlight").
+    reason("highlight").
+    queryType("highlight").
+    queryParams(args).
+    tabID(params.TabID).
+    guards(h.parent.requirePilot, h.parent.requireExtension, h.parent.requireTabTracking).
+    recordAction("highlight", "", map[string]any{"selector": params.Selector}).
+    queuedMessage("Highlight queued").
+    execute(req, args)
+```
+
+### Builder Methods
+
+| Method | Purpose |
+|--------|---------|
+| `correlationPrefix(s)` | Prefix for generated correlation ID |
+| `reason(s)` | Reason string for evidence arming |
+| `queryType(s)` | PendingQuery.Type (e.g. "execute", "browser_action") |
+| `queryParams(p)` | Pre-serialized query params |
+| `buildParams(m)` | Build params from map (calls `buildQueryParams`) |
+| `tabID(id)` | Tab ID for the pending query |
+| `guards(fns...)` | Guard checks (run in order, first blocker short-circuits) |
+| `guardsWithOpts(opts, fns...)` | Guards with StructuredError context options |
+| `cspGuard(world)` | CSP check for world param |
+| `preEnqueue(fn)` | Callback after correlation ID, before enqueue |
+| `postEnqueue(fn)` | Callback after enqueue, before wait |
+| `recordAction(action, url, extra)` | Record AI action after enqueue |
+| `timeout(d)` | Override default enqueue timeout |
+| `queuedMessage(msg)` | Message for async (queued) responses |
+| `execute(req, args)` | Run the full sequence |
+| `executeWithCorrelation(req, args)` | Like execute, also returns correlation ID |
+
+### When NOT to Use
+
+- Handlers with completely custom response logic (e.g. `handleDrawModeStart` returns a static response instead of `MaybeWaitForCommand`)
+- Handlers on `*ToolHandler` (not `*interactActionHandler`) that create queries independently (e.g. `enrichNavigateResponse`)
+
 ## Review Checklist
 
 - [ ] Storage access follows helper/module boundaries.
@@ -51,3 +110,4 @@ Use this as a hard checklist during design, coding, and review.
 - [ ] UX labels/toasts/badges come from shared utilities.
 - [ ] `jscpd` run completed and clones were resolved or documented.
 - [ ] Unit + e2e/smoke tests reflect current behavior and pass.
+- [ ] New interact handlers use `commandBuilder` when the standard guard/correlate/enqueue/wait pattern applies.

--- a/docs/features/feature/interact-explore/flow-map.md
+++ b/docs/features/feature/interact-explore/flow-map.md
@@ -1,7 +1,7 @@
 ---
 doc_type: flow_map_pointer
 status: active
-last_reviewed: 2026-03-05
+last_reviewed: 2026-03-06
 canonical_flow_map: ../../../architecture/flow-maps/interact-navigate-and-document.md
 last_verified_version: 0.7.12
 last_verified_date: 2026-03-05
@@ -21,4 +21,4 @@ Related flow maps:
 - [Interact Overlay & Selector Improvements](../../../architecture/flow-maps/interact-overlay-selector-improvements.md)
 - [Shared Extraction and Contract Normalization](../../../architecture/flow-maps/shared-extraction-and-contract-normalization.md)
 
-Latest sync update (2026-03-05): content fallback extraction internals are deduplicated through shared main-element selection and cleanup helpers, and upload daemon calls use shared JSON request helpers.
+Latest sync update (2026-03-06): interact handlers migrated to `commandBuilder` pattern (`cmd/dev-console/tools_interact_command_builder.go`) to consolidate the repeated guard/correlate/arm/enqueue/wait boilerplate. See `docs/core/common-patterns.md` section 7 for usage.

--- a/docs/features/feature/interact-explore/index.md
+++ b/docs/features/feature/interact-explore/index.md
@@ -4,8 +4,9 @@ feature_id: feature-interact-explore
 status: shipped
 feature_type: feature
 owners: []
-last_reviewed: 2026-03-05
+last_reviewed: 2026-03-06
 code_paths:
+  - cmd/dev-console/tools_interact_command_builder.go
   - cmd/dev-console/tools_interact_action_handler.go
   - cmd/dev-console/tools_interact_entrypoint.go
   - cmd/dev-console/tools_interact_dispatch.go
@@ -58,6 +59,7 @@ code_paths:
   - cmd/dev-console/tools_async_formatting.go
   - cmd/dev-console/tools_summary_pref.go
 test_paths:
+  - cmd/dev-console/tools_interact_command_builder_test.go
   - cmd/dev-console/tools_interact_handler_test.go
   - cmd/dev-console/tools_pending_query_enqueue_test.go
   - cmd/dev-console/tools_interact_rich_test.go


### PR DESCRIPTION
## Summary

- Extracted fluent `commandBuilder` in `tools_interact_command_builder.go` (254 LOC) that encapsulates the repeated correlate→arm→guard→enqueue→wait sequence
- Migrated 14 handlers (25+ action paths) to use the builder
- 117 net lines removed from handler files
- `queries` package import removed from 7 handler files (encapsulated by builder)
- 11 dedicated builder tests

## Not Migrated (intentional)

- `handleDrawModeStart` — returns static `succeed()` instead of `MaybeWaitForCommand`, plus has `MarkDrawStarted()` side effect between enqueue and response
- `enrichNavigateResponse` — lives on `*ToolHandler`, creates queries as post-processing enrichment

## Test plan

- [x] `go build ./cmd/dev-console/...` passes
- [x] `go test ./cmd/dev-console/ -run 'Test[^U]'` passes (skip flaky upload integration)
- [x] 11 new builder tests pass
- [x] Docs updated: `common-patterns.md`, feature index, flow map

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)