### PR TITLE
fix: prevent installer from overwriting existing MCP configs

### DIFF
--- a/cmd/dev-console/native_install.go
+++ b/cmd/dev-console/native_install.go
@@ -114,7 +114,9 @@ func runNativeInstall() {
 	extDir := extensionInstallDir(home)
 
 	// 2. Claude Code
-	installClaudeCode(exe)
+	if err := installClaudeCode(exe); err != nil {
+		stderrf("⚠️  Claude Code config: %v\n", err)
+	}
 
 	// 3. File-based configs
 	configs := []struct {
@@ -183,7 +185,9 @@ func runNativeInstall() {
 			continue // Client directory doesn't exist, skip
 		}
 
-		_ = mergeJSONConfig(path, cfg.key, exe, cfg.isCustom) //nolint:errcheck // best-effort per-client config
+		if err := mergeJSONConfig(path, cfg.key, exe, cfg.isCustom); err != nil {
+			stderrf("⚠️  %s config: %v\n", cfg.name, err)
+		}
 	}
 
 	// 3b. Codex (TOML-based config)
@@ -230,9 +234,9 @@ func startDaemonSilently(exe string) {
 	}
 }
 
-func installClaudeCode(exePath string) {
+func installClaudeCode(exePath string) error {
 	if _, err := exec.LookPath("claude"); err != nil {
-		return
+		return nil // claude CLI not installed, nothing to do
 	}
 
 	// Remove legacy MCP server registrations before adding the canonical one.
@@ -251,7 +255,11 @@ func installClaudeCode(exePath string) {
 	cmd := exec.Command("claude", "mcp", "add-json", "--scope", "user", mcpServerName)
 	cmd.Stdin = strings.NewReader(string(data))
 	cmd.Env = append(os.Environ(), "CLAUDECODE=")
-	_ = cmd.Run() //nolint:errcheck // best-effort Claude Code MCP registration
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("claude mcp add-json failed: %v\n%s", err, out)
+	}
+	return nil
 }
 
 // installCodex updates ~/.codex/config.toml to register the MCP server.
@@ -312,7 +320,11 @@ func installCodex(home, exePath string) {
 func mergeJSONConfig(path, key, exePath string, isCustom bool) error {
 	data := make(map[string]any)
 	if bytes, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(bytes, &data) //nolint:errcheck // start with empty map if unmarshal fails
+		if len(bytes) > 0 {
+			if err := json.Unmarshal(bytes, &data); err != nil {
+				return fmt.Errorf("refusing to overwrite %s: existing file has invalid JSON (%v). Fix the file manually or back it up before retrying", path, err)
+			}
+		}
 	}
 
 	if _, ok := data[key]; !ok {
@@ -351,6 +363,11 @@ func mergeJSONConfig(path, key, exePath string, isCustom bool) error {
 	out, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
+	}
+
+	// Back up existing file before overwriting.
+	if existing, err := os.ReadFile(path); err == nil && len(existing) > 0 {
+		_ = os.WriteFile(path+".bak", existing, 0600)
 	}
 
 	return os.WriteFile(path, append(out, '\n'), 0600)

--- a/cmd/dev-console/native_install_config_test.go
+++ b/cmd/dev-console/native_install_config_test.go
@@ -1,0 +1,188 @@
+// native_install_config_test.go — Tests for mergeJSONConfig safety: backup, invalid-JSON refusal, legacy key removal.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeJSONConfig_PreservesExistingServers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	existing := map[string]any{
+		"mcpServers": map[string]any{
+			"other-server": map[string]any{
+				"command": "/usr/bin/other",
+				"args":    []string{"--flag"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false); err != nil {
+		t.Fatalf("mergeJSONConfig failed: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	servers, ok := result["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers key missing or wrong type")
+	}
+
+	if _, ok := servers["other-server"]; !ok {
+		t.Error("existing server 'other-server' was deleted")
+	}
+	if _, ok := servers[mcpServerName]; !ok {
+		t.Errorf("canonical server %q was not added", mcpServerName)
+	}
+}
+
+func TestMergeJSONConfig_RefusesToOverwriteInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	if err := os.WriteFile(path, []byte("{invalid json}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+
+	// Verify file was NOT overwritten.
+	content, _ := os.ReadFile(path)
+	if string(content) != "{invalid json}" {
+		t.Errorf("file was modified despite invalid JSON; got: %s", content)
+	}
+}
+
+func TestMergeJSONConfig_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	original := `{"mcpServers":{}}`
+	if err := os.WriteFile(path, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false); err != nil {
+		t.Fatalf("mergeJSONConfig failed: %v", err)
+	}
+
+	bakPath := path + ".bak"
+	bak, err := os.ReadFile(bakPath)
+	if err != nil {
+		t.Fatalf("backup file not created: %v", err)
+	}
+	if string(bak) != original {
+		t.Errorf("backup content mismatch: got %q, want %q", bak, original)
+	}
+}
+
+func TestMergeJSONConfig_RemovesLegacyKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	existing := map[string]any{
+		"mcpServers": map[string]any{
+			"gasoline":                map[string]any{"command": "/old"},
+			"gasoline-agentic-browser": map[string]any{"command": "/old2"},
+			"keep-this":               map[string]any{"command": "/keep"},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false); err != nil {
+		t.Fatalf("mergeJSONConfig failed: %v", err)
+	}
+
+	out, _ := os.ReadFile(path)
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	servers := result["mcpServers"].(map[string]any)
+	for _, legacy := range installerLegacyServerKeys {
+		if _, ok := servers[legacy]; ok {
+			t.Errorf("legacy key %q was not removed", legacy)
+		}
+	}
+	if _, ok := servers["keep-this"]; !ok {
+		t.Error("non-legacy server 'keep-this' was incorrectly removed")
+	}
+}
+
+func TestMergeJSONConfig_EmptyFileCreatesNew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	if err := os.WriteFile(path, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false); err != nil {
+		t.Fatalf("mergeJSONConfig failed: %v", err)
+	}
+
+	out, _ := os.ReadFile(path)
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	servers, ok := result["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers key missing")
+	}
+	if _, ok := servers[mcpServerName]; !ok {
+		t.Errorf("canonical server %q was not added", mcpServerName)
+	}
+}
+
+func TestMergeJSONConfig_MissingFileCreatesNew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	if err := mergeJSONConfig(path, "mcpServers", "/usr/bin/gasoline", false); err != nil {
+		t.Fatalf("mergeJSONConfig failed: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file was not created: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	servers, ok := result["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers key missing")
+	}
+	if _, ok := servers[mcpServerName]; !ok {
+		t.Errorf("canonical server %q was not added", mcpServerName)
+	}
+}


### PR DESCRIPTION
## Summary
- **Bug:** `mergeJSONConfig` silently ignored JSON parse errors — if an existing config file had invalid JSON (trailing comma, BOM, etc.), the parse failed and the function overwrote the file with only the gasoline entry, deleting all other MCP servers (github, atlassian, etc.)
- **Fix:** Refuse to overwrite when existing file has invalid JSON, create `.bak` backup before every config write, surface `installClaudeCode` and `mergeJSONConfig` errors to stderr
- Adds 6 regression tests

## Test plan
- [x] `go build ./cmd/dev-console/`
- [x] `go test ./cmd/dev-console/ -run TestMergeJSONConfig -v` (6/6 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)