### PR TITLE
feat(pty): adopt 8 session improvements from CAR analysis

### DIFF
--- a/cmd/browser-agent/main_connection_mcp_shutdown.go
+++ b/cmd/browser-agent/main_connection_mcp_shutdown.go
@@ -92,6 +92,9 @@ func awaitShutdownSignal(server *Server, srv *http.Server, port int, httpDone <-
 			th.capture.Close()
 		}
 	}
+	if server.ptyRelays != nil {
+		server.ptyRelays.closeAll()
+	}
 	if server.ptyManager != nil {
 		server.ptyManager.StopAll()
 	}

--- a/cmd/browser-agent/server.go
+++ b/cmd/browser-agent/server.go
@@ -58,6 +58,7 @@ type Server struct {
 
 	// Terminal PTY session manager
 	ptyManager *pty.Manager
+	ptyRelays  *terminalRelayMap
 
 	// Terminal server port (0 = terminal server not running)
 	terminalPort int

--- a/cmd/browser-agent/terminal_assets/terminal.html
+++ b/cmd/browser-agent/terminal_assets/terminal.html
@@ -102,6 +102,7 @@
       var ws = null;
       var reconnectTimer = null;
       var reconnectDelay = 1000;
+      var processExited = false;
       var lastTypingNotifyAt = 0;
 
       function notifyFocusState(focused) {
@@ -185,6 +186,11 @@
               } else if (msg.type === 'exited') {
                 term.write('\r\n\x1b[90m[Process exited with code ' + (msg.code || 0) + ']\x1b[0m\r\n');
                 statusDot.className = 'status';
+                processExited = true;
+                if (reconnectTimer) {
+                  clearTimeout(reconnectTimer);
+                  reconnectTimer = null;
+                }
                 notifyParent('exited', { code: msg.code });
               }
             } catch(e) {
@@ -206,7 +212,7 @@
       }
 
       function scheduleReconnect() {
-        if (reconnectTimer) return;
+        if (reconnectTimer || processExited) return;
         reconnectTimer = setTimeout(function() {
           reconnectTimer = null;
           connect();

--- a/cmd/browser-agent/terminal_assets/terminal.html
+++ b/cmd/browser-agent/terminal_assets/terminal.html
@@ -171,6 +171,12 @@
                 if (msg.cli) {
                   headerLabel.textContent = msg.cli;
                 }
+              } else if (msg.type === 'replay_end') {
+                // Scrollback replay is complete — all subsequent data is live.
+                notifyParent('replay_end', {});
+              } else if (msg.type === 'alt_screen') {
+                // Alt-screen state changed (e.g., vim, less entered/exited).
+                notifyParent('alt_screen', { active: msg.active });
               } else if (msg.type === 'exited') {
                 term.write('\r\n\x1b[90m[Process exited with code ' + (msg.code || 0) + ']\x1b[0m\r\n');
                 statusDot.className = 'status';

--- a/cmd/browser-agent/terminal_assets/terminal.html
+++ b/cmd/browser-agent/terminal_assets/terminal.html
@@ -148,6 +148,11 @@
           statusDot.className = 'status connected';
           reconnectDelay = 1000;
 
+          // Reset the terminal before scrollback replay to prevent duplicate
+          // output. The server sends the full scrollback history followed by
+          // a replay_end marker, so we start with a clean slate.
+          term.reset();
+
           // Send initial resize
           sendResize();
 

--- a/cmd/browser-agent/terminal_handlers.go
+++ b/cmd/browser-agent/terminal_handlers.go
@@ -163,6 +163,12 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, 
 	// Get or create relay for multi-subscriber fan-out.
 	relay := relays.getOrCreate(sess.ID, sess, "")
 
+	// Capture scrollback BEFORE subscribing to the fanout to avoid duplicate
+	// data. The readLoop appends to scrollback then broadcasts, so any data
+	// arriving after this snapshot will be delivered only via the subscriber
+	// channel, not replayed from scrollback.
+	history := sess.Scrollback()
+
 	subID := nextWSSubID()
 	sub, subErr := relay.fanout.Subscribe(subID)
 	if subErr != nil {
@@ -171,7 +177,7 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, 
 	}
 
 	// Replay scrollback so the reconnecting terminal sees prior output.
-	if history := sess.Scrollback(); len(history) > 0 {
+	if len(history) > 0 {
 		// Send in chunks to avoid oversized frames.
 		for off := 0; off < len(history); off += terminalReadBufSize {
 			end := off + terminalReadBufSize

--- a/cmd/browser-agent/terminal_handlers.go
+++ b/cmd/browser-agent/terminal_handlers.go
@@ -43,6 +43,9 @@ const terminalPromptChars = "$#>%"
 // NOT MCP — These are daemon-served endpoints for the in-browser terminal.
 func registerTerminalRoutes(mux *http.ServeMux, server *Server, mgr *pty.Manager, cap *capture.Store) {
 	relays := newTerminalRelayMap()
+	if server != nil {
+		server.ptyRelays = relays
+	}
 
 	// Serve terminal HTML page.
 	mux.HandleFunc("/terminal", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
@@ -595,6 +598,10 @@ func handleTerminalUpload(w http.ResponseWriter, r *http.Request, mgr *pty.Manag
 	if sessionID == "" {
 		sessionID = "default"
 	}
+
+	// Cap request body at the upload limit (+4KB for overhead) to prevent
+	// unbounded memory buffering before pty.Upload's own LimitReader kicks in.
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20+4096)
 
 	// Verify session exists.
 	if _, err := mgr.Get(sessionID); err != nil {

--- a/cmd/browser-agent/terminal_handlers.go
+++ b/cmd/browser-agent/terminal_handlers.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/capture"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/pty"
-	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/util"
 )
 
 // terminalPingInterval is how often the server sends WebSocket ping frames.
@@ -43,6 +42,8 @@ const terminalPromptChars = "$#>%"
 // registerTerminalRoutes adds terminal-related routes to the mux.
 // NOT MCP — These are daemon-served endpoints for the in-browser terminal.
 func registerTerminalRoutes(mux *http.ServeMux, server *Server, mgr *pty.Manager, cap *capture.Store) {
+	relays := newTerminalRelayMap()
+
 	// Serve terminal HTML page.
 	mux.HandleFunc("/terminal", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		handleTerminalPage(w, r)
@@ -61,15 +62,15 @@ func registerTerminalRoutes(mux *http.ServeMux, server *Server, mgr *pty.Manager
 
 	// WebSocket upgrade for PTY I/O.
 	mux.HandleFunc("/terminal/ws", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
-		handleTerminalWS(w, r, mgr)
+		handleTerminalWS(w, r, mgr, relays)
 	}))
 
 	// Session lifecycle.
 	mux.HandleFunc("/terminal/start", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
-		handleTerminalStart(w, r, server, mgr, cap)
+		handleTerminalStart(w, r, server, mgr, cap, relays)
 	}))
 	mux.HandleFunc("/terminal/stop", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
-		handleTerminalStop(w, r, mgr)
+		handleTerminalStop(w, r, mgr, relays)
 	}))
 
 	// Session validation — checks a specific token against a live session.
@@ -79,7 +80,12 @@ func registerTerminalRoutes(mux *http.ServeMux, server *Server, mgr *pty.Manager
 
 	// Session configuration.
 	mux.HandleFunc("/terminal/config", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
-		handleTerminalConfig(w, r, mgr)
+		handleTerminalConfig(w, r, mgr, relays)
+	}))
+
+	// Image upload for terminal sessions.
+	mux.HandleFunc("/terminal/upload", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		handleTerminalUpload(w, r, mgr, relays)
 	}))
 
 	// NOTE: /config/active-codebase is registered in registerCoreRoutes (not terminal-specific).
@@ -103,7 +109,7 @@ func handleTerminalPage(w http.ResponseWriter, r *http.Request) {
 
 // handleTerminalWS upgrades a GET /terminal/ws request to a WebSocket connection
 // that relays raw PTY I/O to/from the browser's xterm.js terminal emulator.
-func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) {
+func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, relays *terminalRelayMap) {
 	token := r.URL.Query().Get("token")
 	if token == "" {
 		jsonResponse(w, http.StatusUnauthorized, map[string]string{"error": "missing token"})
@@ -151,6 +157,16 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) 
 		return
 	}
 
+	// Get or create relay for multi-subscriber fan-out.
+	relay := relays.getOrCreate(sess.ID, sess, "")
+
+	subID := nextWSSubID()
+	sub, subErr := relay.fanout.Subscribe(subID)
+	if subErr != nil {
+		_ = conn.Close()
+		return
+	}
+
 	// Replay scrollback so the reconnecting terminal sees prior output.
 	if history := sess.Scrollback(); len(history) > 0 {
 		// Send in chunks to avoid oversized frames.
@@ -160,18 +176,27 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) 
 				end = len(history)
 			}
 			if err := wsWriteFrame(bufrw, 0x2, history[off:end]); err != nil {
+				relay.fanout.Unsubscribe(subID)
 				_ = conn.Close()
 				return
 			}
 		}
 	}
+	// Send replay_end marker so the frontend distinguishes replay from live data.
+	replayEnd, _ := json.Marshal(map[string]string{"type": "replay_end"})
+	if err := wsWriteFrame(bufrw, 0x1, replayEnd); err != nil {
+		relay.fanout.Unsubscribe(subID)
+		_ = conn.Close()
+		return
+	}
 
-	terminalWSLoop(conn, bufrw, sess)
+	terminalWSLoop(conn, bufrw, sess, relay, sub)
+	relay.fanout.Unsubscribe(subID)
 }
 
 // terminalWSLoop relays data between a WebSocket connection and a PTY session.
-// Downstream (PTY -> browser): binary WebSocket frames with raw terminal output.
-// Upstream (browser -> PTY): binary frames as keystrokes, text frames as JSON control messages.
+// Downstream (fan-out -> browser): binary WebSocket frames with raw terminal output.
+// Upstream (browser -> PTY): binary frames as keystrokes via write buffer, text frames as JSON control.
 // Server sends ping frames every terminalPingInterval; if no frame (data or pong) arrives
 // within terminalPongTimeout the connection is considered dead and closed. The PTY session
 // survives so the browser can reconnect with scrollback replay.
@@ -180,7 +205,7 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) 
 // closeConn function. Any goroutine that detects a terminal condition calls closeConn(),
 // which closes connDone (unblocking the others) then closes the underlying TCP connection
 // exactly once. This prevents double-close races and goroutine leaks.
-func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session) {
+func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session, relay *terminalRelay, sub <-chan []byte) {
 	// Coordinated shutdown: connDone signals all goroutines to exit,
 	// closeConn ensures conn.Close() is called exactly once.
 	connDone := make(chan struct{})
@@ -192,44 +217,46 @@ func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session) {
 		})
 	}
 
-	// Multiple goroutines emit frames (PTY downstream, keepalive ping, and upstream
+	// Multiple goroutines emit frames (downstream, keepalive ping, and upstream
 	// control responses). Serialize writes to avoid interleaved/corrupted frames.
 	writeFrame := newTerminalFrameWriter(rw)
 
-	// PTY -> WebSocket (downstream): read PTY output and send as binary frames.
-	// Selects on connDone so it exits promptly when the WebSocket dies.
-	ptyDone := make(chan struct{})
-	util.SafeGo(func() {
-		defer close(ptyDone)
-		buf := make([]byte, terminalReadBufSize)
+	// Fan-out -> WebSocket (downstream): read from subscriber channel and send as binary frames.
+	// Also tracks alt-screen state changes and notifies the frontend.
+	downstreamDone := make(chan struct{})
+	go func() { // lint:allow-bare-goroutine — bounded by connDone/channel close
+		defer close(downstreamDone)
+		prevAltScreen := sess.AltScreenActive()
 		for {
-			n, err := sess.Read(buf)
-			if err != nil {
-				// PTY closed or process exited — send close frame and shut down.
-				_ = writeFrame(0x8, nil)
-				closeConn()
-				return
-			}
-			if n > 0 {
-				sess.AppendScrollback(buf[:n])
-				if err := writeFrame(0x2, buf[:n]); err != nil {
+			select {
+			case data, ok := <-sub:
+				if !ok {
+					// Fanout closed (session ended) — send close frame.
+					_ = writeFrame(0x8, nil)
 					closeConn()
 					return
 				}
-			}
-			// Check if connection was closed by another goroutine.
-			select {
+				if err := writeFrame(0x2, data); err != nil {
+					closeConn()
+					return
+				}
+				// Notify frontend of alt-screen state changes.
+				altScreen := sess.AltScreenActive()
+				if altScreen != prevAltScreen {
+					prevAltScreen = altScreen
+					ctrl, _ := json.Marshal(map[string]any{"type": "alt_screen", "active": altScreen})
+					_ = writeFrame(0x1, ctrl)
+				}
 			case <-connDone:
 				return
-			default:
 			}
 		}
-	})
+	}()
 
 	// Server-initiated ping keepalive — detects dead connections (browser crash,
 	// laptop sleep) without ever timing out idle users.
 	pingTicker := time.NewTicker(terminalPingInterval)
-	util.SafeGo(func() {
+	go func() { // lint:allow-bare-goroutine — bounded by connDone
 		defer pingTicker.Stop()
 		for {
 			select {
@@ -242,13 +269,14 @@ func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session) {
 				}
 			}
 		}
-	})
+	}()
 
 	// WebSocket -> PTY (upstream): read frames and dispatch.
+	// Uses relay.writeBuf for non-blocking writes with backpressure.
 	// NOTE: Do NOT call sess.Close() on WebSocket disconnect — the session
 	// must survive page refreshes so the browser can reconnect with scrollback replay.
 	// Sessions are only killed explicitly via POST /terminal/stop (the Exit button).
-	util.SafeGo(func() {
+	go func() { // lint:allow-bare-goroutine — bounded by connDone
 		defer closeConn() // Close conn on exit so downstream detects it and browser auto-reconnects
 		for {
 			// Refresh read deadline on every iteration — any received frame
@@ -277,17 +305,15 @@ func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session) {
 			case 0x9: // Ping -> Pong
 				_ = writeFrame(0xA, payload)
 			case 0xA: // Pong — no-op, deadline already refreshed above
-			case 0x2: // Binary — raw keystrokes -> PTY stdin
-				if _, err := sess.Write(payload); err != nil {
-					return
-				}
+			case 0x2: // Binary — raw keystrokes -> PTY stdin via write buffer
+				_, _ = relay.writeBuf.Write(payload)
 			case 0x1: // Text — JSON control message
 				handleTerminalControlMessage(payload, sess)
 			}
 		}
-	})
+	}()
 
-	<-ptyDone
+	<-downstreamDone
 }
 
 // newTerminalFrameWriter returns a thread-safe frame writer for one WebSocket
@@ -301,34 +327,9 @@ func newTerminalFrameWriter(rw *bufio.ReadWriter) func(opcode byte, payload []by
 	}
 }
 
-// waitForShellPrompt reads PTY output until a prompt character appears or
-// terminalInitTimeout expires. This is more robust than a fixed sleep because
-// shell startup time varies (e.g., .zshrc loading, slow NFS home dirs).
-// Output is appended to scrollback so reconnecting clients see it.
-func waitForShellPrompt(sess *pty.Session) {
-	deadline := time.NewTimer(terminalInitTimeout)
-	defer deadline.Stop()
-	buf := make([]byte, 256)
-	for {
-		select {
-		case <-deadline.C:
-			return // Timeout — write init_command anyway as a best-effort fallback.
-		default:
-		}
-		n, err := sess.Read(buf)
-		if err != nil {
-			return
-		}
-		if n > 0 {
-			sess.AppendScrollback(buf[:n])
-			for _, b := range buf[:n] {
-				if strings.ContainsRune(terminalPromptChars, rune(b)) {
-					return // Prompt detected — shell is ready.
-				}
-			}
-		}
-	}
-}
+// terminalIdleTimeout is the duration of silence after PTY output before
+// the idle callback fires. Used to detect when an agent is waiting for input.
+const terminalIdleTimeout = 30 * time.Second
 
 // terminalControlMessage is a JSON control message from the browser terminal.
 type terminalControlMessage struct {
@@ -356,7 +357,7 @@ func handleTerminalControlMessage(payload []byte, sess *pty.Session) {
 }
 
 // handleTerminalStart creates a new terminal session.
-func handleTerminalStart(w http.ResponseWriter, r *http.Request, server *Server, mgr *pty.Manager, cap *capture.Store) {
+func handleTerminalStart(w http.ResponseWriter, r *http.Request, server *Server, mgr *pty.Manager, cap *capture.Store, relays *terminalRelayMap) {
 	if r.Method != "POST" {
 		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
 		return
@@ -372,6 +373,8 @@ func handleTerminalStart(w http.ResponseWriter, r *http.Request, server *Server,
 		Cols        int      `json:"cols"`
 		Rows        int      `json:"rows"`
 		InitCommand string   `json:"init_command"`
+		RepoPath    string   `json:"repo_path"`
+		AgentType   string   `json:"agent_type"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
@@ -392,27 +395,31 @@ func handleTerminalStart(w http.ResponseWriter, r *http.Request, server *Server,
 	}
 
 	result, err := mgr.Start(pty.StartConfig{
-		ID:   req.ID,
-		Cmd:  req.Cmd,
-		Args: req.Args,
-		Dir:  req.Dir,
-		Cols: uint16(req.Cols),
-		Rows: uint16(req.Rows),
+		ID:        req.ID,
+		Cmd:       req.Cmd,
+		Args:      req.Args,
+		Dir:       req.Dir,
+		Cols:      uint16(req.Cols),
+		Rows:      uint16(req.Rows),
+		RepoPath:  req.RepoPath,
+		AgentType: req.AgentType,
 	})
-	// Write init_command to PTY stdin after shell prompt appears.
-	// Instead of a fixed 500ms sleep, read PTY output until a prompt character
-	// ('$', '#', '>', '%') appears or a 2s timeout expires.
-	if err == nil && req.InitCommand != "" {
-		go func(sessionID, initCmd string) { // lint:allow-bare-goroutine — one-shot init, bounded by timeout
-			sess, getErr := mgr.Get(sessionID)
-			if getErr != nil {
-				return
-			}
-			waitForShellPrompt(sess)
-			// Write the command followed by newline so the shell executes it.
-			cmd := initCmd + "\n"
-			_, _ = sess.Write([]byte(cmd))
-		}(result.SessionID, req.InitCommand)
+	// On success: create relay (fan-out + write buffer), configure idle detection,
+	// and handle init_command via the relay instead of reading PTY directly.
+	if err == nil {
+		sess, _ := mgr.Get(result.SessionID)
+		relay := relays.getOrCreate(result.SessionID, sess, req.Dir)
+		sess.SetIdleConfig(pty.IdleConfig{
+			Timeout: terminalIdleTimeout,
+			Callback: func(id string) {
+				stderrf("[gasoline] terminal session %s is idle\n", id)
+			},
+		})
+		if req.InitCommand != "" {
+			go func(r *terminalRelay, cmd string) { // lint:allow-bare-goroutine — one-shot init, bounded by timeout
+				waitForPromptViaRelay(r, cmd)
+			}(relay, req.InitCommand)
+		}
 	}
 	if err != nil {
 		// Detect macOS sandbox restriction (MCP stdio-spawned daemon can't fork).
@@ -487,7 +494,7 @@ func autoDetectCWD(cap *capture.Store) string {
 }
 
 // handleTerminalStop destroys a terminal session.
-func handleTerminalStop(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) {
+func handleTerminalStop(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, relays *terminalRelayMap) {
 	if r.Method != "POST" {
 		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
 		return
@@ -510,6 +517,7 @@ func handleTerminalStop(w http.ResponseWriter, r *http.Request, mgr *pty.Manager
 		jsonResponse(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
 	}
+	relays.remove(req.ID)
 
 	jsonResponse(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
@@ -523,11 +531,28 @@ func isSandboxError(err error) bool {
 		strings.Contains(msg, "not permitted")
 }
 
-// handleTerminalConfig returns or updates terminal configuration.
-func handleTerminalConfig(w http.ResponseWriter, r *http.Request, mgr *pty.Manager) {
+// handleTerminalConfig returns terminal session details including alt-screen state and subscriber counts.
+func handleTerminalConfig(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, relays *terminalRelayMap) {
 	switch r.Method {
 	case "GET":
-		sessions := mgr.List()
+		ids := mgr.List()
+		sessions := make([]map[string]any, 0, len(ids))
+		for _, id := range ids {
+			sess, err := mgr.Get(id)
+			if err != nil {
+				continue
+			}
+			info := map[string]any{
+				"id":         id,
+				"alive":      sess.IsAlive(),
+				"pid":        sess.Pid(),
+				"alt_screen": sess.AltScreenActive(),
+			}
+			if relay := relays.get(id); relay != nil {
+				info["subscribers"] = relay.fanout.Count()
+			}
+			sessions = append(sessions, info)
+		}
 		jsonResponse(w, http.StatusOK, map[string]any{
 			"sessions": sessions,
 			"count":    mgr.Count(),
@@ -555,6 +580,55 @@ func handleTerminalValidate(w http.ResponseWriter, r *http.Request, mgr *pty.Man
 		return
 	}
 	jsonResponse(w, http.StatusOK, map[string]bool{"valid": sess.IsAlive()})
+}
+
+// handleTerminalUpload handles image uploads for terminal sessions.
+// POST /terminal/upload?session_id=xxx&filename=screenshot.png
+// Content-Type must be an image type. Body is raw image data.
+func handleTerminalUpload(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, relays *terminalRelayMap) {
+	if r.Method != "POST" {
+		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
+
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		sessionID = "default"
+	}
+
+	// Verify session exists.
+	if _, err := mgr.Get(sessionID); err != nil {
+		jsonResponse(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+
+	relay := relays.get(sessionID)
+	workspaceDir := ""
+	if relay != nil {
+		workspaceDir = relay.workspaceDir
+	}
+	if workspaceDir == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "no workspace directory for session"})
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	filename := r.URL.Query().Get("filename")
+
+	result, err := pty.Upload(workspaceDir, sessionID, contentType, filename, r.Body)
+	if err != nil {
+		status := http.StatusBadRequest
+		if err == pty.ErrUploadTooLarge {
+			status = http.StatusRequestEntityTooLarge
+		}
+		jsonResponse(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, map[string]any{
+		"path": result.RelPath,
+		"size": result.Size,
+	})
 }
 
 // handleActiveCodebase gets or sets the active codebase path used as terminal CWD.

--- a/cmd/browser-agent/terminal_handlers.go
+++ b/cmd/browser-agent/terminal_handlers.go
@@ -171,30 +171,39 @@ func handleTerminalWS(w http.ResponseWriter, r *http.Request, mgr *pty.Manager, 
 
 	subID := nextWSSubID()
 	sub, subErr := relay.fanout.Subscribe(subID)
-	if subErr != nil {
-		_ = conn.Close()
-		return
-	}
 
-	// Replay scrollback so the reconnecting terminal sees prior output.
+	// Replay scrollback so the reconnecting (or first-connecting) terminal sees prior output.
 	if len(history) > 0 {
-		// Send in chunks to avoid oversized frames.
 		for off := 0; off < len(history); off += terminalReadBufSize {
 			end := off + terminalReadBufSize
 			if end > len(history) {
 				end = len(history)
 			}
 			if err := wsWriteFrame(bufrw, 0x2, history[off:end]); err != nil {
-				relay.fanout.Unsubscribe(subID)
+				if subErr == nil {
+					relay.fanout.Unsubscribe(subID)
+				}
 				_ = conn.Close()
 				return
 			}
 		}
 	}
-	// Send replay_end marker so the frontend distinguishes replay from live data.
 	replayEnd, _ := json.Marshal(map[string]string{"type": "replay_end"})
 	if err := wsWriteFrame(bufrw, 0x1, replayEnd); err != nil {
-		relay.fanout.Unsubscribe(subID)
+		if subErr == nil {
+			relay.fanout.Unsubscribe(subID)
+		}
+		_ = conn.Close()
+		return
+	}
+
+	// If subscribe failed (fanout already closed — process exited before reconnect),
+	// send the final scrollback, exit notification, and close. The browser receives
+	// the full output history plus the exited message and stops reconnecting.
+	if subErr != nil {
+		exitMsg, _ := json.Marshal(map[string]any{"type": "exited", "code": relay.exitCode})
+		_ = wsWriteFrame(bufrw, 0x1, exitMsg)
+		_ = wsWriteFrame(bufrw, 0x8, nil)
 		_ = conn.Close()
 		return
 	}
@@ -240,7 +249,10 @@ func terminalWSLoop(conn net.Conn, rw *bufio.ReadWriter, sess *pty.Session, rela
 			select {
 			case data, ok := <-sub:
 				if !ok {
-					// Fanout closed (session ended) — send close frame.
+					// Fanout closed (session ended) — send exit notification
+					// so the browser can display the message and stop reconnecting.
+					exitMsg, _ := json.Marshal(map[string]any{"type": "exited", "code": relay.exitCode})
+					_ = writeFrame(0x1, exitMsg)
 					_ = writeFrame(0x8, nil)
 					closeConn()
 					return

--- a/cmd/browser-agent/terminal_handlers_test.go
+++ b/cmd/browser-agent/terminal_handlers_test.go
@@ -244,6 +244,28 @@ func TestHandleTerminalConfig_ListsSessions(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected count 1, got %v", count)
 	}
+
+	// Validate the new rich session objects.
+	sessions, ok := resp["sessions"].([]any)
+	if !ok {
+		t.Fatalf("expected sessions array, got %T", resp["sessions"])
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	sess := sessions[0].(map[string]any)
+	if sess["id"] != "test" {
+		t.Fatalf("expected id 'test', got %v", sess["id"])
+	}
+	if sess["alive"] != true {
+		t.Fatalf("expected alive=true, got %v", sess["alive"])
+	}
+	if sess["pid"] == nil {
+		t.Fatal("expected pid in session info")
+	}
+	if _, hasAlt := sess["alt_screen"]; !hasAlt {
+		t.Fatal("expected alt_screen field in session info")
+	}
 }
 
 func TestHandleTerminalValidate_ValidToken(t *testing.T) {

--- a/cmd/browser-agent/terminal_handlers_test.go
+++ b/cmd/browser-agent/terminal_handlers_test.go
@@ -102,7 +102,8 @@ func TestHandleTerminalStart_CreatesSession(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
-	handleTerminalStart(rec, req, nil, mgr, nil)
+	relays := newTerminalRelayMap()
+	handleTerminalStart(rec, req, nil, mgr, nil, relays)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -132,10 +133,12 @@ func TestHandleTerminalStart_DuplicateReturnsConflict(t *testing.T) {
 		"args": []string{"-c", "exec cat"},
 	})
 
+	relays := newTerminalRelayMap()
+
 	// First start.
 	req := httptest.NewRequest("POST", "/terminal/start", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handleTerminalStart(rec, req, nil, mgr, nil)
+	handleTerminalStart(rec, req, nil, mgr, nil, relays)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("first start: expected 200, got %d", rec.Code)
 	}
@@ -143,7 +146,7 @@ func TestHandleTerminalStart_DuplicateReturnsConflict(t *testing.T) {
 	// Second start with same ID.
 	req = httptest.NewRequest("POST", "/terminal/start", bytes.NewReader(body))
 	rec = httptest.NewRecorder()
-	handleTerminalStart(rec, req, nil, mgr, nil)
+	handleTerminalStart(rec, req, nil, mgr, nil, relays)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("duplicate start: expected 409, got %d", rec.Code)
 	}
@@ -158,7 +161,8 @@ func TestHandleTerminalStart_DefaultsToShell(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
-	handleTerminalStart(rec, req, nil, mgr, nil)
+	relays := newTerminalRelayMap()
+	handleTerminalStart(rec, req, nil, mgr, nil, relays)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -174,15 +178,16 @@ func TestHandleTerminalStop_DestroysSession(t *testing.T) {
 		"cmd":  "/bin/sh",
 		"args": []string{"-c", "exec cat"},
 	})
+	relays := newTerminalRelayMap()
 	req := httptest.NewRequest("POST", "/terminal/start", bytes.NewReader(startBody))
 	rec := httptest.NewRecorder()
-	handleTerminalStart(rec, req, nil, mgr, nil)
+	handleTerminalStart(rec, req, nil, mgr, nil, relays)
 
 	// Stop it.
 	stopBody, _ := json.Marshal(map[string]any{"id": "default"})
 	req = httptest.NewRequest("POST", "/terminal/stop", bytes.NewReader(stopBody))
 	rec = httptest.NewRecorder()
-	handleTerminalStop(rec, req, mgr)
+	handleTerminalStop(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -200,7 +205,8 @@ func TestHandleTerminalStop_NotFound(t *testing.T) {
 	body, _ := json.Marshal(map[string]any{"id": "nonexistent"})
 	req := httptest.NewRequest("POST", "/terminal/stop", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handleTerminalStop(rec, req, mgr)
+	relays := newTerminalRelayMap()
+	handleTerminalStop(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
@@ -223,7 +229,8 @@ func TestHandleTerminalConfig_ListsSessions(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/terminal/config", nil)
 	rec := httptest.NewRecorder()
-	handleTerminalConfig(rec, req, mgr)
+	relays := newTerminalRelayMap()
+	handleTerminalConfig(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
@@ -342,7 +349,8 @@ func TestHandleTerminalWS_MissingToken(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/terminal/ws", nil)
 	rec := httptest.NewRecorder()
-	handleTerminalWS(rec, req, mgr)
+	relays := newTerminalRelayMap()
+	handleTerminalWS(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)
@@ -354,7 +362,8 @@ func TestHandleTerminalWS_InvalidToken(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/terminal/ws?token=bogus", nil)
 	rec := httptest.NewRecorder()
-	handleTerminalWS(rec, req, mgr)
+	relays := newTerminalRelayMap()
+	handleTerminalWS(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)
@@ -376,9 +385,87 @@ func TestHandleTerminalWS_NoUpgradeHeader(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/terminal/ws?token="+result.Token, nil)
 	rec := httptest.NewRecorder()
-	handleTerminalWS(rec, req, mgr)
+	relays := newTerminalRelayMap()
+	handleTerminalWS(rec, req, mgr, relays)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleTerminalUpload_Success(t *testing.T) {
+	mgr := pty.NewManager()
+	defer mgr.StopAll()
+
+	_, err := mgr.Start(pty.StartConfig{
+		ID:   "upload-test",
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sess, _ := mgr.Get("upload-test")
+	relays := newTerminalRelayMap()
+	relays.getOrCreate("upload-test", sess, t.TempDir())
+
+	imgData := bytes.Repeat([]byte{0xFF, 0xD8, 0xFF}, 10)
+	req := httptest.NewRequest("POST", "/terminal/upload?session_id=upload-test&filename=test.png", bytes.NewReader(imgData))
+	req.Header.Set("Content-Type", "image/png")
+	rec := httptest.NewRecorder()
+	handleTerminalUpload(rec, req, mgr, relays)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["path"] == nil || resp["path"] == "" {
+		t.Fatal("expected non-empty path in response")
+	}
+}
+
+func TestHandleTerminalUpload_InvalidContentType(t *testing.T) {
+	mgr := pty.NewManager()
+	defer mgr.StopAll()
+
+	_, err := mgr.Start(pty.StartConfig{
+		ID:   "upload-bad",
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sess, _ := mgr.Get("upload-bad")
+	relays := newTerminalRelayMap()
+	relays.getOrCreate("upload-bad", sess, t.TempDir())
+
+	req := httptest.NewRequest("POST", "/terminal/upload?session_id=upload-bad&filename=test.txt", bytes.NewReader([]byte("not an image")))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	handleTerminalUpload(rec, req, mgr, relays)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleTerminalUpload_SessionNotFound(t *testing.T) {
+	mgr := pty.NewManager()
+	relays := newTerminalRelayMap()
+
+	req := httptest.NewRequest("POST", "/terminal/upload?session_id=nonexistent", bytes.NewReader([]byte("data")))
+	req.Header.Set("Content-Type", "image/png")
+	rec := httptest.NewRecorder()
+	handleTerminalUpload(rec, req, mgr, relays)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
 	}
 }

--- a/cmd/browser-agent/terminal_relay.go
+++ b/cmd/browser-agent/terminal_relay.go
@@ -22,6 +22,7 @@ type terminalRelay struct {
 	writeBuf     *pty.WriteBuffer
 	workspaceDir string
 	done         chan struct{}
+	exitCode     int // set by readLoop before closing fanout; read by downstream after channel close
 }
 
 // newTerminalRelay creates a relay and starts the PTY reader loop.
@@ -39,6 +40,8 @@ func newTerminalRelay(sess *pty.Session, workspaceDir string) *terminalRelay {
 
 // readLoop continuously reads PTY output, appends to scrollback, and broadcasts
 // to all subscribers. Exits when the session closes or the process exits.
+// Before closing the fanout, it reaps the child process to capture the exit code
+// so downstream subscribers can notify the browser.
 func (r *terminalRelay) readLoop() {
 	defer close(r.done)
 	defer r.fanout.Close()
@@ -51,9 +54,22 @@ func (r *terminalRelay) readLoop() {
 			r.fanout.Broadcast(buf[:n])
 		}
 		if err != nil {
+			// Reap child process to capture exit code before fanout closes.
+			// The write to exitCode happens-before fanout.Close() (in defers),
+			// which closes subscriber channels, creating a happens-before edge
+			// to the downstream goroutine's read of exitCode.
+			r.reapExitCode()
 			return
 		}
 	}
+}
+
+// reapExitCode waits for the child process exit code. Called after PTY read
+// returns an error (typically EOF when the child exits), so the Session's
+// reaper goroutine has usually already captured the exit code.
+func (r *terminalRelay) reapExitCode() {
+	r.sess.Wait() // blocks until child exits — usually instant since PTY EOF already received
+	r.exitCode = r.sess.ExitCode()
 }
 
 // Close stops the write buffer. The readLoop exits when the session closes,

--- a/cmd/browser-agent/terminal_relay.go
+++ b/cmd/browser-agent/terminal_relay.go
@@ -1,0 +1,152 @@
+// terminal_relay.go — Per-session relay: fan-out PTY output, buffer writes, prompt detection.
+// Why: Supports multiple WebSocket viewers per session and non-blocking input.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/pty"
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/util"
+)
+
+// terminalRelay manages per-session fan-out, buffered writes, and a PTY reader loop.
+// The reader loop runs from relay creation until the session closes.
+type terminalRelay struct {
+	sess         *pty.Session
+	fanout       *pty.Fanout
+	writeBuf     *pty.WriteBuffer
+	workspaceDir string
+	done         chan struct{}
+}
+
+// newTerminalRelay creates a relay and starts the PTY reader loop.
+func newTerminalRelay(sess *pty.Session, workspaceDir string) *terminalRelay {
+	r := &terminalRelay{
+		sess:         sess,
+		fanout:       pty.NewFanout(),
+		writeBuf:     pty.NewWriteBuffer(sess),
+		workspaceDir: workspaceDir,
+		done:         make(chan struct{}),
+	}
+	util.SafeGo(r.readLoop)
+	return r
+}
+
+// readLoop continuously reads PTY output, appends to scrollback, and broadcasts
+// to all subscribers. Exits when the session closes or the process exits.
+func (r *terminalRelay) readLoop() {
+	defer close(r.done)
+	defer r.fanout.Close()
+	defer r.writeBuf.Close()
+	buf := make([]byte, terminalReadBufSize)
+	for {
+		n, err := r.sess.Read(buf)
+		if n > 0 {
+			r.sess.AppendScrollback(buf[:n])
+			r.fanout.Broadcast(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Close stops the write buffer. The readLoop exits when the session closes,
+// which triggers fanout and writeBuf cleanup via defers.
+func (r *terminalRelay) Close() {
+	r.writeBuf.Close()
+}
+
+// terminalRelayMap manages per-session relays.
+type terminalRelayMap struct {
+	mu     sync.Mutex
+	relays map[string]*terminalRelay
+}
+
+func newTerminalRelayMap() *terminalRelayMap {
+	return &terminalRelayMap{relays: make(map[string]*terminalRelay)}
+}
+
+func (m *terminalRelayMap) get(id string) *terminalRelay {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.relays[id]
+}
+
+func (m *terminalRelayMap) getOrCreate(id string, sess *pty.Session, workspaceDir string) *terminalRelay {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r := m.relays[id]; r != nil {
+		return r
+	}
+	r := newTerminalRelay(sess, workspaceDir)
+	m.relays[id] = r
+	return r
+}
+
+func (m *terminalRelayMap) remove(id string) {
+	m.mu.Lock() // lint:manual-unlock — unlock before Close to avoid holding lock during I/O
+	r := m.relays[id]
+	delete(m.relays, id)
+	m.mu.Unlock()
+	if r != nil {
+		r.Close()
+	}
+}
+
+func (m *terminalRelayMap) closeAll() {
+	m.mu.Lock() // lint:manual-unlock — unlock before Close to avoid holding lock during I/O
+	toClose := make([]*terminalRelay, 0, len(m.relays))
+	for _, r := range m.relays {
+		toClose = append(toClose, r)
+	}
+	m.relays = make(map[string]*terminalRelay)
+	m.mu.Unlock()
+	for _, r := range toClose {
+		r.Close()
+	}
+}
+
+// wsSubCounter generates unique subscriber IDs for WebSocket connections.
+var wsSubCounter atomic.Uint64
+
+func nextWSSubID() string {
+	return fmt.Sprintf("ws-%d", wsSubCounter.Add(1))
+}
+
+// waitForPromptViaRelay subscribes to the relay's fan-out, watches for a
+// shell prompt character, then writes the init command. Replaces the old
+// direct-PTY-read approach so the relay's readLoop owns all PTY reads.
+func waitForPromptViaRelay(relay *terminalRelay, initCmd string) {
+	subID := "init-cmd"
+	ch, err := relay.fanout.Subscribe(subID)
+	if err != nil {
+		_, _ = relay.writeBuf.Write([]byte(initCmd + "\n"))
+		return
+	}
+	defer relay.fanout.Unsubscribe(subID)
+
+	deadline := time.After(terminalInitTimeout)
+	for {
+		select {
+		case <-deadline:
+			_, _ = relay.writeBuf.Write([]byte(initCmd + "\n"))
+			return
+		case data, ok := <-ch:
+			if !ok {
+				return
+			}
+			for _, b := range data {
+				if strings.ContainsRune(terminalPromptChars, rune(b)) {
+					_, _ = relay.writeBuf.Write([]byte(initCmd + "\n"))
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/pty/fanout.go
+++ b/internal/pty/fanout.go
@@ -1,0 +1,108 @@
+// fanout.go — Multi-subscriber fan-out for PTY output.
+// Why: Allows multiple WebSocket connections to watch the same terminal session.
+
+package pty
+
+import (
+	"errors"
+	"sync"
+)
+
+// maxSubscribers is the default maximum number of concurrent subscribers.
+const maxSubscribers = 32
+
+// subscriberBufSize is the channel buffer size per subscriber.
+const subscriberBufSize = 64
+
+// ErrFanoutFull is returned when the maximum subscriber count is reached.
+var ErrFanoutFull = errors.New("pty: subscriber limit reached")
+
+// ErrFanoutClosed is returned when operating on a closed fanout.
+var ErrFanoutClosed = errors.New("pty: fanout closed")
+
+// Fanout broadcasts data to multiple subscribers. Slow subscribers are dropped
+// rather than blocking the producer.
+type Fanout struct {
+	mu          sync.Mutex
+	subscribers map[string]chan []byte
+	maxSubs     int
+	closed      bool
+}
+
+// NewFanout creates a new fan-out broadcaster.
+func NewFanout() *Fanout {
+	return &Fanout{
+		subscribers: make(map[string]chan []byte),
+		maxSubs:     maxSubscribers,
+	}
+}
+
+// Subscribe adds a subscriber and returns a channel for receiving data.
+func (f *Fanout) Subscribe(id string) (<-chan []byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return nil, ErrFanoutClosed
+	}
+	if len(f.subscribers) >= f.maxSubs {
+		return nil, ErrFanoutFull
+	}
+	ch := make(chan []byte, subscriberBufSize)
+	f.subscribers[id] = ch
+	return ch, nil
+}
+
+// Unsubscribe removes a subscriber and closes its channel.
+func (f *Fanout) Unsubscribe(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if ch, ok := f.subscribers[id]; ok {
+		close(ch)
+		delete(f.subscribers, id)
+	}
+}
+
+// Broadcast sends data to all subscribers. Slow subscribers whose channel
+// buffer is full are dropped to prevent blocking the producer.
+func (f *Fanout) Broadcast(data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return
+	}
+	msg := make([]byte, len(data))
+	copy(msg, data)
+	var dropped []string
+	for id, ch := range f.subscribers {
+		select {
+		case ch <- msg:
+		default:
+			close(ch)
+			dropped = append(dropped, id)
+		}
+	}
+	for _, id := range dropped {
+		delete(f.subscribers, id)
+	}
+}
+
+// Count returns the number of active subscribers.
+func (f *Fanout) Count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.subscribers)
+}
+
+// Close closes all subscriber channels and prevents new subscriptions.
+func (f *Fanout) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return
+	}
+	f.closed = true
+	for id, ch := range f.subscribers {
+		close(ch)
+		delete(f.subscribers, id)
+	}
+}

--- a/internal/pty/fanout_test.go
+++ b/internal/pty/fanout_test.go
@@ -1,0 +1,192 @@
+// fanout_test.go — Tests for multi-subscriber fan-out.
+
+package pty
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFanout_SubscribeAndBroadcast(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	ch1, err := f.Subscribe("sub-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ch2, err := f.Subscribe("sub-2")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	f.Broadcast([]byte("hello"))
+
+	for _, tc := range []struct {
+		name string
+		ch   <-chan []byte
+	}{{"sub-1", ch1}, {"sub-2", ch2}} {
+		select {
+		case msg := <-tc.ch:
+			if string(msg) != "hello" {
+				t.Fatalf("%s: expected %q, got %q", tc.name, "hello", string(msg))
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout on %s", tc.name)
+		}
+	}
+}
+
+func TestFanout_Unsubscribe(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	ch, err := f.Subscribe("sub-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	f.Unsubscribe("sub-1")
+
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+	if f.Count() != 0 {
+		t.Fatalf("expected 0 subscribers, got %d", f.Count())
+	}
+}
+
+func TestFanout_SlowSubscriberDropped(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	ch, err := f.Subscribe("slow")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	// Fill the subscriber's channel buffer.
+	for i := 0; i < subscriberBufSize; i++ {
+		f.Broadcast([]byte("msg"))
+	}
+
+	// Next broadcast should drop the slow subscriber.
+	f.Broadcast([]byte("overflow"))
+
+	if f.Count() != 0 {
+		t.Fatalf("expected slow subscriber to be dropped, got count=%d", f.Count())
+	}
+
+	// Drain and verify channel is closed.
+	for range ch {
+	}
+}
+
+func TestFanout_Close(t *testing.T) {
+	f := NewFanout()
+	ch, err := f.Subscribe("sub-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	f.Close()
+
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after fanout close")
+	}
+
+	_, err = f.Subscribe("sub-2")
+	if err != ErrFanoutClosed {
+		t.Fatalf("expected ErrFanoutClosed, got: %v", err)
+	}
+}
+
+func TestFanout_MaxSubscribers(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	for i := 0; i < maxSubscribers; i++ {
+		_, err := f.Subscribe(fmt.Sprintf("sub-%d", i))
+		if err != nil {
+			t.Fatalf("subscribe %d: %v", i, err)
+		}
+	}
+
+	_, err := f.Subscribe("overflow")
+	if err != ErrFanoutFull {
+		t.Fatalf("expected ErrFanoutFull, got: %v", err)
+	}
+}
+
+func TestFanout_ConcurrentBroadcast(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	ch, err := f.Subscribe("sub-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const broadcasts = 100
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < broadcasts; i++ {
+			f.Broadcast([]byte("data"))
+		}
+	}()
+
+	received := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range ch {
+			received++
+		}
+	}()
+
+	wg.Wait()
+	f.Close()
+	<-done
+
+	if received == 0 {
+		t.Fatal("expected to receive at least some messages")
+	}
+}
+
+func TestFanout_DoubleClose(t *testing.T) {
+	f := NewFanout()
+	f.Close()
+	f.Close() // should not panic
+}
+
+func TestFanout_UnsubscribeNonexistent(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+	f.Unsubscribe("nonexistent") // should not panic
+}
+
+func TestFanout_BroadcastDataIsolation(t *testing.T) {
+	f := NewFanout()
+	defer f.Close()
+
+	ch, err := f.Subscribe("sub-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	original := []byte("hello")
+	f.Broadcast(original)
+
+	// Mutate original — subscriber's copy should be unaffected.
+	original[0] = 'X'
+
+	msg := <-ch
+	if string(msg) != "hello" {
+		t.Fatalf("expected %q, got %q (data not isolated)", "hello", string(msg))
+	}
+}

--- a/internal/pty/manager.go
+++ b/internal/pty/manager.go
@@ -12,30 +12,41 @@ import (
 	"sync"
 )
 
+// SessionKey identifies a session by repository path and agent type,
+// allowing multiple providers (e.g., Claude and Codex) to coexist for the same repo.
+type SessionKey struct {
+	RepoPath  string
+	AgentType string
+}
+
 // Manager manages PTY sessions with token-based authentication.
 type Manager struct {
-	mu       sync.RWMutex
-	sessions map[string]*Session // keyed by session ID
-	tokens   map[string]string   // token → session ID
+	mu        sync.RWMutex
+	sessions  map[string]*Session    // keyed by session ID
+	tokens    map[string]string      // token → session ID
+	repoIndex map[SessionKey]string  // (repo, agent) → session ID
 }
 
 // NewManager creates a new session manager.
 func NewManager() *Manager {
 	return &Manager{
-		sessions: make(map[string]*Session),
-		tokens:   make(map[string]string),
+		sessions:  make(map[string]*Session),
+		tokens:    make(map[string]string),
+		repoIndex: make(map[SessionKey]string),
 	}
 }
 
 // StartConfig is the configuration for starting a new terminal session.
 type StartConfig struct {
-	ID   string   // Session ID (default: "default").
-	Cmd  string   // CLI binary.
-	Args []string // CLI arguments.
-	Dir  string   // Working directory.
-	Env  []string // Extra environment variables.
-	Cols uint16   // Terminal columns.
-	Rows uint16   // Terminal rows.
+	ID        string   // Session ID (default: "default").
+	Cmd       string   // CLI binary.
+	Args      []string // CLI arguments.
+	Dir       string   // Working directory.
+	Env       []string // Extra environment variables.
+	Cols      uint16   // Terminal columns.
+	Rows      uint16   // Terminal rows.
+	RepoPath  string   // Repository path (for repo+agent indexing).
+	AgentType string   // Agent type (e.g., "claude", "codex").
 }
 
 // StartResult is returned after successfully starting a session.
@@ -88,6 +99,10 @@ func (m *Manager) Start(cfg StartConfig) (*StartResult, error) {
 
 	m.sessions[cfg.ID] = sess
 	m.tokens[token] = cfg.ID
+	if cfg.RepoPath != "" {
+		key := SessionKey{RepoPath: cfg.RepoPath, AgentType: cfg.AgentType}
+		m.repoIndex[key] = cfg.ID
+	}
 
 	return &StartResult{
 		SessionID: cfg.ID,
@@ -154,6 +169,13 @@ func (m *Manager) Stop(id string) error {
 			break
 		}
 	}
+	// Remove repo-agent mapping.
+	for key, sid := range m.repoIndex {
+		if sid == id {
+			delete(m.repoIndex, key)
+			break
+		}
+	}
 	delete(m.sessions, id)
 	m.mu.Unlock()
 
@@ -171,6 +193,7 @@ func (m *Manager) StopAll() {
 	}
 	m.sessions = make(map[string]*Session)
 	m.tokens = make(map[string]string)
+	m.repoIndex = make(map[SessionKey]string)
 	m.mu.Unlock()
 
 	for _, sess := range toClose {
@@ -195,6 +218,22 @@ func (m *Manager) Count() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return len(m.sessions)
+}
+
+// GetByRepoAgent returns the session for a given repo path and agent type.
+func (m *Manager) GetByRepoAgent(repoPath, agentType string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	key := SessionKey{RepoPath: repoPath, AgentType: agentType}
+	sid, ok := m.repoIndex[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: repo=%s agent=%s", ErrSessionNotFound, repoPath, agentType)
+	}
+	sess, ok := m.sessions[sid]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrSessionNotFound, sid)
+	}
+	return sess, nil
 }
 
 // generateToken creates a cryptographically random 32-byte hex token.

--- a/internal/pty/manager_test.go
+++ b/internal/pty/manager_test.go
@@ -197,3 +197,122 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// --- Session-per-repo-per-agent (improvement 7) ---
+
+func TestManager_GetByRepoAgent(t *testing.T) {
+	m := NewManager()
+	defer m.StopAll()
+
+	_, err := m.Start(StartConfig{
+		ID:        "claude-myrepo",
+		Cmd:       "/bin/sh",
+		Args:      []string{"-c", "exec cat"},
+		RepoPath:  "/home/user/myrepo",
+		AgentType: "claude",
+	})
+	if err != nil {
+		t.Fatalf("start claude: %v", err)
+	}
+
+	_, err = m.Start(StartConfig{
+		ID:        "codex-myrepo",
+		Cmd:       "/bin/sh",
+		Args:      []string{"-c", "exec cat"},
+		RepoPath:  "/home/user/myrepo",
+		AgentType: "codex",
+	})
+	if err != nil {
+		t.Fatalf("start codex: %v", err)
+	}
+
+	// Get Claude session for myrepo.
+	sess, err := m.GetByRepoAgent("/home/user/myrepo", "claude")
+	if err != nil {
+		t.Fatalf("get claude: %v", err)
+	}
+	if sess.ID != "claude-myrepo" {
+		t.Fatalf("expected claude-myrepo, got %s", sess.ID)
+	}
+
+	// Get Codex session for myrepo.
+	sess, err = m.GetByRepoAgent("/home/user/myrepo", "codex")
+	if err != nil {
+		t.Fatalf("get codex: %v", err)
+	}
+	if sess.ID != "codex-myrepo" {
+		t.Fatalf("expected codex-myrepo, got %s", sess.ID)
+	}
+
+	// Nonexistent combination.
+	_, err = m.GetByRepoAgent("/home/user/other", "claude")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound, got: %v", err)
+	}
+}
+
+func TestManager_RepoIndex_CleanedOnStop(t *testing.T) {
+	m := NewManager()
+	defer m.StopAll()
+
+	_, err := m.Start(StartConfig{
+		ID:        "test-sess",
+		Cmd:       "/bin/sh",
+		Args:      []string{"-c", "exec cat"},
+		RepoPath:  "/repo",
+		AgentType: "claude",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if err := m.Stop("test-sess"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	_, err = m.GetByRepoAgent("/repo", "claude")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound after stop, got: %v", err)
+	}
+}
+
+func TestManager_RepoIndex_CleanedOnStopAll(t *testing.T) {
+	m := NewManager()
+
+	_, err := m.Start(StartConfig{
+		ID:        "test-sess",
+		Cmd:       "/bin/sh",
+		Args:      []string{"-c", "exec cat"},
+		RepoPath:  "/repo",
+		AgentType: "claude",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	m.StopAll()
+
+	_, err = m.GetByRepoAgent("/repo", "claude")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound after StopAll, got: %v", err)
+	}
+}
+
+func TestManager_NoRepoIndex_WithoutRepoPath(t *testing.T) {
+	m := NewManager()
+	defer m.StopAll()
+
+	_, err := m.Start(StartConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Without RepoPath, GetByRepoAgent should not find it.
+	_, err = m.GetByRepoAgent("", "")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("expected ErrSessionNotFound, got: %v", err)
+	}
+}

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -7,6 +7,7 @@
 package pty
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -20,6 +21,26 @@ import (
 // maxScrollback is the maximum size of the terminal output scrollback buffer (256 KB).
 const maxScrollback = 256 * 1024
 
+// Alt-screen escape sequences (e.g., vim, htop).
+var (
+	altScreenEnter = []byte("\x1b[?1049h")
+	altScreenExit  = []byte("\x1b[?1049l")
+)
+
+// ScrollbackSentinel is appended after replaying scrollback to distinguish
+// historical data from live output. Frontends use this as a visual separator.
+const ScrollbackSentinel = "\x1b]133;REPLAY_END\x07"
+
+// defaultInputIDMax is the default capacity for the input dedup deque.
+const defaultInputIDMax = 256
+
+// IdleConfig configures idle detection for a session. The callback fires when
+// the session produces output and then goes quiet for the specified duration.
+type IdleConfig struct {
+	Timeout  time.Duration
+	Callback func(sessionID string)
+}
+
 // Session wraps a PTY master + child process for interactive terminal I/O.
 type Session struct {
 	ID         string
@@ -29,7 +50,21 @@ type Session struct {
 	closed     bool
 	done       chan struct{} // closed before ptmx.Close to signal in-flight I/O
 	scrollback []byte        // ring buffer of recent PTY output for reconnect replay
-	scrollMu   sync.Mutex    // protects scrollback
+	scrollMu   sync.Mutex    // protects scrollback, altScreen, idle, lastOutputAt
+
+	// Alt-screen tracking (protected by scrollMu).
+	altScreen    bool
+	lastOutputAt time.Time
+
+	// Idle detection (protected by scrollMu).
+	idleTimeout time.Duration
+	idleCb      func(string)
+	idleTimer   *time.Timer
+
+	// Input tracking (protected by mu).
+	lastInputAt time.Time
+	inputIDs    []string
+	inputIDMax  int
 }
 
 // winsize matches the C struct winsize for TIOCSWINSZ.
@@ -115,10 +150,11 @@ func Spawn(cfg SpawnConfig) (*Session, error) {
 	slave.Close()
 
 	return &Session{
-		ID:   cfg.ID,
-		ptmx: ptmx,
-		cmd:  cmd,
-		done: make(chan struct{}),
+		ID:         cfg.ID,
+		ptmx:       ptmx,
+		cmd:        cmd,
+		done:       make(chan struct{}),
+		inputIDMax: defaultInputIDMax,
 	}, nil
 }
 
@@ -156,6 +192,7 @@ func (s *Session) Write(data []byte) (int, error) {
 		s.mu.Unlock()
 		return 0, ErrSessionClosed
 	}
+	s.lastInputAt = time.Now()
 	ptmx := s.ptmx
 	s.mu.Unlock()
 
@@ -202,6 +239,14 @@ func (s *Session) Close() error {
 	// of a raw OS error from a potentially recycled fd number.
 	close(s.done)
 
+	// Stop idle timer if running. Lock ordering: mu (held) → scrollMu (safe).
+	s.scrollMu.Lock()
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+		s.idleTimer = nil
+	}
+	s.scrollMu.Unlock()
+
 	// Signal the child to terminate.
 	if s.cmd.Process != nil {
 		_ = s.cmd.Process.Signal(syscall.SIGTERM)
@@ -236,9 +281,35 @@ func (s *Session) Wait() error {
 }
 
 // AppendScrollback appends data to the scrollback buffer, evicting oldest bytes
-// if the buffer exceeds maxScrollback.
+// if the buffer exceeds maxScrollback. Also tracks alt-screen state and resets
+// the idle timer.
 func (s *Session) AppendScrollback(data []byte) {
 	s.scrollMu.Lock() // lint:manual-unlock — simple lock/unlock in same function
+
+	// Track alt-screen state — last sequence in the chunk wins.
+	if enterIdx := bytes.LastIndex(data, altScreenEnter); enterIdx >= 0 {
+		if exitIdx := bytes.LastIndex(data, altScreenExit); exitIdx > enterIdx {
+			s.altScreen = false
+		} else {
+			s.altScreen = true
+		}
+	} else if bytes.Contains(data, altScreenExit) {
+		s.altScreen = false
+	}
+
+	// Track output time and reset idle timer.
+	s.lastOutputAt = time.Now()
+	if s.idleCb != nil && s.idleTimeout > 0 {
+		if s.idleTimer != nil {
+			s.idleTimer.Reset(s.idleTimeout)
+		} else {
+			id := s.ID
+			cb := s.idleCb
+			timeout := s.idleTimeout
+			s.idleTimer = time.AfterFunc(timeout, func() { cb(id) })
+		}
+	}
+
 	s.scrollback = append(s.scrollback, data...)
 	if len(s.scrollback) > maxScrollback {
 		// Allocate a new slice to release the old backing array.
@@ -295,4 +366,93 @@ func (s *Session) ForceRedraw() {
 	proc := s.cmd.Process
 	s.mu.Unlock()
 	_ = proc.Signal(syscall.SIGWINCH)
+}
+
+// AltScreenActive returns true if the terminal is in alt-screen mode
+// (e.g., vim, htop). The frontend uses this to toggle scrollbar visibility
+// and copy-paste behavior.
+func (s *Session) AltScreenActive() bool {
+	s.scrollMu.Lock()
+	defer s.scrollMu.Unlock()
+	return s.altScreen
+}
+
+// SetIdleConfig configures idle detection. The callback fires when no output
+// is produced for the given timeout duration after the most recent output.
+// Pass zero Timeout to disable.
+func (s *Session) SetIdleConfig(cfg IdleConfig) {
+	s.scrollMu.Lock()
+	defer s.scrollMu.Unlock()
+	if s.idleTimer != nil {
+		s.idleTimer.Stop()
+		s.idleTimer = nil
+	}
+	s.idleTimeout = cfg.Timeout
+	s.idleCb = cfg.Callback
+}
+
+// LastOutputAt returns the last time PTY output was received.
+func (s *Session) LastOutputAt() time.Time {
+	s.scrollMu.Lock()
+	defer s.scrollMu.Unlock()
+	return s.lastOutputAt
+}
+
+// LastInputAt returns the last time input was written to the session.
+func (s *Session) LastInputAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastInputAt
+}
+
+// ScrollbackWithSentinel returns the scrollback buffer followed by a sentinel
+// marker. Subscribers use the sentinel to distinguish replayed history from
+// live data on reconnect.
+func (s *Session) ScrollbackWithSentinel() []byte {
+	s.scrollMu.Lock()
+	defer s.scrollMu.Unlock()
+	if len(s.scrollback) == 0 {
+		return []byte(ScrollbackSentinel)
+	}
+	out := make([]byte, len(s.scrollback)+len(ScrollbackSentinel))
+	copy(out, s.scrollback)
+	copy(out[len(s.scrollback):], ScrollbackSentinel)
+	return out
+}
+
+// WriteWithID writes to the PTY with input deduplication. If the inputID has
+// been seen recently, the write is silently dropped (returns 0, nil). This
+// prevents duplicate keystrokes on WebSocket reconnect/retry.
+func (s *Session) WriteWithID(data []byte, inputID string) (int, error) {
+	if inputID == "" {
+		return s.Write(data)
+	}
+	s.mu.Lock() // lint:manual-unlock — unlock before blocking I/O
+	if s.closed {
+		s.mu.Unlock()
+		return 0, ErrSessionClosed
+	}
+	for _, id := range s.inputIDs {
+		if id == inputID {
+			s.mu.Unlock()
+			return 0, nil
+		}
+	}
+	s.inputIDs = append(s.inputIDs, inputID)
+	if len(s.inputIDs) > s.inputIDMax {
+		s.inputIDs = s.inputIDs[1:]
+	}
+	s.lastInputAt = time.Now()
+	ptmx := s.ptmx
+	s.mu.Unlock()
+
+	n, err := ptmx.Write(data)
+	if err != nil {
+		select {
+		case <-s.done:
+			return 0, ErrSessionClosed
+		default:
+		}
+	}
+	return n, err
 }

--- a/internal/pty/session.go
+++ b/internal/pty/session.go
@@ -65,6 +65,10 @@ type Session struct {
 	lastInputAt time.Time
 	inputIDs    []string
 	inputIDMax  int
+
+	// Child process reaping (set by reaper goroutine started in Spawn).
+	reaped   chan struct{} // closed when child process has been reaped
+	exitCode int          // set before reaped is closed
 }
 
 // winsize matches the C struct winsize for TIOCSWINSZ.
@@ -149,13 +153,22 @@ func Spawn(cfg SpawnConfig) (*Session, error) {
 	// Slave fd is now owned by the child process; close our copy.
 	slave.Close()
 
-	return &Session{
+	s := &Session{
 		ID:         cfg.ID,
 		ptmx:       ptmx,
 		cmd:        cmd,
 		done:       make(chan struct{}),
 		inputIDMax: defaultInputIDMax,
-	}, nil
+		reaped:     make(chan struct{}),
+	}
+	go func() { // lint:allow-bare-goroutine — sole reaper for child process, exits when child exits
+		_ = cmd.Wait()
+		if cmd.ProcessState != nil {
+			s.exitCode = cmd.ProcessState.ExitCode()
+		}
+		close(s.reaped)
+	}()
+	return s, nil
 }
 
 // Read reads from the PTY master (child's stdout/stderr).
@@ -254,30 +267,26 @@ func (s *Session) Close() error {
 	// Close PTY master — this also signals EOF to the child.
 	err := s.ptmx.Close()
 
-	// Reap the child process with a timeout. If SIGTERM + PTY close aren't
-	// enough, escalate to SIGKILL. Without this timeout, cmd.Wait() blocks
-	// indefinitely and deadlocks the Manager (which holds its write lock).
-	done := make(chan struct{})
-	go func() { // lint:allow-bare-goroutine — one-shot reaper, closes done channel
-		_ = s.cmd.Wait()
-		close(done)
-	}()
+	// Wait for the reaper goroutine (started in Spawn) with a timeout. If
+	// SIGTERM + PTY close aren't enough, escalate to SIGKILL. Without this
+	// timeout the reaper blocks indefinitely and deadlocks the Manager.
 	select {
-	case <-done:
+	case <-s.reaped:
 		// Child exited cleanly.
 	case <-time.After(2 * time.Second):
 		// Escalate to SIGKILL.
 		if s.cmd.Process != nil {
 			_ = s.cmd.Process.Kill()
 		}
-		<-done // Wait for reap after SIGKILL.
+		<-s.reaped // Wait for reap after SIGKILL.
 	}
 	return err
 }
 
-// Wait waits for the child process to exit and returns its error (nil on clean exit).
+// Wait blocks until the child process exits.
 func (s *Session) Wait() error {
-	return s.cmd.Wait()
+	<-s.reaped
+	return nil
 }
 
 // AppendScrollback appends data to the scrollback buffer, evicting oldest bytes
@@ -418,6 +427,17 @@ func (s *Session) ScrollbackWithSentinel() []byte {
 	copy(out, s.scrollback)
 	copy(out[len(s.scrollback):], ScrollbackSentinel)
 	return out
+}
+
+// ExitCode returns the child process exit code, or -1 if the process hasn't
+// been reaped yet. Non-blocking — returns immediately.
+func (s *Session) ExitCode() int {
+	select {
+	case <-s.reaped:
+		return s.exitCode
+	default:
+		return -1
+	}
 }
 
 // WriteWithID writes to the PTY with input deduplication. If the inputID has

--- a/internal/pty/session_test.go
+++ b/internal/pty/session_test.go
@@ -3,6 +3,7 @@
 package pty
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -403,5 +404,318 @@ func TestSession_ConcurrentReadWriteClose(t *testing.T) {
 		// All goroutines exited.
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout: concurrent Read/Write goroutines did not exit after Close")
+	}
+}
+
+// --- Alt-screen detection (improvement 4) ---
+
+func TestSession_AltScreenDetection(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	if sess.AltScreenActive() {
+		t.Fatal("expected alt-screen inactive initially")
+	}
+
+	sess.AppendScrollback([]byte("some output\x1b[?1049h"))
+	if !sess.AltScreenActive() {
+		t.Fatal("expected alt-screen active after enter sequence")
+	}
+
+	sess.AppendScrollback([]byte("\x1b[?1049l"))
+	if sess.AltScreenActive() {
+		t.Fatal("expected alt-screen inactive after exit sequence")
+	}
+}
+
+func TestSession_AltScreen_LastSequenceWins(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	// Both sequences in one chunk — exit is last.
+	sess.AppendScrollback([]byte("\x1b[?1049h some data \x1b[?1049l"))
+	if sess.AltScreenActive() {
+		t.Fatal("expected alt-screen inactive when exit is last")
+	}
+
+	// Enter is last.
+	sess.AppendScrollback([]byte("\x1b[?1049l some data \x1b[?1049h"))
+	if !sess.AltScreenActive() {
+		t.Fatal("expected alt-screen active when enter is last")
+	}
+}
+
+// --- Idle detection (improvement 5) ---
+
+func TestSession_IdleDetection(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	idleCh := make(chan string, 1)
+	sess.SetIdleConfig(IdleConfig{
+		Timeout:  50 * time.Millisecond,
+		Callback: func(id string) { idleCh <- id },
+	})
+
+	// Produce output to start the idle timer.
+	sess.AppendScrollback([]byte("output"))
+
+	select {
+	case id := <-idleCh:
+		if id != sess.ID {
+			t.Fatalf("expected session ID %q, got %q", sess.ID, id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for idle callback")
+	}
+}
+
+func TestSession_IdleDetection_ResetOnOutput(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	callCount := 0
+	var countMu sync.Mutex
+	sess.SetIdleConfig(IdleConfig{
+		Timeout: 100 * time.Millisecond,
+		Callback: func(id string) {
+			countMu.Lock()
+			callCount++
+			countMu.Unlock()
+		},
+	})
+
+	// Keep producing output faster than the timeout.
+	for i := 0; i < 5; i++ {
+		sess.AppendScrollback([]byte("data"))
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	countMu.Lock()
+	c := callCount
+	countMu.Unlock()
+	if c != 0 {
+		t.Fatalf("expected 0 idle callbacks during active output, got %d", c)
+	}
+}
+
+func TestSession_IdleDetection_DisabledByZeroTimeout(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	called := false
+	sess.SetIdleConfig(IdleConfig{
+		Timeout:  50 * time.Millisecond,
+		Callback: func(id string) { called = true },
+	})
+	// Disable by setting zero timeout.
+	sess.SetIdleConfig(IdleConfig{})
+
+	sess.AppendScrollback([]byte("data"))
+	time.Sleep(100 * time.Millisecond)
+
+	if called {
+		t.Fatal("idle callback should not fire after disabling")
+	}
+}
+
+// --- Scrollback replay sentinel (improvement 3) ---
+
+func TestSession_ScrollbackWithSentinel(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	sess.AppendScrollback([]byte("previous output"))
+	result := sess.ScrollbackWithSentinel()
+	expected := "previous output" + ScrollbackSentinel
+	if string(result) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestSession_ScrollbackWithSentinel_Empty(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	result := sess.ScrollbackWithSentinel()
+	if string(result) != ScrollbackSentinel {
+		t.Fatalf("expected sentinel only, got %q", string(result))
+	}
+}
+
+// --- Input deduplication (improvement 6) ---
+
+func TestSession_WriteWithID_Dedup(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	n, err := sess.WriteWithID([]byte("hello\n"), "msg-1")
+	if err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected non-zero bytes written")
+	}
+
+	// Duplicate should be silently dropped.
+	n, err = sess.WriteWithID([]byte("hello\n"), "msg-1")
+	if err != nil {
+		t.Fatalf("dup write: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 bytes for duplicate, got %d", n)
+	}
+
+	// Different ID should succeed.
+	n, err = sess.WriteWithID([]byte("world\n"), "msg-2")
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected non-zero bytes for new ID")
+	}
+}
+
+func TestSession_WriteWithID_EmptyID(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	n, err := sess.WriteWithID([]byte("x"), "")
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 byte, got %d", n)
+	}
+}
+
+func TestSession_WriteWithID_BoundedDeque(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	for i := 0; i < defaultInputIDMax+10; i++ {
+		_, err := sess.WriteWithID([]byte("x"), fmt.Sprintf("id-%d", i))
+		if err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Oldest IDs should have been evicted and can be reused.
+	n, err := sess.WriteWithID([]byte("x"), "id-0")
+	if err != nil {
+		t.Fatalf("reuse write: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected evicted ID to be accepted again")
+	}
+}
+
+// --- Timestamp tracking ---
+
+func TestSession_LastOutputAt(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	if !sess.LastOutputAt().IsZero() {
+		t.Fatal("expected zero LastOutputAt initially")
+	}
+
+	before := time.Now()
+	sess.AppendScrollback([]byte("data"))
+	after := time.Now()
+
+	ts := sess.LastOutputAt()
+	if ts.Before(before) || ts.After(after) {
+		t.Fatalf("LastOutputAt %v not between %v and %v", ts, before, after)
+	}
+}
+
+func TestSession_LastInputAt(t *testing.T) {
+	sess, err := Spawn(SpawnConfig{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "exec cat"},
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+
+	if !sess.LastInputAt().IsZero() {
+		t.Fatal("expected zero LastInputAt initially")
+	}
+
+	before := time.Now()
+	sess.Write([]byte("x"))
+	after := time.Now()
+
+	ts := sess.LastInputAt()
+	if ts.Before(before) || ts.After(after) {
+		t.Fatalf("LastInputAt %v not between %v and %v", ts, before, after)
 	}
 }

--- a/internal/pty/session_unsupported.go
+++ b/internal/pty/session_unsupported.go
@@ -113,6 +113,9 @@ func (s *Session) LastInputAt() time.Time { return time.Time{} }
 // ScrollbackWithSentinel returns sentinel only on unsupported platforms.
 func (s *Session) ScrollbackWithSentinel() []byte { return []byte(ScrollbackSentinel) }
 
+// ExitCode returns -1 on unsupported platforms.
+func (s *Session) ExitCode() int { return -1 }
+
 // WriteWithID is unsupported on non-Unix platforms.
 func (s *Session) WriteWithID(data []byte, inputID string) (int, error) {
 	return 0, errUnsupportedPTY

--- a/internal/pty/session_unsupported.go
+++ b/internal/pty/session_unsupported.go
@@ -6,10 +6,25 @@
 
 package pty
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // maxScrollback keeps API parity with Unix session implementation.
 const maxScrollback = 256 * 1024
+
+// defaultInputIDMax keeps API parity with Unix session implementation.
+const defaultInputIDMax = 256
+
+// ScrollbackSentinel keeps API parity with Unix session implementation.
+const ScrollbackSentinel = "\x1b]133;REPLAY_END\x07"
+
+// IdleConfig configures idle detection for a session.
+type IdleConfig struct {
+	Timeout  time.Duration
+	Callback func(sessionID string)
+}
 
 // Session is a stub PTY session on unsupported platforms.
 type Session struct {
@@ -82,3 +97,23 @@ func (s *Session) Pid() int {
 
 // ForceRedraw is a no-op on unsupported platforms.
 func (s *Session) ForceRedraw() {}
+
+// AltScreenActive reports false on unsupported platforms.
+func (s *Session) AltScreenActive() bool { return false }
+
+// SetIdleConfig is a no-op on unsupported platforms.
+func (s *Session) SetIdleConfig(cfg IdleConfig) {}
+
+// LastOutputAt returns zero time on unsupported platforms.
+func (s *Session) LastOutputAt() time.Time { return time.Time{} }
+
+// LastInputAt returns zero time on unsupported platforms.
+func (s *Session) LastInputAt() time.Time { return time.Time{} }
+
+// ScrollbackWithSentinel returns sentinel only on unsupported platforms.
+func (s *Session) ScrollbackWithSentinel() []byte { return []byte(ScrollbackSentinel) }
+
+// WriteWithID is unsupported on non-Unix platforms.
+func (s *Session) WriteWithID(data []byte, inputID string) (int, error) {
+	return 0, errUnsupportedPTY
+}

--- a/internal/pty/upload.go
+++ b/internal/pty/upload.go
@@ -1,0 +1,124 @@
+// upload.go — Terminal session image upload handler.
+// Why: Allows agents to upload images (screenshots, diagrams) through a terminal session.
+
+package pty
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	uploadMaxSize = 10 << 20 // 10 MB.
+	uploadDirName = "terminal-uploads"
+)
+
+// Allowed MIME type prefixes for upload validation.
+var allowedContentTypes = []string{
+	"image/png",
+	"image/jpeg",
+	"image/gif",
+	"image/webp",
+	"image/svg+xml",
+}
+
+// ErrUploadTooLarge is returned when the upload exceeds the size limit.
+var ErrUploadTooLarge = errors.New("pty: upload exceeds 10MB limit")
+
+// ErrUploadInvalidType is returned when the content type is not an allowed image type.
+var ErrUploadInvalidType = errors.New("pty: invalid content type, must be an image")
+
+// UploadResult contains the result of a successful upload.
+type UploadResult struct {
+	RelPath string // Relative path from workspace root.
+	Size    int64  // Bytes written.
+}
+
+// Upload saves an image to the workspace upload directory for a session.
+// Returns the relative path suitable for referencing in results or telemetry.
+func Upload(workspaceDir, sessionID, contentType, filename string, r io.Reader) (*UploadResult, error) {
+	if !isAllowedContentType(contentType) {
+		return nil, ErrUploadInvalidType
+	}
+
+	safe := sanitizeFilename(filename)
+	if safe == "" {
+		safe = fmt.Sprintf("upload-%d", time.Now().UnixMilli())
+	}
+	if filepath.Ext(safe) == "" {
+		safe += extForContentType(contentType)
+	}
+
+	dir := filepath.Join(workspaceDir, uploadDirName, sessionID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create upload dir: %w", err)
+	}
+
+	path := filepath.Join(dir, safe)
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	limited := io.LimitReader(r, uploadMaxSize+1)
+	n, err := io.Copy(f, limited)
+	if err != nil {
+		os.Remove(path)
+		return nil, fmt.Errorf("write file: %w", err)
+	}
+	if n > uploadMaxSize {
+		os.Remove(path)
+		return nil, ErrUploadTooLarge
+	}
+
+	relPath := filepath.Join(uploadDirName, sessionID, safe)
+	return &UploadResult{RelPath: relPath, Size: n}, nil
+}
+
+func isAllowedContentType(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	for _, allowed := range allowedContentTypes {
+		if strings.HasPrefix(ct, allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeFilename(name string) string {
+	name = filepath.Base(name)
+	if name == "." || name == ".." {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func extForContentType(ct string) string {
+	ct = strings.ToLower(ct)
+	switch {
+	case strings.HasPrefix(ct, "image/png"):
+		return ".png"
+	case strings.HasPrefix(ct, "image/jpeg"):
+		return ".jpeg"
+	case strings.HasPrefix(ct, "image/gif"):
+		return ".gif"
+	case strings.HasPrefix(ct, "image/webp"):
+		return ".webp"
+	case strings.HasPrefix(ct, "image/svg+xml"):
+		return ".svg"
+	default:
+		return ".bin"
+	}
+}

--- a/internal/pty/upload_test.go
+++ b/internal/pty/upload_test.go
@@ -1,0 +1,124 @@
+// upload_test.go — Tests for terminal session image upload.
+
+package pty
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpload_Success(t *testing.T) {
+	dir := t.TempDir()
+	r := strings.NewReader("fake png data")
+	result, err := Upload(dir, "sess-1", "image/png", "screenshot.png", r)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	expected := filepath.Join(uploadDirName, "sess-1", "screenshot.png")
+	if result.RelPath != expected {
+		t.Fatalf("expected path %q, got %q", expected, result.RelPath)
+	}
+	if result.Size != 13 {
+		t.Fatalf("expected size 13, got %d", result.Size)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, result.RelPath))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != "fake png data" {
+		t.Fatalf("unexpected content: %s", string(data))
+	}
+}
+
+func TestUpload_TooLarge(t *testing.T) {
+	dir := t.TempDir()
+	r := io.LimitReader(zeroReader{}, uploadMaxSize+1)
+	_, err := Upload(dir, "sess-1", "image/png", "big.png", r)
+	if !errors.Is(err, ErrUploadTooLarge) {
+		t.Fatalf("expected ErrUploadTooLarge, got: %v", err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestUpload_InvalidContentType(t *testing.T) {
+	dir := t.TempDir()
+	r := strings.NewReader("data")
+	_, err := Upload(dir, "sess-1", "text/html", "page.html", r)
+	if !errors.Is(err, ErrUploadInvalidType) {
+		t.Fatalf("expected ErrUploadInvalidType, got: %v", err)
+	}
+}
+
+func TestUpload_SanitizesFilename(t *testing.T) {
+	dir := t.TempDir()
+	r := strings.NewReader("data")
+	result, err := Upload(dir, "sess-1", "image/png", "../../../etc/passwd", r)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if strings.Contains(result.RelPath, "..") {
+		t.Fatalf("path traversal not sanitized: %s", result.RelPath)
+	}
+}
+
+func TestUpload_EmptyFilename(t *testing.T) {
+	dir := t.TempDir()
+	r := strings.NewReader("data")
+	result, err := Upload(dir, "sess-1", "image/png", "", r)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if result.RelPath == "" {
+		t.Fatal("expected non-empty path for empty filename")
+	}
+	if filepath.Ext(result.RelPath) != ".png" {
+		t.Fatalf("expected .png extension, got %s", filepath.Ext(result.RelPath))
+	}
+}
+
+func TestUpload_AddsExtension(t *testing.T) {
+	dir := t.TempDir()
+	r := strings.NewReader("data")
+	result, err := Upload(dir, "sess-1", "image/jpeg", "photo", r)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if filepath.Ext(result.RelPath) != ".jpeg" {
+		t.Fatalf("expected .jpeg extension, got %s", filepath.Ext(result.RelPath))
+	}
+}
+
+func TestUpload_AllowedContentTypes(t *testing.T) {
+	for _, ct := range []string{"image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"} {
+		dir := t.TempDir()
+		r := strings.NewReader("data")
+		_, err := Upload(dir, "sess-1", ct, "file", r)
+		if err != nil {
+			t.Fatalf("content type %q should be allowed, got: %v", ct, err)
+		}
+	}
+}
+
+func TestUpload_RejectedContentTypes(t *testing.T) {
+	for _, ct := range []string{"text/html", "application/json", "video/mp4", ""} {
+		dir := t.TempDir()
+		r := strings.NewReader("data")
+		_, err := Upload(dir, "sess-1", ct, "file", r)
+		if !errors.Is(err, ErrUploadInvalidType) {
+			t.Fatalf("content type %q should be rejected, got: %v", ct, err)
+		}
+	}
+}

--- a/internal/pty/writebuf.go
+++ b/internal/pty/writebuf.go
@@ -1,0 +1,137 @@
+// writebuf.go — Non-blocking write buffer with backpressure for PTY input.
+// Why: Prevents WebSocket handlers from blocking when the child process stalls on stdin.
+
+package pty
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// Write buffer constants.
+const (
+	writeBufferMax = 1 << 20   // 1 MB backpressure cap.
+	writeChunkSize = 16 * 1024 // 16 KB per write syscall.
+)
+
+// ErrWriteBufferFull is returned when the write buffer exceeds the backpressure cap.
+var ErrWriteBufferFull = errors.New("pty: write buffer full")
+
+// WriteBuffer provides non-blocking writes with async draining to an io.Writer.
+// Data remains in the buffer until successfully written to the underlying writer,
+// providing accurate backpressure.
+type WriteBuffer struct {
+	mu      sync.Mutex
+	buf     []byte
+	maxSize int
+	writer  io.Writer
+	notify  chan struct{}
+	done    chan struct{}
+	closed  bool
+}
+
+// NewWriteBuffer creates a buffered writer that drains asynchronously.
+func NewWriteBuffer(w io.Writer) *WriteBuffer {
+	wb := &WriteBuffer{
+		maxSize: writeBufferMax,
+		writer:  w,
+		notify:  make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	go wb.drain() // lint:allow-bare-goroutine — long-lived drain loop, exits on Close
+	return wb
+}
+
+// Write appends data to the buffer without blocking. Returns ErrWriteBufferFull
+// if the buffer exceeds the backpressure cap.
+func (wb *WriteBuffer) Write(data []byte) (int, error) {
+	wb.mu.Lock()
+	if wb.closed {
+		wb.mu.Unlock()
+		return 0, ErrWriteBufferFull
+	}
+	if len(wb.buf)+len(data) > wb.maxSize {
+		wb.mu.Unlock()
+		return 0, ErrWriteBufferFull
+	}
+	wb.buf = append(wb.buf, data...)
+	wb.mu.Unlock()
+	select {
+	case wb.notify <- struct{}{}:
+	default:
+	}
+	return len(data), nil
+}
+
+// drain waits for notifications and flushes buffered data to the writer.
+func (wb *WriteBuffer) drain() {
+	defer close(wb.done)
+	for {
+		_, ok := <-wb.notify
+		if !ok {
+			return
+		}
+		wb.flushAll()
+	}
+}
+
+// flushAll writes all buffered data to the underlying writer in chunks.
+// Data is only removed from the buffer after a successful write, so Pending()
+// reflects the true amount of undelivered data.
+func (wb *WriteBuffer) flushAll() {
+	for {
+		wb.mu.Lock()
+		if len(wb.buf) == 0 {
+			wb.mu.Unlock()
+			return
+		}
+		n := len(wb.buf)
+		if n > writeChunkSize {
+			n = writeChunkSize
+		}
+		chunk := make([]byte, n)
+		copy(chunk, wb.buf[:n])
+		wb.mu.Unlock()
+
+		_, err := wb.writer.Write(chunk)
+
+		wb.mu.Lock()
+		if len(wb.buf) >= n {
+			wb.buf = wb.buf[n:]
+		}
+		if len(wb.buf) == 0 {
+			wb.buf = nil
+		}
+		wb.mu.Unlock()
+
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Pending returns the number of bytes waiting in the buffer.
+func (wb *WriteBuffer) Pending() int {
+	wb.mu.Lock()
+	defer wb.mu.Unlock()
+	return len(wb.buf)
+}
+
+// Close stops the drain goroutine and flushes remaining data.
+func (wb *WriteBuffer) Close() error {
+	wb.mu.Lock()
+	if wb.closed {
+		wb.mu.Unlock()
+		return nil
+	}
+	wb.closed = true
+	wb.mu.Unlock()
+
+	close(wb.notify)
+	<-wb.done
+
+	// Final synchronous flush.
+	wb.flushAll()
+	return nil
+}

--- a/internal/pty/writebuf.go
+++ b/internal/pty/writebuf.go
@@ -46,7 +46,7 @@ func NewWriteBuffer(w io.Writer) *WriteBuffer {
 // Write appends data to the buffer without blocking. Returns ErrWriteBufferFull
 // if the buffer exceeds the backpressure cap.
 func (wb *WriteBuffer) Write(data []byte) (int, error) {
-	wb.mu.Lock()
+	wb.mu.Lock() // lint:manual-unlock — multiple early-return paths
 	if wb.closed {
 		wb.mu.Unlock()
 		return 0, ErrWriteBufferFull
@@ -81,7 +81,7 @@ func (wb *WriteBuffer) drain() {
 // reflects the true amount of undelivered data.
 func (wb *WriteBuffer) flushAll() {
 	for {
-		wb.mu.Lock()
+		wb.mu.Lock() // lint:manual-unlock — lock/unlock brackets I/O outside lock
 		if len(wb.buf) == 0 {
 			wb.mu.Unlock()
 			return
@@ -95,8 +95,14 @@ func (wb *WriteBuffer) flushAll() {
 		wb.mu.Unlock()
 
 		_, err := wb.writer.Write(chunk)
+		if err != nil {
+			// Leave data in buffer — caller can retry or Close will
+			// attempt a final flush. For PTY stdin this typically means
+			// the child process exited, so the data is undeliverable.
+			return
+		}
 
-		wb.mu.Lock()
+		wb.mu.Lock() // lint:manual-unlock — same pattern as above
 		if len(wb.buf) >= n {
 			wb.buf = wb.buf[n:]
 		}
@@ -104,10 +110,6 @@ func (wb *WriteBuffer) flushAll() {
 			wb.buf = nil
 		}
 		wb.mu.Unlock()
-
-		if err != nil {
-			return
-		}
 	}
 }
 
@@ -120,7 +122,7 @@ func (wb *WriteBuffer) Pending() int {
 
 // Close stops the drain goroutine and flushes remaining data.
 func (wb *WriteBuffer) Close() error {
-	wb.mu.Lock()
+	wb.mu.Lock() // lint:manual-unlock — unlock before blocking on drain goroutine
 	if wb.closed {
 		wb.mu.Unlock()
 		return nil

--- a/internal/pty/writebuf_test.go
+++ b/internal/pty/writebuf_test.go
@@ -1,0 +1,134 @@
+// writebuf_test.go — Tests for non-blocking write buffer with backpressure.
+
+package pty
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteBuffer_BasicWrite(t *testing.T) {
+	var dest bytes.Buffer
+	wb := NewWriteBuffer(&dest)
+
+	n, err := wb.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("expected 5 bytes, got %d", n)
+	}
+
+	// Close waits for drain to complete, making dest safe to read.
+	wb.Close()
+
+	if dest.String() != "hello" {
+		t.Fatalf("expected %q, got %q", "hello", dest.String())
+	}
+}
+
+func TestWriteBuffer_Backpressure(t *testing.T) {
+	gw := &gatedWriter{gate: make(chan struct{})}
+	wb := NewWriteBuffer(gw)
+	defer func() {
+		close(gw.gate)
+		wb.Close()
+	}()
+
+	// Fill buffer to capacity.
+	data := make([]byte, writeBufferMax)
+	_, err := wb.Write(data)
+	if err != nil {
+		t.Fatalf("write to fill: %v", err)
+	}
+
+	// Exceeding capacity should fail.
+	_, err = wb.Write([]byte("x"))
+	if err != ErrWriteBufferFull {
+		t.Fatalf("expected ErrWriteBufferFull, got: %v", err)
+	}
+}
+
+// gatedWriter blocks on Write until gate channel is closed.
+type gatedWriter struct {
+	gate chan struct{}
+}
+
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	<-w.gate
+	return len(p), nil
+}
+
+func TestWriteBuffer_Pending(t *testing.T) {
+	gw := &gatedWriter{gate: make(chan struct{})}
+	wb := NewWriteBuffer(gw)
+	defer func() {
+		close(gw.gate)
+		wb.Close()
+	}()
+
+	wb.Write([]byte("hello"))
+	// Pending should reflect buffered data (drain is blocked).
+	p := wb.Pending()
+	if p < 0 {
+		t.Fatalf("expected non-negative pending, got %d", p)
+	}
+}
+
+func TestWriteBuffer_CloseFlushes(t *testing.T) {
+	var dest bytes.Buffer
+	wb := NewWriteBuffer(&dest)
+
+	wb.Write([]byte("data"))
+	wb.Close()
+
+	if dest.String() != "data" {
+		t.Fatalf("expected %q after close, got %q", "data", dest.String())
+	}
+}
+
+func TestWriteBuffer_DoubleClose(t *testing.T) {
+	var dest bytes.Buffer
+	wb := NewWriteBuffer(&dest)
+	wb.Close()
+	if err := wb.Close(); err != nil {
+		t.Fatalf("double close: %v", err)
+	}
+}
+
+func TestWriteBuffer_WriteAfterClose(t *testing.T) {
+	var dest bytes.Buffer
+	wb := NewWriteBuffer(&dest)
+	wb.Close()
+
+	_, err := wb.Write([]byte("x"))
+	if err != ErrWriteBufferFull {
+		t.Fatalf("expected ErrWriteBufferFull after close, got: %v", err)
+	}
+}
+
+func TestWriteBuffer_LargeWrite(t *testing.T) {
+	var dest bytes.Buffer
+	wb := NewWriteBuffer(&dest)
+
+	// Write data larger than one chunk to exercise chunked flushing.
+	data := make([]byte, writeChunkSize*3)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	n, err := wb.Write(data)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("expected %d bytes, got %d", len(data), n)
+	}
+
+	// Close waits for drain to complete, making dest safe to read.
+	wb.Close()
+
+	if dest.Len() != len(data) {
+		t.Fatalf("expected %d drained bytes, got %d", len(data), dest.Len())
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #528 — implements all 8 PTY session improvements identified in the CAR (codex-autorunner) comparative analysis, preparing `internal/pty` for the BlazeTorch Foundry workflow-runner web UI.

- **Non-blocking I/O** — `WriteBuffer` with 1MB backpressure cap and chunked async drain (`writebuf.go`)
- **Multi-subscriber fan-out** — up to 32 concurrent WebSocket watchers per session, slow subscribers dropped (`fanout.go`)
- **Scrollback replay sentinel** — `ScrollbackWithSentinel()` appends marker so frontends distinguish replay from live data
- **Alt-screen detection** — tracks `ESC[?1049h/l` sequences, exposes `AltScreenActive()` for TUI vs streaming detection
- **Idle detection** — configurable timeout + callback fires when session goes quiet after output
- **Input deduplication** — `WriteWithID()` with bounded 256-entry deque drops duplicate keystrokes on reconnect
- **Session-per-repo-per-agent** — Manager indexes by `(RepoPath, AgentType)` tuple for multi-provider coexistence
- **Image upload** — `Upload()` saves images to workspace with 10MB cap, content-type validation, filename sanitization

## Test plan

- [x] 56 tests pass (`go test ./internal/pty/...`)
- [x] Race detector clean (`-race` flag)
- [x] `go vet` clean
- [x] Full project builds (`go build ./...`)
- [x] All files under 800 LOC limit
- [x] Zero production dependencies added
- [x] Existing session/manager tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)