### PR TITLE
feat: add Claude Code skill for browser automation

### DIFF
--- a/claude_skill/README.md
+++ b/claude_skill/README.md
@@ -1,0 +1,75 @@
+# Gasoline — Claude Code Skill
+
+## What is this?
+
+Gasoline is an MCP server by default, but it can also run as a CLI. This skill packages the CLI into a Claude Code skill for browser observation, debugging, automation, and testing.
+
+There is no difference in functionality between the MCP and the skill — both expose the same 5 tools and capabilities. The advantage of the skill is that it uses progressive disclosure to load only what's needed, instead of loading ~21,250 tokens of MCP tool schemas into every conversation, saving tokens upfront.
+
+## Installation
+
+1. Install the Gasoline Chrome Extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/gasoline/ghgoccajngbgapjmhofojkkagjgffmpj), or [load the unpacked extension](#loading-the-unpacked-extension) for development.
+2. Run the install script:
+   ```bash
+   bash claude_skill/install.sh
+   ```
+   The script will:
+   - Ask where to install the skill files:
+     - **Globally** (`~/.claude/skills/gasoline/`) — available in all Claude Code sessions
+     - **Project-only** (`.claude/skills/gasoline/`) — available only in the current project
+   - Install the MCP server binary (`gasoline-agentic-browser`) via npm. To avoid version mismatches,
+     the script asks for your extension version (check `chrome://extensions` → Gasoline Devtools).
+     Press Enter to install the latest version instead.
+
+   > **Note:** Unlike the standard MCP setup (`npx gasoline-mcp` in `.mcp.json`), this installs
+   > the binary globally. The skill calls it directly via HTTP, not as an MCP server.
+
+## Usage
+
+Before using the skill, navigate to the tab you want to inspect, open the Gasoline extension popup, and click **Track this tab**. This tells the extension to start capturing telemetry for that tab.
+
+Once tracking, the skill is automatically triggered in Claude Code when you ask about browser debugging, screenshots, automation, audits, etc. Examples:
+
+```
+"check my browser for errors"
+"take a screenshot of the current page"
+"run an accessibility audit"
+"click the submit button"
+"show me the network requests"
+"generate a Playwright test from the last recording"
+"what's on the page right now?"
+```
+
+## Tools
+
+The skill exposes 5 tools:
+
+| Tool | Purpose | Example modes |
+|------|---------|---------------|
+| **observe** | Read captured browser telemetry (passive) | errors, logs, network, screenshot, tabs |
+| **analyze** | Active analysis queries sent to extension | dom, accessibility, security, performance |
+| **generate** | Create artifacts from captured data | test, reproduction, har, sarif |
+| **configure** | Session management and diagnostics | health, doctor, store, clear |
+| **interact** | Browser automation | click, type, navigate, fill_form, scroll |
+
+## Loading the Unpacked Extension
+
+If you're developing or want to run from source instead of the Chrome Web Store version:
+
+1. Build the extension:
+   ```bash
+   make compile-ts
+   ```
+2. Open Chrome and navigate to `chrome://extensions`
+3. Enable **Developer mode** (toggle in the top-right corner)
+4. Click **Load unpacked**
+5. Select the `extension/` folder from this repository
+6. The Gasoline Devtools extension should now appear in your extensions list
+
+> **Tip:** After making changes to the extension source, run `make compile-ts` again and click the refresh icon on the extension card in `chrome://extensions` to reload it.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GASOLINE_PORT` | 7890 | Daemon HTTP port |

--- a/claude_skill/gasoline/SKILL.md
+++ b/claude_skill/gasoline/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gasoline
+description: >
+  Browser observation, debugging, automation, and testing via Gasoline daemon.
+  Use when user asks to debug browser errors, inspect network requests, take
+  screenshots, automate browser interactions, run accessibility audits, capture
+  performance metrics, generate tests from browser sessions, or audit a web
+  application. Trigger phrases: "check my browser", "debug this page",
+  "take a screenshot", "run site audit", "browser errors", "network requests",
+  "automate the browser", "record a test", "accessibility audit",
+  "performance check", "what's on the page".
+license: AGPL-3.0
+compatibility: >
+  Requires gasoline-agentic-devtools binary on PATH and Gasoline Chrome
+  extension connected. macOS, Linux, Windows.
+metadata:
+  author: Strum AI
+  version: 0.8.1
+  category: developer-tools
+  tags: [browser, debugging, automation, testing, observability]
+---
+
+# Gasoline
+
+## Critical: Daemon Setup
+
+Before any tool call, ensure the daemon is running:
+
+```bash
+bash scripts/ensure-daemon.sh
+```
+
+If this fails, run the connection doctor:
+
+```bash
+bash scripts/connection-doctor.sh
+```
+
+## How to Call Tools
+
+All 5 tools are called via the helper script:
+
+```bash
+bash scripts/gasoline-call.sh <tool> '<json_arguments>'
+```
+
+Examples:
+
+```bash
+# Read browser errors
+bash scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
+
+# Take a screenshot
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","format":"png"}'
+
+# Click an element
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
+
+# Run accessibility audit
+bash scripts/gasoline-call.sh analyze '{"what":"accessibility"}'
+
+# Generate a Playwright test
+bash scripts/gasoline-call.sh generate '{"what":"test","test_name":"login_flow"}'
+
+# Check health
+bash scripts/gasoline-call.sh configure '{"what":"health"}'
+```
+
+## Tools Quick Reference
+
+### observe — Read captured browser telemetry (passive)
+
+Top modes: `errors`, `logs`, `network_waterfall`, `network_bodies`, `actions`, `screenshot`, `page`, `tabs`, `storage`, `recordings`, `websocket_events`, `error_bundles`, `timeline`, `transients`, `page_inventory`
+
+Common params: `what` (required), `limit`, `since_cursor`, `summary`, `format`, `url`, `scope`
+
+Pagination: pass `after_cursor`/`before_cursor`/`since_cursor` from response metadata. Set `restart_on_eviction=true` if cursor expired.
+
+Full reference: `references/observe-modes.md`
+
+### analyze — Active analysis queries (sent to extension)
+
+Top modes: `dom`, `accessibility`, `security_audit`, `performance`, `forms`, `link_health`, `page_summary`, `computed_styles`, `visual_diff`, `api_validation`, `third_party_audit`, `audit`
+
+Common params: `what` (required), `selector`, `timeout_ms`, `background`, `summary`
+
+Async mode: set `background:true` to get `correlation_id`, then poll with `observe(what='command_result', correlation_id=...)`.
+
+Full reference: `references/analyze-modes.md`
+
+### generate — Create artifacts from captured data
+
+Top modes: `test`, `reproduction`, `pr_summary`, `har`, `csp`, `sarif`, `visual_test`, `test_from_context`, `test_heal`, `test_classify`
+
+Common params: `what` (required), `test_name`, `save_to`, `last_n`
+
+Full reference: `references/generate-modes.md`
+
+### configure — Session management and diagnostics
+
+Top modes: `health`, `doctor`, `store`, `clear`, `describe_capabilities`, `event_recording_start`, `event_recording_stop`, `playback`, `noise_rule`, `streaming`, `telemetry`, `diff_sessions`
+
+Common params: `what` (required), `store_action`, `key`, `value`
+
+Full reference: `references/configure-modes.md`
+
+### interact — Browser automation
+
+Top modes: `click`, `type`, `navigate`, `screenshot`, `execute_js`, `explore_page`, `list_interactive`, `fill_form`, `scroll_to`, `hover`, `wait_for`, `batch`
+
+Common params: `what` (required), `selector`, `text`, `url`, `script`
+
+Targeting priority: `selector` > `element_id` > `index` > `x/y` coordinates
+
+Semantic selectors: `text=Submit`, `role=button`, `placeholder=Email`
+
+Composable enrichment: add `include_screenshot:true`, `action_diff:true`, or `wait_for_stable:true` to any action.
+
+Full reference: `references/interact-actions.md`
+
+## Workflows
+
+Choose the workflow that matches your task:
+
+| Task | Workflow |
+|------|----------|
+| Debug errors, triage failures, create regression tests | `references/workflow-debug-and-triage.md` |
+| Site audit, UX review, accessibility, security, API validation | `references/workflow-audit-and-security.md` |
+| Browser automation, demos, test generation, release gates | `references/workflow-automate-and-test.md` |
+| Performance measurement and comparison | `references/workflow-performance.md` |
+
+## Troubleshooting
+
+### Daemon not running
+
+Run: `bash scripts/ensure-daemon.sh`
+If fails: check `which gasoline` — binary must be on PATH.
+Install: `npm install -g gasoline-agentic-browser`
+
+### Extension not connected
+
+Run: `bash scripts/connection-doctor.sh`
+Check Chrome extension is installed and enabled on the target page.
+The extension POSTs telemetry to localhost:7890.
+
+### No data returned
+
+Ensure a tab is tracked:
+
+```bash
+bash scripts/gasoline-call.sh observe '{"what":"tabs"}'
+```
+
+If no tracked tab, open a page with the extension active.
+
+### Tool call returns error
+
+Use describe_capabilities for parameter help:
+
+```bash
+bash scripts/gasoline-call.sh configure '{"what":"describe_capabilities","tool":"observe","mode":"errors"}'
+```
+
+### Connection lost mid-session
+
+Re-run ensure-daemon and retry:
+
+```bash
+bash scripts/ensure-daemon.sh
+bash scripts/gasoline-call.sh configure '{"what":"health"}'
+```

--- a/claude_skill/gasoline/references/analyze-modes.md
+++ b/claude_skill/gasoline/references/analyze-modes.md
@@ -16,7 +16,7 @@ DOM structure analysis.
 **Params:** selector (string), frame (string), tab_id (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"dom","selector":"main"}'
+bash scripts/gasoline-call.sh analyze '{"what":"dom","selector":"main"}'
 ```
 
 ## performance
@@ -24,7 +24,7 @@ Performance metrics.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"performance"}'
+bash scripts/gasoline-call.sh analyze '{"what":"performance"}'
 ```
 
 ## accessibility
@@ -32,7 +32,7 @@ Accessibility audit.
 **Params:** selector (string), frame (string), scope (string), tags (array), force_refresh (bool), summary (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","tags":["wcag2a"],"summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"accessibility","tags":["wcag2a"],"summary":true}'
 ```
 
 ## error_clusters
@@ -40,7 +40,7 @@ Error pattern clustering.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"error_clusters"}'
+bash scripts/gasoline-call.sh analyze '{"what":"error_clusters"}'
 ```
 
 ## navigation_patterns
@@ -48,7 +48,7 @@ Navigation pattern detection.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation_patterns"}'
+bash scripts/gasoline-call.sh analyze '{"what":"navigation_patterns"}'
 ```
 
 ## security_audit
@@ -56,7 +56,7 @@ Security vulnerability audit.
 **Params:** checks (array: credentials|pii|headers|cookies|transport|auth), severity_min (string: critical|high|medium|low|info), summary (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii"],"severity_min":"high"}'
+bash scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii"],"severity_min":"high"}'
 ```
 
 ## third_party_audit
@@ -64,7 +64,7 @@ Third-party script analysis.
 **Params:** first_party_origins (array), include_static (bool), custom_lists (object), summary (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","first_party_origins":["example.com"],"summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"third_party_audit","first_party_origins":["example.com"],"summary":true}'
 ```
 
 ## link_health
@@ -72,7 +72,7 @@ Link health validation.
 **Params:** domain (string), timeout_ms (number, default 10000), max_workers (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_health","domain":"example.com","timeout_ms":5000}'
+bash scripts/gasoline-call.sh analyze '{"what":"link_health","domain":"example.com","timeout_ms":5000}'
 ```
 
 ## link_validation
@@ -80,7 +80,7 @@ Link validation.
 **Params:** urls (array)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_validation","urls":["https://example.com/page1","https://example.com/page2"]}'
+bash scripts/gasoline-call.sh analyze '{"what":"link_validation","urls":["https://example.com/page1","https://example.com/page2"]}'
 ```
 
 ## page_summary
@@ -88,7 +88,7 @@ Page content summary.
 **Params:** timeout_ms (number, default 5000), world (string: auto|main|isolated), tab_id (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary","timeout_ms":3000}'
+bash scripts/gasoline-call.sh analyze '{"what":"page_summary","timeout_ms":3000}'
 ```
 
 ## annotations
@@ -96,7 +96,7 @@ Retrieve annotations from draw sessions.
 **Params:** operation (string: analyze|report|clear|flush), annot_session (string), url (string), url_pattern (string), timeout_ms (number, default 15000)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"annotations","operation":"report","url_pattern":"*.example.com/*"}'
+bash scripts/gasoline-call.sh analyze '{"what":"annotations","operation":"report","url_pattern":"*.example.com/*"}'
 ```
 
 ## annotation_detail
@@ -104,7 +104,7 @@ Detail for specific annotation.
 **Params:** correlation_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"annotation_detail","correlation_id":"abc-123"}'
+bash scripts/gasoline-call.sh analyze '{"what":"annotation_detail","correlation_id":"abc-123"}'
 ```
 
 ## api_validation
@@ -112,7 +112,7 @@ API endpoint validation.
 **Params:** operation (string: analyze|report|clear|flush), ignore_endpoints (array)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"analyze","ignore_endpoints":["/health"]}'
+bash scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"analyze","ignore_endpoints":["/health"]}'
 ```
 
 ## draw_history
@@ -120,7 +120,7 @@ Draw session history.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"draw_history"}'
+bash scripts/gasoline-call.sh analyze '{"what":"draw_history"}'
 ```
 
 ## draw_session
@@ -128,7 +128,7 @@ Load specific draw session.
 **Params:** file (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"draw_session","file":"session-2026-03-12.json"}'
+bash scripts/gasoline-call.sh analyze '{"what":"draw_session","file":"session-2026-03-12.json"}'
 ```
 
 ## computed_styles
@@ -136,7 +136,7 @@ Computed CSS styles.
 **Params:** selector (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":".hero-banner"}'
+bash scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":".hero-banner"}'
 ```
 
 ## forms
@@ -144,7 +144,7 @@ Form element analysis.
 **Params:** selector (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"forms","selector":"#login-form"}'
+bash scripts/gasoline-call.sh analyze '{"what":"forms","selector":"#login-form"}'
 ```
 
 ## form_state
@@ -152,7 +152,7 @@ Form field state capture.
 **Params:** selector (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_state","selector":"#checkout-form"}'
+bash scripts/gasoline-call.sh analyze '{"what":"form_state","selector":"#checkout-form"}'
 ```
 
 ## form_validation
@@ -160,7 +160,7 @@ Form validation rules.
 **Params:** summary (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
 ```
 
 ## data_table
@@ -168,7 +168,7 @@ Data table extraction.
 **Params:** selector (string), max_rows (number), max_cols (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"data_table","selector":"table.results","max_rows":50}'
+bash scripts/gasoline-call.sh analyze '{"what":"data_table","selector":"table.results","max_rows":50}'
 ```
 
 ## visual_baseline
@@ -176,7 +176,7 @@ Visual baseline capture.
 **Params:** name (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_baseline","name":"homepage-v1"}'
+bash scripts/gasoline-call.sh analyze '{"what":"visual_baseline","name":"homepage-v1"}'
 ```
 
 ## visual_diff
@@ -184,7 +184,7 @@ Visual diff comparison.
 **Params:** name (string), baseline (string), threshold (number, 0-255, default 30)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_diff","name":"homepage-current","baseline":"homepage-v1","threshold":25}'
+bash scripts/gasoline-call.sh analyze '{"what":"visual_diff","name":"homepage-current","baseline":"homepage-v1","threshold":25}'
 ```
 
 ## visual_baselines
@@ -192,7 +192,7 @@ List visual baselines.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_baselines"}'
+bash scripts/gasoline-call.sh analyze '{"what":"visual_baselines"}'
 ```
 
 ## navigation
@@ -200,7 +200,7 @@ Navigation structure analysis.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation"}'
+bash scripts/gasoline-call.sh analyze '{"what":"navigation"}'
 ```
 
 ## page_structure
@@ -208,7 +208,7 @@ Page structural analysis.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
+bash scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
 ```
 
 ## audit
@@ -216,7 +216,7 @@ Comprehensive audit.
 **Params:** categories (array: performance|accessibility|security|best_practices), summary (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"audit","categories":["performance","accessibility"],"summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"audit","categories":["performance","accessibility"],"summary":true}'
 ```
 
 ## feature_gates
@@ -224,5 +224,5 @@ Feature flag detection.
 **Params:** none (universal only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"feature_gates"}'
+bash scripts/gasoline-call.sh analyze '{"what":"feature_gates"}'
 ```

--- a/claude_skill/gasoline/references/analyze-modes.md
+++ b/claude_skill/gasoline/references/analyze-modes.md
@@ -1,0 +1,228 @@
+# Analyze Tool Reference
+
+Complete reference for all 27 analyze modes.
+
+**Universal params (available on every mode):**
+- `what` (string, required) — mode name
+- `telemetry_mode` (string) — telemetry collection mode
+- `background` (bool) — run asynchronously, returns `correlation_id`
+- `selector` (string) — CSS selector scope
+- `frame` (string) — target frame
+
+---
+
+## dom
+DOM structure analysis.
+**Params:** selector (string), frame (string), tab_id (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"dom","selector":"main"}'
+```
+
+## performance
+Performance metrics.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"performance"}'
+```
+
+## accessibility
+Accessibility audit.
+**Params:** selector (string), frame (string), scope (string), tags (array), force_refresh (bool), summary (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","tags":["wcag2a"],"summary":true}'
+```
+
+## error_clusters
+Error pattern clustering.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"error_clusters"}'
+```
+
+## navigation_patterns
+Navigation pattern detection.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation_patterns"}'
+```
+
+## security_audit
+Security vulnerability audit.
+**Params:** checks (array: credentials|pii|headers|cookies|transport|auth), severity_min (string: critical|high|medium|low|info), summary (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii"],"severity_min":"high"}'
+```
+
+## third_party_audit
+Third-party script analysis.
+**Params:** first_party_origins (array), include_static (bool), custom_lists (object), summary (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","first_party_origins":["example.com"],"summary":true}'
+```
+
+## link_health
+Link health validation.
+**Params:** domain (string), timeout_ms (number, default 10000), max_workers (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_health","domain":"example.com","timeout_ms":5000}'
+```
+
+## link_validation
+Link validation.
+**Params:** urls (array)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_validation","urls":["https://example.com/page1","https://example.com/page2"]}'
+```
+
+## page_summary
+Page content summary.
+**Params:** timeout_ms (number, default 5000), world (string: auto|main|isolated), tab_id (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary","timeout_ms":3000}'
+```
+
+## annotations
+Retrieve annotations from draw sessions.
+**Params:** operation (string: analyze|report|clear|flush), annot_session (string), url (string), url_pattern (string), timeout_ms (number, default 15000)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"annotations","operation":"report","url_pattern":"*.example.com/*"}'
+```
+
+## annotation_detail
+Detail for specific annotation.
+**Params:** correlation_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"annotation_detail","correlation_id":"abc-123"}'
+```
+
+## api_validation
+API endpoint validation.
+**Params:** operation (string: analyze|report|clear|flush), ignore_endpoints (array)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"analyze","ignore_endpoints":["/health"]}'
+```
+
+## draw_history
+Draw session history.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"draw_history"}'
+```
+
+## draw_session
+Load specific draw session.
+**Params:** file (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"draw_session","file":"session-2026-03-12.json"}'
+```
+
+## computed_styles
+Computed CSS styles.
+**Params:** selector (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":".hero-banner"}'
+```
+
+## forms
+Form element analysis.
+**Params:** selector (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"forms","selector":"#login-form"}'
+```
+
+## form_state
+Form field state capture.
+**Params:** selector (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_state","selector":"#checkout-form"}'
+```
+
+## form_validation
+Form validation rules.
+**Params:** summary (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
+```
+
+## data_table
+Data table extraction.
+**Params:** selector (string), max_rows (number), max_cols (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"data_table","selector":"table.results","max_rows":50}'
+```
+
+## visual_baseline
+Visual baseline capture.
+**Params:** name (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_baseline","name":"homepage-v1"}'
+```
+
+## visual_diff
+Visual diff comparison.
+**Params:** name (string), baseline (string), threshold (number, 0-255, default 30)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_diff","name":"homepage-current","baseline":"homepage-v1","threshold":25}'
+```
+
+## visual_baselines
+List visual baselines.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"visual_baselines"}'
+```
+
+## navigation
+Navigation structure analysis.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation"}'
+```
+
+## page_structure
+Page structural analysis.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
+```
+
+## audit
+Comprehensive audit.
+**Params:** categories (array: performance|accessibility|security|best_practices), summary (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"audit","categories":["performance","accessibility"],"summary":true}'
+```
+
+## feature_gates
+Feature flag detection.
+**Params:** none (universal only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"feature_gates"}'
+```

--- a/claude_skill/gasoline/references/configure-modes.md
+++ b/claude_skill/gasoline/references/configure-modes.md
@@ -9,7 +9,7 @@ Persist and retrieve session data.
 **Params:** store_action (save|load|list|delete|stats), namespace (string, default: session), key (string), data (object), value (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"store","store_action":"save","namespace":"session","key":"my_key","value":"my_value"}'
+bash scripts/gasoline-call.sh configure '{"what":"store","store_action":"save","namespace":"session","key":"my_key","value":"my_value"}'
 ```
 
 ## load
@@ -17,7 +17,7 @@ Load persisted data.
 **Params:** namespace (string), key (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"load","namespace":"session","key":"my_key"}'
+bash scripts/gasoline-call.sh configure '{"what":"load","namespace":"session","key":"my_key"}'
 ```
 
 ## clear
@@ -25,7 +25,7 @@ Clear buffers or session data.
 **Params:** buffer (network|websocket|actions|logs|inbox|all)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+bash scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
 ```
 
 ## health
@@ -33,7 +33,7 @@ System health status.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
+bash scripts/gasoline-call.sh configure '{"what":"health"}'
 ```
 
 ## tutorial
@@ -41,7 +41,7 @@ Interactive tutorial.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"tutorial"}'
+bash scripts/gasoline-call.sh configure '{"what":"tutorial"}'
 ```
 
 ## examples
@@ -49,7 +49,7 @@ Usage examples.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"examples"}'
+bash scripts/gasoline-call.sh configure '{"what":"examples"}'
 ```
 
 ## noise_rule
@@ -57,7 +57,7 @@ Manage event noise filtering.
 **Params:** noise_action (add|remove|list|reset|auto_detect), rules (array), classification (string), message_regex (string), source_regex (string), url_regex (string), status_min (int), status_max (int), level (string), rule_id (string), pattern (string), category (console|network|websocket, default: console), reason (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"noise_rule","noise_action":"add","category":"console","message_regex":".*favicon.*","reason":"ignore favicon noise"}'
+bash scripts/gasoline-call.sh configure '{"what":"noise_rule","noise_action":"add","category":"console","message_regex":".*favicon.*","reason":"ignore favicon noise"}'
 ```
 
 ## streaming
@@ -65,7 +65,7 @@ Push notification config.
 **Params:** streaming_action (enable|disable|status), events (array: errors|network_errors|performance|user_frustration|security|regression|anomaly|ci|all), throttle_seconds (int, 1-60), severity_min (info|warning|error)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"streaming","streaming_action":"enable","events":["errors","network_errors"],"throttle_seconds":5}'
+bash scripts/gasoline-call.sh configure '{"what":"streaming","streaming_action":"enable","events":["errors","network_errors"],"throttle_seconds":5}'
 ```
 
 ## test_boundary_start
@@ -73,7 +73,7 @@ Mark test start boundary.
 **Params:** test_id (string), label (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"test_boundary_start","test_id":"t1","label":"login flow test"}'
+bash scripts/gasoline-call.sh configure '{"what":"test_boundary_start","test_id":"t1","label":"login flow test"}'
 ```
 
 ## test_boundary_end
@@ -81,7 +81,7 @@ Mark test end boundary.
 **Params:** test_id (string), label (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"test_boundary_end","test_id":"t1","label":"login flow test"}'
+bash scripts/gasoline-call.sh configure '{"what":"test_boundary_end","test_id":"t1","label":"login flow test"}'
 ```
 
 ## event_recording_start
@@ -89,7 +89,7 @@ Begin event recording session.
 **Params:** name (string), sensitive_data_enabled (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"checkout_flow","sensitive_data_enabled":false}'
+bash scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"checkout_flow","sensitive_data_enabled":false}'
 ```
 
 ## event_recording_stop
@@ -97,7 +97,7 @@ End event recording session.
 **Params:** recording_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_stop","recording_id":"rec_abc123"}'
+bash scripts/gasoline-call.sh configure '{"what":"event_recording_stop","recording_id":"rec_abc123"}'
 ```
 
 ## playback
@@ -105,7 +105,7 @@ Replay recorded events.
 **Params:** recording_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"playback","recording_id":"rec_abc123"}'
+bash scripts/gasoline-call.sh configure '{"what":"playback","recording_id":"rec_abc123"}'
 ```
 
 ## log_diff
@@ -113,7 +113,7 @@ Compare logs between recordings.
 **Params:** original_id (string), replay_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"log_diff","original_id":"rec_abc123","replay_id":"rec_def456"}'
+bash scripts/gasoline-call.sh configure '{"what":"log_diff","original_id":"rec_abc123","replay_id":"rec_def456"}'
 ```
 
 ## telemetry
@@ -121,7 +121,7 @@ Configure telemetry metadata.
 **Params:** telemetry_mode (off|auto|full)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"telemetry","telemetry_mode":"auto"}'
+bash scripts/gasoline-call.sh configure '{"what":"telemetry","telemetry_mode":"auto"}'
 ```
 
 ## describe_capabilities
@@ -129,7 +129,7 @@ List available modes and parameters.
 **Params:** tool (string, optional filter), mode (string, optional filter)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"describe_capabilities","tool":"configure"}'
+bash scripts/gasoline-call.sh configure '{"what":"describe_capabilities","tool":"configure"}'
 ```
 
 ## diff_sessions
@@ -137,7 +137,7 @@ Capture and compare session snapshots.
 **Params:** verif_session_action (capture|compare|list|delete), name (string), compare_a (string), compare_b (string), url (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"before_deploy","url":"https://example.com"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"before_deploy","url":"https://example.com"}'
 ```
 
 ## audit_log
@@ -145,7 +145,7 @@ Analyze tool call history.
 **Params:** operation (analyze|report|clear), audit_session_id (string), tool_name (string), since (ISO 8601), limit (number, default 100, max 1000)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report","limit":50}'
+bash scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report","limit":50}'
 ```
 
 ## restart
@@ -153,7 +153,7 @@ Restart server/extension.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"restart"}'
+bash scripts/gasoline-call.sh configure '{"what":"restart"}'
 ```
 
 ## save_sequence
@@ -161,7 +161,7 @@ Save interaction sequence.
 **Params:** name (string), steps (array), description (string), tags (array)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"tool":"interact","args":{"what":"click","selector":"#login"}}],"description":"Automated login","tags":["auth"]}'
+bash scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"tool":"interact","args":{"what":"click","selector":"#login"}}],"description":"Automated login","tags":["auth"]}'
 ```
 
 ## get_sequence
@@ -169,7 +169,7 @@ Retrieve saved sequence.
 **Params:** name (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"get_sequence","name":"login_flow"}'
+bash scripts/gasoline-call.sh configure '{"what":"get_sequence","name":"login_flow"}'
 ```
 
 ## list_sequences
@@ -177,7 +177,7 @@ List all sequences.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"list_sequences"}'
+bash scripts/gasoline-call.sh configure '{"what":"list_sequences"}'
 ```
 
 ## delete_sequence
@@ -185,7 +185,7 @@ Delete saved sequence.
 **Params:** name (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"delete_sequence","name":"login_flow"}'
+bash scripts/gasoline-call.sh configure '{"what":"delete_sequence","name":"login_flow"}'
 ```
 
 ## replay_sequence
@@ -193,7 +193,7 @@ Replay interaction sequence.
 **Params:** name (string), override_steps (array), step_timeout_ms (number, default 10000), continue_on_error (bool, default true), stop_after_step (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow","step_timeout_ms":15000,"continue_on_error":true}'
+bash scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow","step_timeout_ms":15000,"continue_on_error":true}'
 ```
 
 ## doctor
@@ -201,7 +201,7 @@ Diagnostics and troubleshooting.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+bash scripts/gasoline-call.sh configure '{"what":"doctor"}'
 ```
 
 ## security_mode
@@ -209,7 +209,7 @@ Toggle security proxy mode.
 **Params:** mode (normal|insecure_proxy), confirm (bool, required true for insecure_proxy)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"security_mode","mode":"insecure_proxy","confirm":true}'
+bash scripts/gasoline-call.sh configure '{"what":"security_mode","mode":"insecure_proxy","confirm":true}'
 ```
 
 ## network_recording
@@ -217,7 +217,7 @@ Record HTTP/WebSocket traffic.
 **Params:** operation (start|stop|status), method (string), domain (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"network_recording","operation":"start","domain":"api.example.com"}'
+bash scripts/gasoline-call.sh configure '{"what":"network_recording","operation":"start","domain":"api.example.com"}'
 ```
 
 ## action_jitter
@@ -225,7 +225,7 @@ Add random delays to actions.
 **Params:** action_jitter_ms (number, 0 to disable)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"action_jitter","action_jitter_ms":200}'
+bash scripts/gasoline-call.sh configure '{"what":"action_jitter","action_jitter_ms":200}'
 ```
 
 ## report_issue
@@ -233,5 +233,5 @@ Create and submit issue reports.
 **Params:** operation (list_templates|preview|submit), template (string), title (string), user_context (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"report_issue","operation":"preview","template":"bug","title":"Click fails on modal","user_context":"Happens after popup opens"}'
+bash scripts/gasoline-call.sh configure '{"what":"report_issue","operation":"preview","template":"bug","title":"Click fails on modal","user_context":"Happens after popup opens"}'
 ```

--- a/claude_skill/gasoline/references/configure-modes.md
+++ b/claude_skill/gasoline/references/configure-modes.md
@@ -1,0 +1,237 @@
+# Configure Tool — Mode Reference
+
+29 modes. Universal params on every call: `what` (required), `telemetry_mode` (off|auto|full), `tab_id` (number).
+
+---
+
+## store
+Persist and retrieve session data.
+**Params:** store_action (save|load|list|delete|stats), namespace (string, default: session), key (string), data (object), value (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"store","store_action":"save","namespace":"session","key":"my_key","value":"my_value"}'
+```
+
+## load
+Load persisted data.
+**Params:** namespace (string), key (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"load","namespace":"session","key":"my_key"}'
+```
+
+## clear
+Clear buffers or session data.
+**Params:** buffer (network|websocket|actions|logs|inbox|all)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+```
+
+## health
+System health status.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
+```
+
+## tutorial
+Interactive tutorial.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"tutorial"}'
+```
+
+## examples
+Usage examples.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"examples"}'
+```
+
+## noise_rule
+Manage event noise filtering.
+**Params:** noise_action (add|remove|list|reset|auto_detect), rules (array), classification (string), message_regex (string), source_regex (string), url_regex (string), status_min (int), status_max (int), level (string), rule_id (string), pattern (string), category (console|network|websocket, default: console), reason (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"noise_rule","noise_action":"add","category":"console","message_regex":".*favicon.*","reason":"ignore favicon noise"}'
+```
+
+## streaming
+Push notification config.
+**Params:** streaming_action (enable|disable|status), events (array: errors|network_errors|performance|user_frustration|security|regression|anomaly|ci|all), throttle_seconds (int, 1-60), severity_min (info|warning|error)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"streaming","streaming_action":"enable","events":["errors","network_errors"],"throttle_seconds":5}'
+```
+
+## test_boundary_start
+Mark test start boundary.
+**Params:** test_id (string), label (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"test_boundary_start","test_id":"t1","label":"login flow test"}'
+```
+
+## test_boundary_end
+Mark test end boundary.
+**Params:** test_id (string), label (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"test_boundary_end","test_id":"t1","label":"login flow test"}'
+```
+
+## event_recording_start
+Begin event recording session.
+**Params:** name (string), sensitive_data_enabled (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"checkout_flow","sensitive_data_enabled":false}'
+```
+
+## event_recording_stop
+End event recording session.
+**Params:** recording_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_stop","recording_id":"rec_abc123"}'
+```
+
+## playback
+Replay recorded events.
+**Params:** recording_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"playback","recording_id":"rec_abc123"}'
+```
+
+## log_diff
+Compare logs between recordings.
+**Params:** original_id (string), replay_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"log_diff","original_id":"rec_abc123","replay_id":"rec_def456"}'
+```
+
+## telemetry
+Configure telemetry metadata.
+**Params:** telemetry_mode (off|auto|full)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"telemetry","telemetry_mode":"auto"}'
+```
+
+## describe_capabilities
+List available modes and parameters.
+**Params:** tool (string, optional filter), mode (string, optional filter)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"describe_capabilities","tool":"configure"}'
+```
+
+## diff_sessions
+Capture and compare session snapshots.
+**Params:** verif_session_action (capture|compare|list|delete), name (string), compare_a (string), compare_b (string), url (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"before_deploy","url":"https://example.com"}'
+```
+
+## audit_log
+Analyze tool call history.
+**Params:** operation (analyze|report|clear), audit_session_id (string), tool_name (string), since (ISO 8601), limit (number, default 100, max 1000)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report","limit":50}'
+```
+
+## restart
+Restart server/extension.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"restart"}'
+```
+
+## save_sequence
+Save interaction sequence.
+**Params:** name (string), steps (array), description (string), tags (array)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"tool":"interact","args":{"what":"click","selector":"#login"}}],"description":"Automated login","tags":["auth"]}'
+```
+
+## get_sequence
+Retrieve saved sequence.
+**Params:** name (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"get_sequence","name":"login_flow"}'
+```
+
+## list_sequences
+List all sequences.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"list_sequences"}'
+```
+
+## delete_sequence
+Delete saved sequence.
+**Params:** name (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"delete_sequence","name":"login_flow"}'
+```
+
+## replay_sequence
+Replay interaction sequence.
+**Params:** name (string), override_steps (array), step_timeout_ms (number, default 10000), continue_on_error (bool, default true), stop_after_step (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow","step_timeout_ms":15000,"continue_on_error":true}'
+```
+
+## doctor
+Diagnostics and troubleshooting.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+```
+
+## security_mode
+Toggle security proxy mode.
+**Params:** mode (normal|insecure_proxy), confirm (bool, required true for insecure_proxy)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"security_mode","mode":"insecure_proxy","confirm":true}'
+```
+
+## network_recording
+Record HTTP/WebSocket traffic.
+**Params:** operation (start|stop|status), method (string), domain (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"network_recording","operation":"start","domain":"api.example.com"}'
+```
+
+## action_jitter
+Add random delays to actions.
+**Params:** action_jitter_ms (number, 0 to disable)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"action_jitter","action_jitter_ms":200}'
+```
+
+## report_issue
+Create and submit issue reports.
+**Params:** operation (list_templates|preview|submit), template (string), title (string), user_context (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"report_issue","operation":"preview","template":"bug","title":"Click fails on modal","user_context":"Happens after popup opens"}'
+```

--- a/claude_skill/gasoline/references/generate-modes.md
+++ b/claude_skill/gasoline/references/generate-modes.md
@@ -1,0 +1,109 @@
+# Generate Tool — Mode Reference
+
+All modes require `what` (string). Universal optional params: `telemetry_mode` (off|auto|full), `save_to` (string).
+
+---
+
+## reproduction
+Generate bug reproduction script from captured actions.
+**Params:** error_message (string), last_n (number), base_url (string), include_screenshots (bool), generate_fixtures (bool), visual_assertions (bool), output_format (gasoline-agentic-browser|playwright), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"reproduction","error_message":"TypeError: undefined is not a function","last_n":10,"output_format":"playwright"}'
+```
+
+## test
+Generate test script from captured data.
+**Params:** test_name (string), assert_network (bool), assert_no_errors (bool), assert_response_shape (bool), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"login-flow","assert_network":true,"assert_no_errors":true}'
+```
+
+## pr_summary
+Generate PR summary from captured data.
+**Params:** save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
+```
+
+## har
+Generate HAR file from network data.
+**Params:** url (string), method (string), status_min (number), status_max (number), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"har","url":"api.example.com","method":"POST","status_min":400,"status_max":599}'
+```
+
+## csp
+Generate Content Security Policy.
+**Params:** mode (strict|moderate|report_only), include_report_uri (bool), exclude_origins (array of strings), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict","include_report_uri":true,"exclude_origins":["analytics.example.com"]}'
+```
+
+## sri
+Generate Subresource Integrity hashes.
+**Params:** resource_types (array: script|stylesheet), origins (array of strings), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sri","resource_types":["script","stylesheet"],"origins":["cdn.example.com"]}'
+```
+
+## sarif
+Generate SARIF static analysis results.
+**Params:** scope (string), include_passes (bool), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sarif","scope":"security","include_passes":false}'
+```
+
+## visual_test
+Generate visual assertion test.
+**Params:** test_name (string), annot_session (string), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"visual_test","test_name":"homepage-layout","annot_session":"sess_abc123"}'
+```
+
+## annotation_report
+Generate annotation report.
+**Params:** annot_session (string), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_report","annot_session":"sess_abc123"}'
+```
+
+## annotation_issues
+Generate annotation issues.
+**Params:** annot_session (string), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_issues","annot_session":"sess_abc123"}'
+```
+
+## test_from_context
+Generate test from error/interaction/regression context.
+**Params:** context (required, enum: error|interaction|regression), error_id (string), include_mocks (bool), output_format (file|inline), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"err_42","include_mocks":true,"output_format":"file"}'
+```
+
+## test_heal
+Analyze and repair broken test selectors.
+**Params:** action (analyze|repair|batch), test_file (string, for analyze), test_dir (string, for batch), broken_selectors (array, for repair), auto_apply (bool, for repair), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_heal","action":"analyze","test_file":"tests/login.spec.ts"}'
+```
+
+## test_classify
+Classify test failures.
+**Params:** action (failure|batch), failure (object with error required + test_name, screenshot, trace, duration_ms optional), failures (array of failure objects for batch), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_classify","action":"failure","failure":{"error":"Element not found: #submit-btn","test_name":"checkout.spec.ts"}}'
+```

--- a/claude_skill/gasoline/references/generate-modes.md
+++ b/claude_skill/gasoline/references/generate-modes.md
@@ -9,7 +9,7 @@ Generate bug reproduction script from captured actions.
 **Params:** error_message (string), last_n (number), base_url (string), include_screenshots (bool), generate_fixtures (bool), visual_assertions (bool), output_format (gasoline-agentic-browser|playwright), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"reproduction","error_message":"TypeError: undefined is not a function","last_n":10,"output_format":"playwright"}'
+bash scripts/gasoline-call.sh generate '{"what":"reproduction","error_message":"TypeError: undefined is not a function","last_n":10,"output_format":"playwright"}'
 ```
 
 ## test
@@ -17,7 +17,7 @@ Generate test script from captured data.
 **Params:** test_name (string), assert_network (bool), assert_no_errors (bool), assert_response_shape (bool), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"login-flow","assert_network":true,"assert_no_errors":true}'
+bash scripts/gasoline-call.sh generate '{"what":"test","test_name":"login-flow","assert_network":true,"assert_no_errors":true}'
 ```
 
 ## pr_summary
@@ -25,7 +25,7 @@ Generate PR summary from captured data.
 **Params:** save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
+bash scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
 ```
 
 ## har
@@ -33,7 +33,7 @@ Generate HAR file from network data.
 **Params:** url (string), method (string), status_min (number), status_max (number), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"har","url":"api.example.com","method":"POST","status_min":400,"status_max":599}'
+bash scripts/gasoline-call.sh generate '{"what":"har","url":"api.example.com","method":"POST","status_min":400,"status_max":599}'
 ```
 
 ## csp
@@ -41,7 +41,7 @@ Generate Content Security Policy.
 **Params:** mode (strict|moderate|report_only), include_report_uri (bool), exclude_origins (array of strings), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict","include_report_uri":true,"exclude_origins":["analytics.example.com"]}'
+bash scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict","include_report_uri":true,"exclude_origins":["analytics.example.com"]}'
 ```
 
 ## sri
@@ -49,7 +49,7 @@ Generate Subresource Integrity hashes.
 **Params:** resource_types (array: script|stylesheet), origins (array of strings), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sri","resource_types":["script","stylesheet"],"origins":["cdn.example.com"]}'
+bash scripts/gasoline-call.sh generate '{"what":"sri","resource_types":["script","stylesheet"],"origins":["cdn.example.com"]}'
 ```
 
 ## sarif
@@ -57,7 +57,7 @@ Generate SARIF static analysis results.
 **Params:** scope (string), include_passes (bool), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sarif","scope":"security","include_passes":false}'
+bash scripts/gasoline-call.sh generate '{"what":"sarif","scope":"security","include_passes":false}'
 ```
 
 ## visual_test
@@ -65,7 +65,7 @@ Generate visual assertion test.
 **Params:** test_name (string), annot_session (string), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"visual_test","test_name":"homepage-layout","annot_session":"sess_abc123"}'
+bash scripts/gasoline-call.sh generate '{"what":"visual_test","test_name":"homepage-layout","annot_session":"sess_abc123"}'
 ```
 
 ## annotation_report
@@ -73,7 +73,7 @@ Generate annotation report.
 **Params:** annot_session (string), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_report","annot_session":"sess_abc123"}'
+bash scripts/gasoline-call.sh generate '{"what":"annotation_report","annot_session":"sess_abc123"}'
 ```
 
 ## annotation_issues
@@ -81,7 +81,7 @@ Generate annotation issues.
 **Params:** annot_session (string), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_issues","annot_session":"sess_abc123"}'
+bash scripts/gasoline-call.sh generate '{"what":"annotation_issues","annot_session":"sess_abc123"}'
 ```
 
 ## test_from_context
@@ -89,7 +89,7 @@ Generate test from error/interaction/regression context.
 **Params:** context (required, enum: error|interaction|regression), error_id (string), include_mocks (bool), output_format (file|inline), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"err_42","include_mocks":true,"output_format":"file"}'
+bash scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"err_42","include_mocks":true,"output_format":"file"}'
 ```
 
 ## test_heal
@@ -97,7 +97,7 @@ Analyze and repair broken test selectors.
 **Params:** action (analyze|repair|batch), test_file (string, for analyze), test_dir (string, for batch), broken_selectors (array, for repair), auto_apply (bool, for repair), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_heal","action":"analyze","test_file":"tests/login.spec.ts"}'
+bash scripts/gasoline-call.sh generate '{"what":"test_heal","action":"analyze","test_file":"tests/login.spec.ts"}'
 ```
 
 ## test_classify
@@ -105,5 +105,5 @@ Classify test failures.
 **Params:** action (failure|batch), failure (object with error required + test_name, screenshot, trace, duration_ms optional), failures (array of failure objects for batch), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_classify","action":"failure","failure":{"error":"Element not found: #submit-btn","test_name":"checkout.spec.ts"}}'
+bash scripts/gasoline-call.sh generate '{"what":"test_classify","action":"failure","failure":{"error":"Element not found: #submit-btn","test_name":"checkout.spec.ts"}}'
 ```

--- a/claude_skill/gasoline/references/interact-actions.md
+++ b/claude_skill/gasoline/references/interact-actions.md
@@ -1,0 +1,558 @@
+# Interact Tool — Action Reference
+
+59 actions + 6 aliases grouped by category.
+
+**Targeting params** (most DOM actions): `selector`, `element_id`, `index`, `index_generation`, `nth`, `x`, `y`, `scope_selector`, `scope_rect`, `frame`
+
+**Enrichment params:** `include_screenshot`, `include_interactive`, `action_diff`, `evidence` (off|on_mutation|always), `observe_mutations`, `wait_for_stable`, `stability_ms`, `analyze`, `subtitle`
+
+**Dispatch params:** `what` (required), `telemetry_mode`, `background`, `reason`, `correlation_id`
+
+---
+
+# Navigation
+
+## navigate
+Navigate to a URL in the tracked tab or a new tab.
+**Params:** `url` (string, required), `include_content` (bool), `new_tab` (bool), `analyze` (bool), `auto_dismiss` (bool), `wait_for_stable` (bool), `stability_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"https://example.com"}'
+```
+
+## refresh
+Reload the current page.
+**Params:** `analyze` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"refresh"}'
+```
+
+## back
+Navigate back in browser history.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"back"}'
+```
+
+## forward
+Navigate forward in browser history.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"forward"}'
+```
+
+## new_tab
+Open a new browser tab.
+**Params:** `url` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"new_tab","url":"https://example.com"}'
+```
+
+## switch_tab
+Switch to a different browser tab.
+**Params:** `tab_id` (number), `tab_index` (number), `set_tracked` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":2,"set_tracked":true}'
+```
+
+## close_tab
+Close a browser tab.
+**Params:** `tab_id` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"close_tab","tab_id":123}'
+```
+
+## navigate_and_wait_for
+Navigate to a URL and wait for a specific selector to appear.
+**Params:** `url` (string, required), `wait_for` (string, required), `include_content` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate_and_wait_for","url":"https://example.com","wait_for":"#main-content"}'
+```
+
+## navigate_and_document
+Click an element to navigate and document the result.
+**Params:** `selector` (string), `element_id` (string), `index` (number), `timeout_ms` (number), `wait_for_url_change` (bool), `wait_for_stable` (bool), `stability_ms` (number), `include_screenshot` (bool), `include_interactive` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate_and_document","selector":"a.nav-link","include_screenshot":true}'
+```
+
+---
+
+# DOM Interaction
+
+## click
+Click an element on the page.
+**Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `reason` (string), `correlation_id` (string), `timeout_ms` (number), `x` (number), `y` (number), `analyze` (bool), `wait_for_stable` (bool), `stability_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
+```
+
+## type
+Type text into an input element.
+**Params:** `text` (string, required), `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `clear` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"type","selector":"#search","text":"hello world","clear":true}'
+```
+
+## select
+Choose an option from a dropdown element.
+**Params:** `value` (string, required), `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"select","selector":"#country","value":"US"}'
+```
+
+## check
+Toggle a checkbox or radio button.
+**Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `checked` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"check","selector":"#agree-terms","checked":true}'
+```
+
+## focus
+Focus an element.
+**Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"focus","selector":"#email-input"}'
+```
+
+## hover
+Hover over an element.
+**Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"hover","selector":".dropdown-trigger"}'
+```
+
+## scroll_to
+Scroll an element into view or scroll the page directionally.
+**Params:** `selector` (string), `element_id` (string), `direction` (string: top|bottom|up|down)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
+```
+
+## key_press
+Send keyboard key presses.
+**Params:** `text` (string: Enter|Tab|Escape|Backspace|ArrowDown|ArrowUp|Space)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"key_press","text":"Enter"}'
+```
+
+## paste
+Paste text via the clipboard into an element.
+**Params:** `text` (string, required), `selector` (string), `element_id` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"paste","text":"pasted content","selector":"#editor"}'
+```
+
+## hardware_click
+CDP-level click at exact viewport coordinates.
+**Params:** `x` (number), `y` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"hardware_click","x":150,"y":300}'
+```
+
+## highlight
+Highlight an element with a visual overlay.
+**Params:** `selector` (string), `element_id` (string), `duration_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"highlight","selector":".target-element","duration_ms":3000}'
+```
+
+---
+
+# DOM Reading
+
+## get_text
+Read the text content of an element.
+**Params:** `selector` (string), `element_id` (string), `structured` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_text","selector":"h1"}'
+```
+
+## get_value
+Read the current value of an input element.
+**Params:** `selector` (string), `element_id` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_value","selector":"#username"}'
+```
+
+## get_attribute
+Read an HTML attribute from an element.
+**Params:** `name` (string, required), `selector` (string), `element_id` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_attribute","selector":"a.link","name":"href"}'
+```
+
+## query
+Query the DOM for existence, count, text, or attributes.
+**Params:** `selector` (string), `query_type` (string: exists|count|text|text_all|attributes), `attribute_names` (array of strings)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"query","selector":".item","query_type":"count"}'
+```
+
+## set_attribute
+Set an HTML attribute on an element.
+**Params:** `name` (string, required), `selector` (string), `value` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_attribute","selector":"#logo","name":"alt","value":"Company Logo"}'
+```
+
+---
+
+# Page Discovery
+
+## explore_page
+Composite page exploration returning screenshot, interactive elements, text, navigation, and metadata.
+**Params:** `url` (string), `visible_only` (bool), `limit` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page","visible_only":true,"limit":50}'
+```
+
+## list_interactive
+List all clickable and typeable elements on the page.
+**Params:** `visible_only` (bool), `frame` (string), `scope_selector` (string), `scope_rect` (object), `text_contains` (string), `role` (string), `exclude_nav` (bool), `limit` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true,"role":"button"}'
+```
+
+## get_readable
+Extract readable text content from the page.
+**Params:** `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_readable"}'
+```
+
+## get_markdown
+Extract the page content as markdown.
+**Params:** `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_markdown"}'
+```
+
+## screenshot
+Capture a screenshot of the current page (alias for observe/screenshot).
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screenshot"}'
+```
+
+---
+
+# Forms
+
+## fill_form
+Fill multiple form fields at once.
+**Params:** `fields` (array of `{selector, value, index}`, required), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form","fields":[{"selector":"#name","value":"Jane"},{"selector":"#email","value":"jane@example.com"}]}'
+```
+
+## fill_form_and_submit
+Fill form fields and click the submit button.
+**Params:** `fields` (array of `{selector, value, index}`), `submit_selector` (string), `submit_index` (number), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#user","value":"admin"}],"submit_selector":"button[type=submit]"}'
+```
+
+---
+
+# Wait & Stability
+
+## wait_for
+Wait for a selector, text, or URL pattern to appear.
+**Params:** `selector` (string), `timeout_ms` (number), `frame` (string), `absent` (bool), `url_contains` (string), `text` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".loaded","timeout_ms":5000}'
+```
+
+## wait_for_stable
+Wait for the DOM to stabilize (no mutations for a period).
+**Params:** `stability_ms` (number), `timeout_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":500,"timeout_ms":10000}'
+```
+
+## auto_dismiss_overlays
+Automatically dismiss cookie banners, consent dialogs, and overlays.
+**Params:** `timeout_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"auto_dismiss_overlays","timeout_ms":3000}'
+```
+
+---
+
+# Dialog & Overlay
+
+## confirm_top_dialog
+Accept the top-most dialog or modal.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"confirm_top_dialog"}'
+```
+
+## dismiss_top_overlay
+Close the top-most overlay or popover.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"dismiss_top_overlay"}'
+```
+
+## subtitle
+Display a status subtitle in the extension UI.
+**Params:** `text` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"subtitle","text":"Processing step 3 of 5..."}'
+```
+
+---
+
+# State Management
+
+## save_state
+Snapshot cookies, storage, and/or URL into a named state.
+**Params:** `snapshot_name` (string, required), `storage_type` (string), `include_url` (bool)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"save_state","snapshot_name":"logged_in","include_url":true}'
+```
+
+## load_state
+Restore a previously saved state snapshot.
+**Params:** `snapshot_name` (string, required), `storage_type` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"load_state","snapshot_name":"logged_in"}'
+```
+
+## list_states
+List all saved state snapshots.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_states"}'
+```
+
+## delete_state
+Delete a saved state snapshot.
+**Params:** `snapshot_name` (string, required)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_state","snapshot_name":"logged_in"}'
+```
+
+---
+
+# Storage
+
+## set_storage
+Set a key in localStorage or sessionStorage.
+**Params:** `key` (string, required), `storage_type` (string), `value` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_storage","key":"theme","value":"dark","storage_type":"local"}'
+```
+
+## delete_storage
+Delete a key from localStorage or sessionStorage.
+**Params:** `key` (string, required), `storage_type` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_storage","key":"theme","storage_type":"local"}'
+```
+
+## clear_storage
+Clear all keys from localStorage or sessionStorage.
+**Params:** `storage_type` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clear_storage","storage_type":"session"}'
+```
+
+## set_cookie
+Set a browser cookie.
+**Params:** `name` (string, required), `value` (string), `domain` (string), `path` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_cookie","name":"session_id","value":"abc123","domain":".example.com"}'
+```
+
+## delete_cookie
+Delete a browser cookie.
+**Params:** `name` (string, required), `domain` (string), `path` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_cookie","name":"session_id","domain":".example.com"}'
+```
+
+---
+
+# Clipboard
+
+## clipboard_read
+Read the current clipboard text content.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clipboard_read"}'
+```
+
+## clipboard_write
+Write text to the clipboard.
+**Params:** `text` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clipboard_write","text":"copied text"}'
+```
+
+---
+
+# JavaScript
+
+## execute_js
+Run JavaScript in the page context.
+**Params:** `script` (string, required), `world` (string: auto|main|isolated), `timeout_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"execute_js","script":"document.title","world":"main"}'
+```
+
+---
+
+# Recording
+
+## screen_recording_start
+Start a video recording of the browser tab.
+**Params:** `name` (string), `audio` (string: tab|mic|both), `fps` (number, 5-60, default 15)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"test_run","fps":30}'
+```
+
+## screen_recording_stop
+Stop a video recording.
+**Params:** `name` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"test_run"}'
+```
+
+---
+
+# File Upload
+
+## upload
+Upload a file to a file input or API endpoint.
+**Params:** `file_path` (string), `api_endpoint` (string), `submit` (bool), `escalation_timeout_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"upload","file_path":"/tmp/document.pdf","submit":true}'
+```
+
+---
+
+# Annotation
+
+## draw_mode_start
+Activate the annotation drawing overlay.
+**Params:** `annot_session` (string), `timeout_ms` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"draw_mode_start","annot_session":"review_1","timeout_ms":60000}'
+```
+
+## run_a11y_and_export_sarif
+Run an accessibility audit and export results as SARIF.
+**Params:** `save_to` (string), `scope_selector` (string), `frame` (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"/tmp/a11y-report.sarif"}'
+```
+
+---
+
+# Composer (Claude-specific)
+
+## open_composer
+Open the Claude composer interface.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"open_composer"}'
+```
+
+## submit_active_composer
+Submit the message in the active Claude composer.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"submit_active_composer"}'
+```
+
+## activate_tab
+Bring the tracked browser tab to the foreground.
+**Params:** none
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"activate_tab"}'
+```
+
+---
+
+# Batch
+
+## batch
+Execute a sequence of interact actions in order.
+**Params:** `steps` (array of action objects, required), `step_timeout_ms` (number, default 10000), `continue_on_error` (bool, default true), `stop_after_step` (number)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"click","selector":"#login"},{"what":"type","selector":"#user","text":"admin"},{"what":"key_press","text":"Enter"}]}'
+```
+
+---
+
+# Aliases
+
+| Alias | Canonical Action |
+|-------|-----------------|
+| `state_save` | `save_state` |
+| `state_load` | `load_state` |
+| `state_list` | `list_states` |
+| `state_delete` | `delete_state` |
+| `record_start` | `screen_recording_start` |
+| `record_stop` | `screen_recording_stop` |

--- a/claude_skill/gasoline/references/interact-actions.md
+++ b/claude_skill/gasoline/references/interact-actions.md
@@ -17,7 +17,7 @@ Navigate to a URL in the tracked tab or a new tab.
 **Params:** `url` (string, required), `include_content` (bool), `new_tab` (bool), `analyze` (bool), `auto_dismiss` (bool), `wait_for_stable` (bool), `stability_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"https://example.com"}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"https://example.com"}'
 ```
 
 ## refresh
@@ -25,7 +25,7 @@ Reload the current page.
 **Params:** `analyze` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"refresh"}'
+bash scripts/gasoline-call.sh interact '{"what":"refresh"}'
 ```
 
 ## back
@@ -33,7 +33,7 @@ Navigate back in browser history.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"back"}'
+bash scripts/gasoline-call.sh interact '{"what":"back"}'
 ```
 
 ## forward
@@ -41,7 +41,7 @@ Navigate forward in browser history.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"forward"}'
+bash scripts/gasoline-call.sh interact '{"what":"forward"}'
 ```
 
 ## new_tab
@@ -49,7 +49,7 @@ Open a new browser tab.
 **Params:** `url` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"new_tab","url":"https://example.com"}'
+bash scripts/gasoline-call.sh interact '{"what":"new_tab","url":"https://example.com"}'
 ```
 
 ## switch_tab
@@ -57,7 +57,7 @@ Switch to a different browser tab.
 **Params:** `tab_id` (number), `tab_index` (number), `set_tracked` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":2,"set_tracked":true}'
+bash scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":2,"set_tracked":true}'
 ```
 
 ## close_tab
@@ -65,7 +65,7 @@ Close a browser tab.
 **Params:** `tab_id` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"close_tab","tab_id":123}'
+bash scripts/gasoline-call.sh interact '{"what":"close_tab","tab_id":123}'
 ```
 
 ## navigate_and_wait_for
@@ -73,7 +73,7 @@ Navigate to a URL and wait for a specific selector to appear.
 **Params:** `url` (string, required), `wait_for` (string, required), `include_content` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate_and_wait_for","url":"https://example.com","wait_for":"#main-content"}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate_and_wait_for","url":"https://example.com","wait_for":"#main-content"}'
 ```
 
 ## navigate_and_document
@@ -81,7 +81,7 @@ Click an element to navigate and document the result.
 **Params:** `selector` (string), `element_id` (string), `index` (number), `timeout_ms` (number), `wait_for_url_change` (bool), `wait_for_stable` (bool), `stability_ms` (number), `include_screenshot` (bool), `include_interactive` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate_and_document","selector":"a.nav-link","include_screenshot":true}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate_and_document","selector":"a.nav-link","include_screenshot":true}'
 ```
 
 ---
@@ -93,7 +93,7 @@ Click an element on the page.
 **Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `reason` (string), `correlation_id` (string), `timeout_ms` (number), `x` (number), `y` (number), `analyze` (bool), `wait_for_stable` (bool), `stability_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
 ```
 
 ## type
@@ -101,7 +101,7 @@ Type text into an input element.
 **Params:** `text` (string, required), `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `clear` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"type","selector":"#search","text":"hello world","clear":true}'
+bash scripts/gasoline-call.sh interact '{"what":"type","selector":"#search","text":"hello world","clear":true}'
 ```
 
 ## select
@@ -109,7 +109,7 @@ Choose an option from a dropdown element.
 **Params:** `value` (string, required), `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"select","selector":"#country","value":"US"}'
+bash scripts/gasoline-call.sh interact '{"what":"select","selector":"#country","value":"US"}'
 ```
 
 ## check
@@ -117,7 +117,7 @@ Toggle a checkbox or radio button.
 **Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string), `checked` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"check","selector":"#agree-terms","checked":true}'
+bash scripts/gasoline-call.sh interact '{"what":"check","selector":"#agree-terms","checked":true}'
 ```
 
 ## focus
@@ -125,7 +125,7 @@ Focus an element.
 **Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"focus","selector":"#email-input"}'
+bash scripts/gasoline-call.sh interact '{"what":"focus","selector":"#email-input"}'
 ```
 
 ## hover
@@ -133,7 +133,7 @@ Hover over an element.
 **Params:** `selector` (string), `element_id` (string), `index` (number), `nth` (number), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"hover","selector":".dropdown-trigger"}'
+bash scripts/gasoline-call.sh interact '{"what":"hover","selector":".dropdown-trigger"}'
 ```
 
 ## scroll_to
@@ -141,7 +141,7 @@ Scroll an element into view or scroll the page directionally.
 **Params:** `selector` (string), `element_id` (string), `direction` (string: top|bottom|up|down)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
+bash scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
 ```
 
 ## key_press
@@ -149,7 +149,7 @@ Send keyboard key presses.
 **Params:** `text` (string: Enter|Tab|Escape|Backspace|ArrowDown|ArrowUp|Space)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"key_press","text":"Enter"}'
+bash scripts/gasoline-call.sh interact '{"what":"key_press","text":"Enter"}'
 ```
 
 ## paste
@@ -157,7 +157,7 @@ Paste text via the clipboard into an element.
 **Params:** `text` (string, required), `selector` (string), `element_id` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"paste","text":"pasted content","selector":"#editor"}'
+bash scripts/gasoline-call.sh interact '{"what":"paste","text":"pasted content","selector":"#editor"}'
 ```
 
 ## hardware_click
@@ -165,7 +165,7 @@ CDP-level click at exact viewport coordinates.
 **Params:** `x` (number), `y` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"hardware_click","x":150,"y":300}'
+bash scripts/gasoline-call.sh interact '{"what":"hardware_click","x":150,"y":300}'
 ```
 
 ## highlight
@@ -173,7 +173,7 @@ Highlight an element with a visual overlay.
 **Params:** `selector` (string), `element_id` (string), `duration_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"highlight","selector":".target-element","duration_ms":3000}'
+bash scripts/gasoline-call.sh interact '{"what":"highlight","selector":".target-element","duration_ms":3000}'
 ```
 
 ---
@@ -185,7 +185,7 @@ Read the text content of an element.
 **Params:** `selector` (string), `element_id` (string), `structured` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_text","selector":"h1"}'
+bash scripts/gasoline-call.sh interact '{"what":"get_text","selector":"h1"}'
 ```
 
 ## get_value
@@ -193,7 +193,7 @@ Read the current value of an input element.
 **Params:** `selector` (string), `element_id` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_value","selector":"#username"}'
+bash scripts/gasoline-call.sh interact '{"what":"get_value","selector":"#username"}'
 ```
 
 ## get_attribute
@@ -201,7 +201,7 @@ Read an HTML attribute from an element.
 **Params:** `name` (string, required), `selector` (string), `element_id` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_attribute","selector":"a.link","name":"href"}'
+bash scripts/gasoline-call.sh interact '{"what":"get_attribute","selector":"a.link","name":"href"}'
 ```
 
 ## query
@@ -209,7 +209,7 @@ Query the DOM for existence, count, text, or attributes.
 **Params:** `selector` (string), `query_type` (string: exists|count|text|text_all|attributes), `attribute_names` (array of strings)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"query","selector":".item","query_type":"count"}'
+bash scripts/gasoline-call.sh interact '{"what":"query","selector":".item","query_type":"count"}'
 ```
 
 ## set_attribute
@@ -217,7 +217,7 @@ Set an HTML attribute on an element.
 **Params:** `name` (string, required), `selector` (string), `value` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_attribute","selector":"#logo","name":"alt","value":"Company Logo"}'
+bash scripts/gasoline-call.sh interact '{"what":"set_attribute","selector":"#logo","name":"alt","value":"Company Logo"}'
 ```
 
 ---
@@ -229,7 +229,7 @@ Composite page exploration returning screenshot, interactive elements, text, nav
 **Params:** `url` (string), `visible_only` (bool), `limit` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page","visible_only":true,"limit":50}'
+bash scripts/gasoline-call.sh interact '{"what":"explore_page","visible_only":true,"limit":50}'
 ```
 
 ## list_interactive
@@ -237,7 +237,7 @@ List all clickable and typeable elements on the page.
 **Params:** `visible_only` (bool), `frame` (string), `scope_selector` (string), `scope_rect` (object), `text_contains` (string), `role` (string), `exclude_nav` (bool), `limit` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true,"role":"button"}'
+bash scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true,"role":"button"}'
 ```
 
 ## get_readable
@@ -245,7 +245,7 @@ Extract readable text content from the page.
 **Params:** `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_readable"}'
+bash scripts/gasoline-call.sh interact '{"what":"get_readable"}'
 ```
 
 ## get_markdown
@@ -253,7 +253,7 @@ Extract the page content as markdown.
 **Params:** `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"get_markdown"}'
+bash scripts/gasoline-call.sh interact '{"what":"get_markdown"}'
 ```
 
 ## screenshot
@@ -261,7 +261,7 @@ Capture a screenshot of the current page (alias for observe/screenshot).
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screenshot"}'
+bash scripts/gasoline-call.sh interact '{"what":"screenshot"}'
 ```
 
 ---
@@ -273,7 +273,7 @@ Fill multiple form fields at once.
 **Params:** `fields` (array of `{selector, value, index}`, required), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form","fields":[{"selector":"#name","value":"Jane"},{"selector":"#email","value":"jane@example.com"}]}'
+bash scripts/gasoline-call.sh interact '{"what":"fill_form","fields":[{"selector":"#name","value":"Jane"},{"selector":"#email","value":"jane@example.com"}]}'
 ```
 
 ## fill_form_and_submit
@@ -281,7 +281,7 @@ Fill form fields and click the submit button.
 **Params:** `fields` (array of `{selector, value, index}`), `submit_selector` (string), `submit_index` (number), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#user","value":"admin"}],"submit_selector":"button[type=submit]"}'
+bash scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#user","value":"admin"}],"submit_selector":"button[type=submit]"}'
 ```
 
 ---
@@ -293,7 +293,7 @@ Wait for a selector, text, or URL pattern to appear.
 **Params:** `selector` (string), `timeout_ms` (number), `frame` (string), `absent` (bool), `url_contains` (string), `text` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".loaded","timeout_ms":5000}'
+bash scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".loaded","timeout_ms":5000}'
 ```
 
 ## wait_for_stable
@@ -301,7 +301,7 @@ Wait for the DOM to stabilize (no mutations for a period).
 **Params:** `stability_ms` (number), `timeout_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":500,"timeout_ms":10000}'
+bash scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":500,"timeout_ms":10000}'
 ```
 
 ## auto_dismiss_overlays
@@ -309,7 +309,7 @@ Automatically dismiss cookie banners, consent dialogs, and overlays.
 **Params:** `timeout_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"auto_dismiss_overlays","timeout_ms":3000}'
+bash scripts/gasoline-call.sh interact '{"what":"auto_dismiss_overlays","timeout_ms":3000}'
 ```
 
 ---
@@ -321,7 +321,7 @@ Accept the top-most dialog or modal.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"confirm_top_dialog"}'
+bash scripts/gasoline-call.sh interact '{"what":"confirm_top_dialog"}'
 ```
 
 ## dismiss_top_overlay
@@ -329,7 +329,7 @@ Close the top-most overlay or popover.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"dismiss_top_overlay"}'
+bash scripts/gasoline-call.sh interact '{"what":"dismiss_top_overlay"}'
 ```
 
 ## subtitle
@@ -337,7 +337,7 @@ Display a status subtitle in the extension UI.
 **Params:** `text` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"subtitle","text":"Processing step 3 of 5..."}'
+bash scripts/gasoline-call.sh interact '{"what":"subtitle","text":"Processing step 3 of 5..."}'
 ```
 
 ---
@@ -349,7 +349,7 @@ Snapshot cookies, storage, and/or URL into a named state.
 **Params:** `snapshot_name` (string, required), `storage_type` (string), `include_url` (bool)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"save_state","snapshot_name":"logged_in","include_url":true}'
+bash scripts/gasoline-call.sh interact '{"what":"save_state","snapshot_name":"logged_in","include_url":true}'
 ```
 
 ## load_state
@@ -357,7 +357,7 @@ Restore a previously saved state snapshot.
 **Params:** `snapshot_name` (string, required), `storage_type` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"load_state","snapshot_name":"logged_in"}'
+bash scripts/gasoline-call.sh interact '{"what":"load_state","snapshot_name":"logged_in"}'
 ```
 
 ## list_states
@@ -365,7 +365,7 @@ List all saved state snapshots.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_states"}'
+bash scripts/gasoline-call.sh interact '{"what":"list_states"}'
 ```
 
 ## delete_state
@@ -373,7 +373,7 @@ Delete a saved state snapshot.
 **Params:** `snapshot_name` (string, required)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_state","snapshot_name":"logged_in"}'
+bash scripts/gasoline-call.sh interact '{"what":"delete_state","snapshot_name":"logged_in"}'
 ```
 
 ---
@@ -385,7 +385,7 @@ Set a key in localStorage or sessionStorage.
 **Params:** `key` (string, required), `storage_type` (string), `value` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_storage","key":"theme","value":"dark","storage_type":"local"}'
+bash scripts/gasoline-call.sh interact '{"what":"set_storage","key":"theme","value":"dark","storage_type":"local"}'
 ```
 
 ## delete_storage
@@ -393,7 +393,7 @@ Delete a key from localStorage or sessionStorage.
 **Params:** `key` (string, required), `storage_type` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_storage","key":"theme","storage_type":"local"}'
+bash scripts/gasoline-call.sh interact '{"what":"delete_storage","key":"theme","storage_type":"local"}'
 ```
 
 ## clear_storage
@@ -401,7 +401,7 @@ Clear all keys from localStorage or sessionStorage.
 **Params:** `storage_type` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clear_storage","storage_type":"session"}'
+bash scripts/gasoline-call.sh interact '{"what":"clear_storage","storage_type":"session"}'
 ```
 
 ## set_cookie
@@ -409,7 +409,7 @@ Set a browser cookie.
 **Params:** `name` (string, required), `value` (string), `domain` (string), `path` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"set_cookie","name":"session_id","value":"abc123","domain":".example.com"}'
+bash scripts/gasoline-call.sh interact '{"what":"set_cookie","name":"session_id","value":"abc123","domain":".example.com"}'
 ```
 
 ## delete_cookie
@@ -417,7 +417,7 @@ Delete a browser cookie.
 **Params:** `name` (string, required), `domain` (string), `path` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"delete_cookie","name":"session_id","domain":".example.com"}'
+bash scripts/gasoline-call.sh interact '{"what":"delete_cookie","name":"session_id","domain":".example.com"}'
 ```
 
 ---
@@ -429,7 +429,7 @@ Read the current clipboard text content.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clipboard_read"}'
+bash scripts/gasoline-call.sh interact '{"what":"clipboard_read"}'
 ```
 
 ## clipboard_write
@@ -437,7 +437,7 @@ Write text to the clipboard.
 **Params:** `text` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"clipboard_write","text":"copied text"}'
+bash scripts/gasoline-call.sh interact '{"what":"clipboard_write","text":"copied text"}'
 ```
 
 ---
@@ -449,7 +449,7 @@ Run JavaScript in the page context.
 **Params:** `script` (string, required), `world` (string: auto|main|isolated), `timeout_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"execute_js","script":"document.title","world":"main"}'
+bash scripts/gasoline-call.sh interact '{"what":"execute_js","script":"document.title","world":"main"}'
 ```
 
 ---
@@ -461,7 +461,7 @@ Start a video recording of the browser tab.
 **Params:** `name` (string), `audio` (string: tab|mic|both), `fps` (number, 5-60, default 15)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"test_run","fps":30}'
+bash scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"test_run","fps":30}'
 ```
 
 ## screen_recording_stop
@@ -469,7 +469,7 @@ Stop a video recording.
 **Params:** `name` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"test_run"}'
+bash scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"test_run"}'
 ```
 
 ---
@@ -481,7 +481,7 @@ Upload a file to a file input or API endpoint.
 **Params:** `file_path` (string), `api_endpoint` (string), `submit` (bool), `escalation_timeout_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"upload","file_path":"/tmp/document.pdf","submit":true}'
+bash scripts/gasoline-call.sh interact '{"what":"upload","file_path":"/tmp/document.pdf","submit":true}'
 ```
 
 ---
@@ -493,7 +493,7 @@ Activate the annotation drawing overlay.
 **Params:** `annot_session` (string), `timeout_ms` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"draw_mode_start","annot_session":"review_1","timeout_ms":60000}'
+bash scripts/gasoline-call.sh interact '{"what":"draw_mode_start","annot_session":"review_1","timeout_ms":60000}'
 ```
 
 ## run_a11y_and_export_sarif
@@ -501,7 +501,7 @@ Run an accessibility audit and export results as SARIF.
 **Params:** `save_to` (string), `scope_selector` (string), `frame` (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"/tmp/a11y-report.sarif"}'
+bash scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"/tmp/a11y-report.sarif"}'
 ```
 
 ---
@@ -513,7 +513,7 @@ Open the Claude composer interface.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"open_composer"}'
+bash scripts/gasoline-call.sh interact '{"what":"open_composer"}'
 ```
 
 ## submit_active_composer
@@ -521,7 +521,7 @@ Submit the message in the active Claude composer.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"submit_active_composer"}'
+bash scripts/gasoline-call.sh interact '{"what":"submit_active_composer"}'
 ```
 
 ## activate_tab
@@ -529,7 +529,7 @@ Bring the tracked browser tab to the foreground.
 **Params:** none
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"activate_tab"}'
+bash scripts/gasoline-call.sh interact '{"what":"activate_tab"}'
 ```
 
 ---
@@ -541,7 +541,7 @@ Execute a sequence of interact actions in order.
 **Params:** `steps` (array of action objects, required), `step_timeout_ms` (number, default 10000), `continue_on_error` (bool, default true), `stop_after_step` (number)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"click","selector":"#login"},{"what":"type","selector":"#user","text":"admin"},{"what":"key_press","text":"Enter"}]}'
+bash scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"click","selector":"#login"},{"what":"type","selector":"#user","text":"admin"},{"what":"key_press","text":"Enter"}]}'
 ```
 
 ---

--- a/claude_skill/gasoline/references/observe-modes.md
+++ b/claude_skill/gasoline/references/observe-modes.md
@@ -24,7 +24,7 @@ Browser console errors.
 **Params:** url (string), scope (`current_page` | `all`), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","scope":"current_page"}'
+bash scripts/gasoline-call.sh observe '{"what":"errors","scope":"current_page"}'
 ```
 
 ## logs
@@ -32,7 +32,7 @@ Browser console logs.
 **Params:** min_level (`debug` | `log` | `info` | `warn` | `error`), source (string), include_internal (boolean), include_extension_logs (boolean), extension_limit (integer), url (string), scope (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn"}'
+bash scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn"}'
 ```
 
 ## extension_logs
@@ -40,7 +40,7 @@ Internal extension debug logs.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"extension_logs"}'
+bash scripts/gasoline-call.sh observe '{"what":"extension_logs"}'
 ```
 
 ## network_waterfall
@@ -48,7 +48,7 @@ All network requests (HTTP, fetch, XHR).
 **Params:** url (string), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","url":"https://example.com"}'
+bash scripts/gasoline-call.sh observe '{"what":"network_waterfall","url":"https://example.com"}'
 ```
 
 ## network_bodies
@@ -56,7 +56,7 @@ Fetch request/response bodies.
 **Params:** url (string), method (string), status_min (integer), status_max (integer), body_path (string), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","method":"POST","status_min":400}'
+bash scripts/gasoline-call.sh observe '{"what":"network_bodies","method":"POST","status_min":400}'
 ```
 
 ## websocket_events
@@ -64,7 +64,7 @@ WebSocket messages.
 **Params:** url (string), connection_id (string), direction (`incoming` | `outgoing`), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"websocket_events","direction":"incoming"}'
+bash scripts/gasoline-call.sh observe '{"what":"websocket_events","direction":"incoming"}'
 ```
 
 ## websocket_status
@@ -72,7 +72,7 @@ WebSocket connection status.
 **Params:** connection_id (string), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"websocket_status"}'
+bash scripts/gasoline-call.sh observe '{"what":"websocket_status"}'
 ```
 
 ## actions
@@ -80,7 +80,7 @@ User actions recorded.
 **Params:** url (string), last_n (integer), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"actions","last_n":10}'
+bash scripts/gasoline-call.sh observe '{"what":"actions","last_n":10}'
 ```
 
 ## vitals
@@ -88,7 +88,7 @@ Web vitals metrics.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+bash scripts/gasoline-call.sh observe '{"what":"vitals"}'
 ```
 
 ## page
@@ -96,7 +96,7 @@ Current page state.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+bash scripts/gasoline-call.sh observe '{"what":"page"}'
 ```
 
 ## tabs
@@ -104,7 +104,7 @@ Open browser tabs.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash scripts/gasoline-call.sh observe '{"what":"tabs"}'
 ```
 
 ## history
@@ -112,7 +112,7 @@ Browser history.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"history"}'
+bash scripts/gasoline-call.sh observe '{"what":"history"}'
 ```
 
 ## pilot
@@ -120,7 +120,7 @@ Pilot mode data.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"pilot"}'
+bash scripts/gasoline-call.sh observe '{"what":"pilot"}'
 ```
 
 ## timeline
@@ -128,7 +128,7 @@ Timeline events.
 **Params:** include (array of categories), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"timeline","include":["network","console"]}'
+bash scripts/gasoline-call.sh observe '{"what":"timeline","include":["network","console"]}'
 ```
 
 ## error_bundles
@@ -136,7 +136,7 @@ Pre-assembled error context.
 **Params:** url (string), scope (string), window_seconds (integer, default 3, max 10), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
+bash scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
 ```
 
 ## screenshot
@@ -144,7 +144,7 @@ Page screenshots.
 **Params:** format (`png` | `jpeg`), quality (integer, 1-100, jpeg only), full_page (boolean), selector (string), wait_for_stable (boolean), save_to (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","format":"png","full_page":true}'
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","format":"png","full_page":true}'
 ```
 
 ## storage
@@ -152,7 +152,7 @@ localStorage/sessionStorage/cookies.
 **Params:** storage_type (`local` | `session` | `cookies`), key (string), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"local","key":"auth_token"}'
+bash scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"local","key":"auth_token"}'
 ```
 
 ## indexeddb
@@ -160,7 +160,7 @@ IndexedDB contents.
 **Params:** database (string), store (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"indexeddb","database":"myDB","store":"users"}'
+bash scripts/gasoline-call.sh observe '{"what":"indexeddb","database":"myDB","store":"users"}'
 ```
 
 ## command_result
@@ -168,7 +168,7 @@ Async command results.
 **Params:** correlation_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"abc-123"}'
+bash scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"abc-123"}'
 ```
 
 ## pending_commands
@@ -176,7 +176,7 @@ Commands awaiting execution.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"pending_commands"}'
+bash scripts/gasoline-call.sh observe '{"what":"pending_commands"}'
 ```
 
 ## failed_commands
@@ -184,7 +184,7 @@ Failed commands.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"failed_commands"}'
+bash scripts/gasoline-call.sh observe '{"what":"failed_commands"}'
 ```
 
 ## saved_videos
@@ -192,7 +192,7 @@ Saved video recordings.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"saved_videos"}'
+bash scripts/gasoline-call.sh observe '{"what":"saved_videos"}'
 ```
 
 ## recordings
@@ -200,7 +200,7 @@ Recording metadata.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"recordings"}'
+bash scripts/gasoline-call.sh observe '{"what":"recordings"}'
 ```
 
 ## recording_actions
@@ -208,7 +208,7 @@ Actions within a recording.
 **Params:** recording_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"recording_actions","recording_id":"rec-001"}'
+bash scripts/gasoline-call.sh observe '{"what":"recording_actions","recording_id":"rec-001"}'
 ```
 
 ## playback_results
@@ -216,7 +216,7 @@ Playback results.
 **Params:** recording_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"playback_results","recording_id":"rec-001"}'
+bash scripts/gasoline-call.sh observe '{"what":"playback_results","recording_id":"rec-001"}'
 ```
 
 ## log_diff_report
@@ -224,7 +224,7 @@ Log diff report.
 **Params:** original_id (string), replay_id (string)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"log_diff_report","original_id":"rec-001","replay_id":"rec-002"}'
+bash scripts/gasoline-call.sh observe '{"what":"log_diff_report","original_id":"rec-001","replay_id":"rec-002"}'
 ```
 
 ## summarized_logs
@@ -232,7 +232,7 @@ Aggregated/grouped logs.
 **Params:** min_group_size (integer, default 2)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"summarized_logs","min_group_size":3}'
+bash scripts/gasoline-call.sh observe '{"what":"summarized_logs","min_group_size":3}'
 ```
 
 ## page_inventory
@@ -240,7 +240,7 @@ Inventory of page elements.
 **Params:** visible_only (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page_inventory","visible_only":true}'
+bash scripts/gasoline-call.sh observe '{"what":"page_inventory","visible_only":true}'
 ```
 
 ## transients
@@ -248,7 +248,7 @@ Transient UI elements (alerts, toasts).
 **Params:** url (string), classification (`alert` | `toast` | `snackbar` | `notification` | `tooltip` | `banner` | `flash`), summary (boolean)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"transients","classification":"toast"}'
+bash scripts/gasoline-call.sh observe '{"what":"transients","classification":"toast"}'
 ```
 
 ## inbox
@@ -256,5 +256,5 @@ Message inbox.
 **Params:** none (universal params only)
 **Example:**
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"inbox"}'
+bash scripts/gasoline-call.sh observe '{"what":"inbox"}'
 ```

--- a/claude_skill/gasoline/references/observe-modes.md
+++ b/claude_skill/gasoline/references/observe-modes.md
@@ -1,0 +1,260 @@
+# Observe Tool Reference
+
+Complete reference for all 31 observe modes available via the `observe` MCP tool.
+
+## Universal Parameters
+
+These parameters apply to **every** observe mode:
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `what` | string, **required** | The observe mode to invoke |
+| `telemetry_mode` | `off` \| `auto` \| `full` | Controls telemetry collection level |
+| `limit` | integer (default 100, max 1000) | Maximum number of results to return |
+| `after_cursor` | string | Cursor for forward pagination |
+| `before_cursor` | string | Cursor for backward pagination |
+| `since_cursor` | string | Return only results newer than this cursor |
+| `restart_on_eviction` | boolean | Restart streaming if the cursor was evicted |
+| `summary` | boolean | Return a summarized response |
+
+---
+
+## errors
+Browser console errors.
+**Params:** url (string), scope (`current_page` | `all`), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","scope":"current_page"}'
+```
+
+## logs
+Browser console logs.
+**Params:** min_level (`debug` | `log` | `info` | `warn` | `error`), source (string), include_internal (boolean), include_extension_logs (boolean), extension_limit (integer), url (string), scope (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn"}'
+```
+
+## extension_logs
+Internal extension debug logs.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"extension_logs"}'
+```
+
+## network_waterfall
+All network requests (HTTP, fetch, XHR).
+**Params:** url (string), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","url":"https://example.com"}'
+```
+
+## network_bodies
+Fetch request/response bodies.
+**Params:** url (string), method (string), status_min (integer), status_max (integer), body_path (string), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","method":"POST","status_min":400}'
+```
+
+## websocket_events
+WebSocket messages.
+**Params:** url (string), connection_id (string), direction (`incoming` | `outgoing`), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"websocket_events","direction":"incoming"}'
+```
+
+## websocket_status
+WebSocket connection status.
+**Params:** connection_id (string), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"websocket_status"}'
+```
+
+## actions
+User actions recorded.
+**Params:** url (string), last_n (integer), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"actions","last_n":10}'
+```
+
+## vitals
+Web vitals metrics.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+```
+
+## page
+Current page state.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+```
+
+## tabs
+Open browser tabs.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
+```
+
+## history
+Browser history.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"history"}'
+```
+
+## pilot
+Pilot mode data.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"pilot"}'
+```
+
+## timeline
+Timeline events.
+**Params:** include (array of categories), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"timeline","include":["network","console"]}'
+```
+
+## error_bundles
+Pre-assembled error context.
+**Params:** url (string), scope (string), window_seconds (integer, default 3, max 10), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
+```
+
+## screenshot
+Page screenshots.
+**Params:** format (`png` | `jpeg`), quality (integer, 1-100, jpeg only), full_page (boolean), selector (string), wait_for_stable (boolean), save_to (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","format":"png","full_page":true}'
+```
+
+## storage
+localStorage/sessionStorage/cookies.
+**Params:** storage_type (`local` | `session` | `cookies`), key (string), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"local","key":"auth_token"}'
+```
+
+## indexeddb
+IndexedDB contents.
+**Params:** database (string), store (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"indexeddb","database":"myDB","store":"users"}'
+```
+
+## command_result
+Async command results.
+**Params:** correlation_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"abc-123"}'
+```
+
+## pending_commands
+Commands awaiting execution.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"pending_commands"}'
+```
+
+## failed_commands
+Failed commands.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"failed_commands"}'
+```
+
+## saved_videos
+Saved video recordings.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"saved_videos"}'
+```
+
+## recordings
+Recording metadata.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"recordings"}'
+```
+
+## recording_actions
+Actions within a recording.
+**Params:** recording_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"recording_actions","recording_id":"rec-001"}'
+```
+
+## playback_results
+Playback results.
+**Params:** recording_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"playback_results","recording_id":"rec-001"}'
+```
+
+## log_diff_report
+Log diff report.
+**Params:** original_id (string), replay_id (string)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"log_diff_report","original_id":"rec-001","replay_id":"rec-002"}'
+```
+
+## summarized_logs
+Aggregated/grouped logs.
+**Params:** min_group_size (integer, default 2)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"summarized_logs","min_group_size":3}'
+```
+
+## page_inventory
+Inventory of page elements.
+**Params:** visible_only (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page_inventory","visible_only":true}'
+```
+
+## transients
+Transient UI elements (alerts, toasts).
+**Params:** url (string), classification (`alert` | `toast` | `snackbar` | `notification` | `tooltip` | `banner` | `flash`), summary (boolean)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"transients","classification":"toast"}'
+```
+
+## inbox
+Message inbox.
+**Params:** none (universal params only)
+**Example:**
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"inbox"}'
+```

--- a/claude_skill/gasoline/references/workflow-audit-and-security.md
+++ b/claude_skill/gasoline/references/workflow-audit-and-security.md
@@ -1,0 +1,181 @@
+# Audit and Security Workflow
+
+Use this workflow for site audits, UX reviews, accessibility checks, security audits, and API validation.
+Merges: site-audit, ux-audit, security-redaction, api-validation.
+
+## Inputs
+
+- Start URL and audit boundary (allowed domains/paths)
+- Auth/session readiness
+- Page budget and time budget
+- Priority flows and exclusions (logout, destructive actions, billing)
+- Secret classes to test (for security: API keys, tokens, cookies)
+- API endpoints/operations to validate (for API validation)
+
+## Step 1: Confirm Starting State
+
+```bash
+bash gasoline-browser/scripts/ensure-daemon.sh
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+```
+
+Verify the user is logged in and on the intended start page.
+
+## Step 2: Discover Navigation Structure
+
+```bash
+# Explore the current page
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page"}'
+
+# List all interactive elements
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
+
+# Get page structure
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
+
+# Capture navigation architecture
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation"}'
+```
+
+Build a discovery queue from nav, sidebars, footers, and major CTAs.
+
+## Step 3: Per-Page Audit
+
+For each page in the queue:
+
+```bash
+# Navigate
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true}'
+
+# Screenshot evidence (top, scrolled, bottom)
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_top.png"}'
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_bottom.png"}'
+
+# Page summary and diagnostics
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
+```
+
+Per-page capture checklist:
+- Page purpose and primary user jobs
+- Major UI regions/components
+- Outbound links and routes
+- Key interactions and outcomes
+- UX strengths and issues
+- Errors/warnings/network failures
+
+## Step 4: Accessibility Audit
+
+```bash
+# Full accessibility check
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","summary":true}'
+
+# Detailed check on specific area
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","selector":"main","tags":["wcag2a","wcag2aa"]}'
+
+# Form analysis
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"forms"}'
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
+
+# Export as SARIF for CI integration
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"audit/a11y.sarif"}'
+```
+
+Check: labels, focus flow, landmarks, contrast, heading order, keyboard navigation.
+
+## Step 5: Security Audit
+
+```bash
+# Comprehensive security scan
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","summary":true}'
+
+# Targeted checks
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii","headers","cookies"]}'
+
+# Third-party script analysis
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
+
+# Generate CSP recommendation
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict"}'
+
+# Generate SRI hashes
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sri"}'
+```
+
+### Security Redaction Testing
+
+Seed synthetic secrets and verify they are redacted in all outputs:
+
+```bash
+# Trigger flows that handle sensitive data
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":20}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","limit":30}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage"}'
+```
+
+Check: raw and transformed outputs for token/secret leaks.
+
+## Step 6: API Validation
+
+```bash
+# Collect traffic
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":50}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":30}'
+
+# Run API contract validation
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
+
+# Get validation report
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"report"}'
+
+# Link health check
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_health","timeout_ms":15000}'
+```
+
+Classify mismatches: schema drift, status drift, auth failure, routing mismatch, serialization issue.
+
+## Step 7: UX Assessment
+
+Review across all captured evidence:
+
+- Information hierarchy: heading order, CTA prominence, scan order, above-the-fold clarity
+- Interaction clarity: affordances, feedback, error/help text quality
+- Consistency: visual patterns, terminology, behavior across pages
+- Loading/empty/error states: are they handled gracefully?
+
+## Step 8: Generate Report
+
+```bash
+# Generate SARIF report for all findings
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sarif","save_to":"audit/full-report.sarif"}'
+
+# Generate annotation report if draw mode was used
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_report","save_to":"audit/annotations.md"}'
+```
+
+### Report Structure
+
+1. Executive summary
+2. Scope, constraints, and method
+3. Coverage summary (routes discovered, audited, gaps)
+4. Navigation and menu inventory
+5. Page-by-page findings (with screenshot references)
+6. Feature-by-feature findings
+7. Accessibility assessment
+8. Security findings
+9. API contract findings
+10. UX/usability report
+11. Strengths (what works well)
+12. Issues ranked by severity
+13. Prioritized remediation plan
+14. Evidence appendix
+
+## Troubleshooting
+
+- **Blocked by auth:** Verify session is active with `observe(storage, storage_type="cookies")`.
+- **Too many pages:** Set strict crawl bounds and use page budget. Prioritize breadth first.
+- **Accessibility timeout:** Use `background:true` and poll with `observe(command_result)`.
+- **Security false positives:** Use `severity_min:"high"` to filter noise.

--- a/claude_skill/gasoline/references/workflow-audit-and-security.md
+++ b/claude_skill/gasoline/references/workflow-audit-and-security.md
@@ -15,9 +15,9 @@ Merges: site-audit, ux-audit, security-redaction, api-validation.
 ## Step 1: Confirm Starting State
 
 ```bash
-bash gasoline-browser/scripts/ensure-daemon.sh
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+bash scripts/ensure-daemon.sh
+bash scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash scripts/gasoline-call.sh observe '{"what":"page"}'
 ```
 
 Verify the user is logged in and on the intended start page.
@@ -26,16 +26,16 @@ Verify the user is logged in and on the intended start page.
 
 ```bash
 # Explore the current page
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page"}'
+bash scripts/gasoline-call.sh interact '{"what":"explore_page"}'
 
 # List all interactive elements
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
+bash scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
 
 # Get page structure
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
+bash scripts/gasoline-call.sh analyze '{"what":"page_structure"}'
 
 # Capture navigation architecture
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"navigation"}'
+bash scripts/gasoline-call.sh analyze '{"what":"navigation"}'
 ```
 
 Build a discovery queue from nav, sidebars, footers, and major CTAs.
@@ -46,17 +46,17 @@ For each page in the queue:
 
 ```bash
 # Navigate
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true}'
 
 # Screenshot evidence (top, scrolled, bottom)
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_top.png"}'
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_bottom.png"}'
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_top.png"}'
+bash scripts/gasoline-call.sh interact '{"what":"scroll_to","direction":"bottom"}'
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"audit/<page_id>_bottom.png"}'
 
 # Page summary and diagnostics
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
+bash scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
+bash scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
 ```
 
 Per-page capture checklist:
@@ -71,17 +71,17 @@ Per-page capture checklist:
 
 ```bash
 # Full accessibility check
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"accessibility","summary":true}'
 
 # Detailed check on specific area
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"accessibility","selector":"main","tags":["wcag2a","wcag2aa"]}'
+bash scripts/gasoline-call.sh analyze '{"what":"accessibility","selector":"main","tags":["wcag2a","wcag2aa"]}'
 
 # Form analysis
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"forms"}'
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"forms"}'
+bash scripts/gasoline-call.sh analyze '{"what":"form_validation","summary":true}'
 
 # Export as SARIF for CI integration
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"audit/a11y.sarif"}'
+bash scripts/gasoline-call.sh interact '{"what":"run_a11y_and_export_sarif","save_to":"audit/a11y.sarif"}'
 ```
 
 Check: labels, focus flow, landmarks, contrast, heading order, keyboard navigation.
@@ -90,19 +90,19 @@ Check: labels, focus flow, landmarks, contrast, heading order, keyboard navigati
 
 ```bash
 # Comprehensive security scan
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"security_audit","summary":true}'
 
 # Targeted checks
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii","headers","cookies"]}'
+bash scripts/gasoline-call.sh analyze '{"what":"security_audit","checks":["credentials","pii","headers","cookies"]}'
 
 # Third-party script analysis
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
 
 # Generate CSP recommendation
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict"}'
+bash scripts/gasoline-call.sh generate '{"what":"csp","mode":"strict"}'
 
 # Generate SRI hashes
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sri"}'
+bash scripts/gasoline-call.sh generate '{"what":"sri"}'
 ```
 
 ### Security Redaction Testing
@@ -111,9 +111,9 @@ Seed synthetic secrets and verify they are redacted in all outputs:
 
 ```bash
 # Trigger flows that handle sensitive data
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":20}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","limit":30}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage"}'
+bash scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":20}'
+bash scripts/gasoline-call.sh observe '{"what":"logs","limit":30}'
+bash scripts/gasoline-call.sh observe '{"what":"storage"}'
 ```
 
 Check: raw and transformed outputs for token/secret leaks.
@@ -122,17 +122,17 @@ Check: raw and transformed outputs for token/secret leaks.
 
 ```bash
 # Collect traffic
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":50}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":30}'
+bash scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":50}'
+bash scripts/gasoline-call.sh observe '{"what":"network_bodies","limit":30}'
 
 # Run API contract validation
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
+bash scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
 
 # Get validation report
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"report"}'
+bash scripts/gasoline-call.sh analyze '{"what":"api_validation","operation":"report"}'
 
 # Link health check
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"link_health","timeout_ms":15000}'
+bash scripts/gasoline-call.sh analyze '{"what":"link_health","timeout_ms":15000}'
 ```
 
 Classify mismatches: schema drift, status drift, auth failure, routing mismatch, serialization issue.
@@ -150,10 +150,10 @@ Review across all captured evidence:
 
 ```bash
 # Generate SARIF report for all findings
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"sarif","save_to":"audit/full-report.sarif"}'
+bash scripts/gasoline-call.sh generate '{"what":"sarif","save_to":"audit/full-report.sarif"}'
 
 # Generate annotation report if draw mode was used
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"annotation_report","save_to":"audit/annotations.md"}'
+bash scripts/gasoline-call.sh generate '{"what":"annotation_report","save_to":"audit/annotations.md"}'
 ```
 
 ### Report Structure

--- a/claude_skill/gasoline/references/workflow-automate-and-test.md
+++ b/claude_skill/gasoline/references/workflow-automate-and-test.md
@@ -1,0 +1,210 @@
+# Automate and Test Workflow
+
+Use this workflow for browser automation, demo creation, test generation, coverage improvement, and release readiness.
+Merges: automate, demo, reliability, test-coverage, release-readiness.
+
+## Inputs
+
+- Target workflow or feature
+- Start URL and auth preconditions
+- Success condition
+- Test/coverage targets (for testing flows)
+- Release branch/commit and required gates (for release readiness)
+
+---
+
+## Automation
+
+### Step 1: Validate Preconditions
+
+```bash
+bash gasoline-browser/scripts/ensure-daemon.sh
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+
+# Check auth state
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"cookies"}'
+```
+
+### Step 2: Plan Robust Selectors
+
+Prefer semantic selectors and stable attributes over brittle CSS chains.
+
+```bash
+# Discover interactive elements
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
+
+# Use element_id from list_interactive for stable targeting
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","element_id":"<stable_id>"}'
+```
+
+Selector priority: `element_id` > semantic (`text=Submit`, `role=button`) > CSS selector > coordinates.
+
+### Step 3: Execute in Small Steps
+
+After each interact call, verify the result.
+
+```bash
+# Navigate
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<url>","wait_for_stable":true}'
+
+# Interact with action_diff for mutation tracking
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit","action_diff":true}'
+
+# Fill and submit forms
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#email","value":"user@example.com"},{"selector":"#password","value":"pass"}],"submit_selector":"button[type=submit]"}'
+
+# Wait for expected state
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".success-message","timeout_ms":5000}'
+```
+
+### Step 4: Bounded Recovery
+
+If a step fails, retry once with alternate selector or wait strategy.
+
+```bash
+# Try alternate selector
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"text=Submit","timeout_ms":10000}'
+
+# Or wait for stability then retry
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":1000}'
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
+```
+
+### Step 5: Batch Execution
+
+For multi-step sequences, use batch mode:
+
+```bash
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"navigate","url":"https://example.com"},{"what":"click","selector":"#login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}],"continue_on_error":false}'
+```
+
+### Step 6: Save Reusable Sequences
+
+```bash
+# Save a sequence for reuse
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"what":"navigate","url":"https://example.com/login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}]}'
+
+# Replay it later
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow"}'
+```
+
+---
+
+## Demo Creation
+
+### Build Demo Script
+
+```bash
+# Start recording
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"demo_feature_x"}'
+
+# Execute steps with subtitles for narration
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<demo_url>","subtitle":"Opening the dashboard"}'
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<feature_cta>","subtitle":"Launching Feature X"}'
+
+# Capture proof screenshots
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"demo/step1.png"}'
+
+# Stop recording
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"demo_feature_x"}'
+```
+
+---
+
+## Test Generation
+
+```bash
+# Start recording user actions
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"test_session"}'
+
+# ... perform the user journey ...
+
+# Stop recording
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_stop"}'
+
+# Generate test from captured session
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"user_journey","save_to":"tests/user-journey.spec.ts"}'
+
+# Generate test from specific context
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"interaction","save_to":"tests/interaction.spec.ts"}'
+
+# Heal broken selectors in existing tests
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_heal","action":"batch","test_dir":"tests/"}'
+```
+
+---
+
+## Reliability Validation
+
+### Canary Flows
+
+Cover all tool paths:
+
+```bash
+# Observe path
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":5}'
+
+# Interact path
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page"}'
+
+# Analyze path
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
+
+# Generate path
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
+```
+
+### Stress Transitions
+
+Test reconnect, tab switches, extension restarts:
+
+```bash
+# Switch tabs
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":1}'
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":0}'
+
+# Verify health after stress
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+```
+
+---
+
+## Release Readiness
+
+### Quality Gates
+
+```bash
+# System health
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+
+# Audit tool usage
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report"}'
+```
+
+### Integration Smoke
+
+Run critical end-to-end flows and capture results:
+
+```bash
+# Session diff: capture before and after
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"pre_release"}'
+
+# ... run critical flows ...
+
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"post_release"}'
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"pre_release","compare_b":"post_release"}'
+```
+
+### Decision
+
+Return: go/no-go with blockers, mitigations, and confidence level.
+
+## Troubleshooting
+
+- **Flaky selectors:** Use `list_interactive` to discover stable `element_id` values.
+- **Automation timeout:** Increase `timeout_ms` or add explicit `wait_for` steps.
+- **Recording fails:** Check disk space and that no other recording is active.
+- **Test generation empty:** Ensure actions were captured during the session with `observe(actions)`.

--- a/claude_skill/gasoline/references/workflow-automate-and-test.md
+++ b/claude_skill/gasoline/references/workflow-automate-and-test.md
@@ -18,12 +18,12 @@ Merges: automate, demo, reliability, test-coverage, release-readiness.
 ### Step 1: Validate Preconditions
 
 ```bash
-bash gasoline-browser/scripts/ensure-daemon.sh
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+bash scripts/ensure-daemon.sh
+bash scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash scripts/gasoline-call.sh observe '{"what":"page"}'
 
 # Check auth state
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"cookies"}'
+bash scripts/gasoline-call.sh observe '{"what":"storage","storage_type":"cookies"}'
 ```
 
 ### Step 2: Plan Robust Selectors
@@ -32,10 +32,10 @@ Prefer semantic selectors and stable attributes over brittle CSS chains.
 
 ```bash
 # Discover interactive elements
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
+bash scripts/gasoline-call.sh interact '{"what":"list_interactive","visible_only":true}'
 
 # Use element_id from list_interactive for stable targeting
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","element_id":"<stable_id>"}'
+bash scripts/gasoline-call.sh interact '{"what":"click","element_id":"<stable_id>"}'
 ```
 
 Selector priority: `element_id` > semantic (`text=Submit`, `role=button`) > CSS selector > coordinates.
@@ -46,16 +46,16 @@ After each interact call, verify the result.
 
 ```bash
 # Navigate
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<url>","wait_for_stable":true}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"<url>","wait_for_stable":true}'
 
 # Interact with action_diff for mutation tracking
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit","action_diff":true}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit","action_diff":true}'
 
 # Fill and submit forms
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#email","value":"user@example.com"},{"selector":"#password","value":"pass"}],"submit_selector":"button[type=submit]"}'
+bash scripts/gasoline-call.sh interact '{"what":"fill_form_and_submit","fields":[{"selector":"#email","value":"user@example.com"},{"selector":"#password","value":"pass"}],"submit_selector":"button[type=submit]"}'
 
 # Wait for expected state
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".success-message","timeout_ms":5000}'
+bash scripts/gasoline-call.sh interact '{"what":"wait_for","selector":".success-message","timeout_ms":5000}'
 ```
 
 ### Step 4: Bounded Recovery
@@ -64,11 +64,11 @@ If a step fails, retry once with alternate selector or wait strategy.
 
 ```bash
 # Try alternate selector
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"text=Submit","timeout_ms":10000}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"text=Submit","timeout_ms":10000}'
 
 # Or wait for stability then retry
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":1000}'
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
+bash scripts/gasoline-call.sh interact '{"what":"wait_for_stable","stability_ms":1000}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"button.submit"}'
 ```
 
 ### Step 5: Batch Execution
@@ -76,17 +76,17 @@ bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","select
 For multi-step sequences, use batch mode:
 
 ```bash
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"navigate","url":"https://example.com"},{"what":"click","selector":"#login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}],"continue_on_error":false}'
+bash scripts/gasoline-call.sh interact '{"what":"batch","steps":[{"what":"navigate","url":"https://example.com"},{"what":"click","selector":"#login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}],"continue_on_error":false}'
 ```
 
 ### Step 6: Save Reusable Sequences
 
 ```bash
 # Save a sequence for reuse
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"what":"navigate","url":"https://example.com/login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}]}'
+bash scripts/gasoline-call.sh configure '{"what":"save_sequence","name":"login_flow","steps":[{"what":"navigate","url":"https://example.com/login"},{"what":"type","selector":"#email","text":"user@example.com"},{"what":"click","selector":"button[type=submit]"}]}'
 
 # Replay it later
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow"}'
+bash scripts/gasoline-call.sh configure '{"what":"replay_sequence","name":"login_flow"}'
 ```
 
 ---
@@ -97,17 +97,17 @@ bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"replay_sequen
 
 ```bash
 # Start recording
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"demo_feature_x"}'
+bash scripts/gasoline-call.sh interact '{"what":"screen_recording_start","name":"demo_feature_x"}'
 
 # Execute steps with subtitles for narration
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<demo_url>","subtitle":"Opening the dashboard"}'
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<feature_cta>","subtitle":"Launching Feature X"}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"<demo_url>","subtitle":"Opening the dashboard"}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"<feature_cta>","subtitle":"Launching Feature X"}'
 
 # Capture proof screenshots
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"demo/step1.png"}'
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"demo/step1.png"}'
 
 # Stop recording
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"demo_feature_x"}'
+bash scripts/gasoline-call.sh interact '{"what":"screen_recording_stop","name":"demo_feature_x"}'
 ```
 
 ---
@@ -116,21 +116,21 @@ bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"screen_recordi
 
 ```bash
 # Start recording user actions
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"test_session"}'
+bash scripts/gasoline-call.sh configure '{"what":"event_recording_start","name":"test_session"}'
 
 # ... perform the user journey ...
 
 # Stop recording
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"event_recording_stop"}'
+bash scripts/gasoline-call.sh configure '{"what":"event_recording_stop"}'
 
 # Generate test from captured session
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"user_journey","save_to":"tests/user-journey.spec.ts"}'
+bash scripts/gasoline-call.sh generate '{"what":"test","test_name":"user_journey","save_to":"tests/user-journey.spec.ts"}'
 
 # Generate test from specific context
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"interaction","save_to":"tests/interaction.spec.ts"}'
+bash scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"interaction","save_to":"tests/interaction.spec.ts"}'
 
 # Heal broken selectors in existing tests
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_heal","action":"batch","test_dir":"tests/"}'
+bash scripts/gasoline-call.sh generate '{"what":"test_heal","action":"batch","test_dir":"tests/"}'
 ```
 
 ---
@@ -143,16 +143,16 @@ Cover all tool paths:
 
 ```bash
 # Observe path
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":5}'
+bash scripts/gasoline-call.sh observe '{"what":"errors","limit":5}'
 
 # Interact path
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"explore_page"}'
+bash scripts/gasoline-call.sh interact '{"what":"explore_page"}'
 
 # Analyze path
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
+bash scripts/gasoline-call.sh analyze '{"what":"page_summary"}'
 
 # Generate path
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
+bash scripts/gasoline-call.sh generate '{"what":"pr_summary"}'
 ```
 
 ### Stress Transitions
@@ -161,12 +161,12 @@ Test reconnect, tab switches, extension restarts:
 
 ```bash
 # Switch tabs
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":1}'
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":0}'
+bash scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":1}'
+bash scripts/gasoline-call.sh interact '{"what":"switch_tab","tab_index":0}'
 
 # Verify health after stress
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+bash scripts/gasoline-call.sh configure '{"what":"health"}'
+bash scripts/gasoline-call.sh configure '{"what":"doctor"}'
 ```
 
 ---
@@ -177,11 +177,11 @@ bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
 
 ```bash
 # System health
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"health"}'
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"doctor"}'
+bash scripts/gasoline-call.sh configure '{"what":"health"}'
+bash scripts/gasoline-call.sh configure '{"what":"doctor"}'
 
 # Audit tool usage
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report"}'
+bash scripts/gasoline-call.sh configure '{"what":"audit_log","operation":"report"}'
 ```
 
 ### Integration Smoke
@@ -190,12 +190,12 @@ Run critical end-to-end flows and capture results:
 
 ```bash
 # Session diff: capture before and after
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"pre_release"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"pre_release"}'
 
 # ... run critical flows ...
 
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"post_release"}'
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"pre_release","compare_b":"post_release"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"post_release"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"pre_release","compare_b":"post_release"}'
 ```
 
 ### Decision

--- a/claude_skill/gasoline/references/workflow-debug-and-triage.md
+++ b/claude_skill/gasoline/references/workflow-debug-and-triage.md
@@ -16,13 +16,13 @@ Capture current state before reproducing:
 
 ```bash
 # Check connection health
-bash gasoline-browser/scripts/ensure-daemon.sh
+bash scripts/ensure-daemon.sh
 
 # Capture baseline state
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":20,"summary":true}'
+bash scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash scripts/gasoline-call.sh observe '{"what":"page"}'
+bash scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
+bash scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":20,"summary":true}'
 ```
 
 ## Step 2: Reproduce Deliberately
@@ -31,11 +31,11 @@ Use small interact actions, one step at a time. Keep a correlation ID per high-l
 
 ```bash
 # Navigate to the page
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<target_url>","wait_for_stable":true}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"<target_url>","wait_for_stable":true}'
 
 # Execute repro steps one at a time
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<selector>","correlation_id":"step1"}'
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"type","selector":"<selector>","text":"<input>","correlation_id":"step2"}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"<selector>","correlation_id":"step1"}'
+bash scripts/gasoline-call.sh interact '{"what":"type","selector":"<selector>","text":"<input>","correlation_id":"step2"}'
 ```
 
 ## Step 3: Capture Failure Evidence
@@ -44,19 +44,19 @@ Collect evidence at the failure point. Start broad, then narrow.
 
 ```bash
 # Pre-assembled error context (best starting point)
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
+bash scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
 
 # Detailed console errors
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":50}'
+bash scripts/gasoline-call.sh observe '{"what":"errors","limit":50}'
 
 # Network failures
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","status_min":400,"limit":20}'
+bash scripts/gasoline-call.sh observe '{"what":"network_bodies","status_min":400,"limit":20}'
 
 # Console logs around failure
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn","limit":30}'
+bash scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn","limit":30}'
 
 # Async command results if relevant
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"<id>"}'
+bash scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"<id>"}'
 ```
 
 ## Step 4: Deep Analysis (if needed)
@@ -65,16 +65,16 @@ Only use analyze when evidence from observe suggests a specific mismatch.
 
 ```bash
 # DOM state inspection
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"dom","selector":"<problem_area>"}'
+bash scripts/gasoline-call.sh analyze '{"what":"dom","selector":"<problem_area>"}'
 
 # Computed styles (layout issues)
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":"<element>"}'
+bash scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":"<element>"}'
 
 # API contract validation
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
+bash scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
 
 # Visual screenshot for comparison
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"evidence.png"}'
+bash scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"evidence.png"}'
 ```
 
 ## Step 5: Classify Root Cause
@@ -104,13 +104,13 @@ After the bug is confirmed and fixed:
 
 ```bash
 # Generate test from captured session
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"regression_<bug_id>"}'
+bash scripts/gasoline-call.sh generate '{"what":"test","test_name":"regression_<bug_id>"}'
 
 # Or generate from specific error context
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"<id>"}'
+bash scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"<id>"}'
 
 # Generate reproduction script
-bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"reproduction","output_format":"playwright","save_to":"repro.spec.ts"}'
+bash scripts/gasoline-call.sh generate '{"what":"reproduction","output_format":"playwright","save_to":"repro.spec.ts"}'
 ```
 
 Regression test checklist:

--- a/claude_skill/gasoline/references/workflow-debug-and-triage.md
+++ b/claude_skill/gasoline/references/workflow-debug-and-triage.md
@@ -1,0 +1,127 @@
+# Debug and Triage Workflow
+
+Use this workflow when something is broken and you need root cause with proof.
+Merges: debug, debug-triage, regression-test.
+
+## Inputs
+
+- Target URL
+- Expected vs actual behavior
+- Repro steps or user action sequence
+- Test layer preference (for regression test: unit, integration, e2e)
+
+## Step 1: Establish Baseline
+
+Capture current state before reproducing:
+
+```bash
+# Check connection health
+bash gasoline-browser/scripts/ensure-daemon.sh
+
+# Capture baseline state
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"tabs"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"page"}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":20}'
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","limit":20,"summary":true}'
+```
+
+## Step 2: Reproduce Deliberately
+
+Use small interact actions, one step at a time. Keep a correlation ID per high-level step.
+
+```bash
+# Navigate to the page
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<target_url>","wait_for_stable":true}'
+
+# Execute repro steps one at a time
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<selector>","correlation_id":"step1"}'
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"type","selector":"<selector>","text":"<input>","correlation_id":"step2"}'
+```
+
+## Step 3: Capture Failure Evidence
+
+Collect evidence at the failure point. Start broad, then narrow.
+
+```bash
+# Pre-assembled error context (best starting point)
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"error_bundles","window_seconds":5}'
+
+# Detailed console errors
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"errors","limit":50}'
+
+# Network failures
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","status_min":400,"limit":20}'
+
+# Console logs around failure
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"logs","min_level":"warn","limit":30}'
+
+# Async command results if relevant
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"command_result","correlation_id":"<id>"}'
+```
+
+## Step 4: Deep Analysis (if needed)
+
+Only use analyze when evidence from observe suggests a specific mismatch.
+
+```bash
+# DOM state inspection
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"dom","selector":"<problem_area>"}'
+
+# Computed styles (layout issues)
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"computed_styles","selector":"<element>"}'
+
+# API contract validation
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"api_validation"}'
+
+# Visual screenshot for comparison
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"screenshot","save_to":"evidence.png"}'
+```
+
+## Step 5: Classify Root Cause
+
+Pick one primary source:
+
+| Class | Signals |
+|-------|---------|
+| Frontend runtime | JS errors, undefined references, React/Vue errors |
+| Backend/API | 4xx/5xx responses, schema mismatches, missing fields |
+| Auth/session | 401/403, missing cookies/tokens, expired sessions |
+| CSP/extension bridge | CSP violations, extension disconnected, command timeouts |
+| Timing/race | Intermittent failures, stale data, out-of-order responses |
+| Third-party | External script errors, CDN failures |
+
+## Step 6: Produce Fix-Oriented Output
+
+Return:
+- `root_cause` — single sentence
+- `evidence` — exact log lines, network traces, DOM state
+- `minimal_fix` — smallest change that addresses root cause
+- `verification_step` — one action to confirm the fix works
+
+## Step 7: Create Regression Test (optional)
+
+After the bug is confirmed and fixed:
+
+```bash
+# Generate test from captured session
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test","test_name":"regression_<bug_id>"}'
+
+# Or generate from specific error context
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"test_from_context","context":"error","error_id":"<id>"}'
+
+# Generate reproduction script
+bash gasoline-browser/scripts/gasoline-call.sh generate '{"what":"reproduction","output_format":"playwright","save_to":"repro.spec.ts"}'
+```
+
+Regression test checklist:
+- Test fails on pre-fix behavior
+- Test passes after fix
+- Guard assertions prevent overfitting
+- Run multiple times to verify no flakiness
+
+## Troubleshooting
+
+- **No errors captured:** Check `observe(tabs)` for tracked tab. Ensure extension is active on the page.
+- **Errors too old:** Use `since_cursor` to get only recent entries, or `clear` buffers and reproduce fresh.
+- **Async command timeout:** Set `background:true` on analyze calls, then poll with `observe(command_result)`.
+- **Intermittent failure:** Use `event_recording_start`/`stop` to capture a full session, then replay with `playback`.

--- a/claude_skill/gasoline/references/workflow-performance.md
+++ b/claude_skill/gasoline/references/workflow-performance.md
@@ -14,32 +14,32 @@ Use this workflow for performance triage, regression checks, and optimization va
 List the exact navigation and interaction sequence to measure. Keep it deterministic.
 
 ```bash
-bash gasoline-browser/scripts/ensure-daemon.sh
+bash scripts/ensure-daemon.sh
 
 # Clear existing data for clean measurement
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+bash scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
 ```
 
 ## Step 2: Capture Baseline
 
 ```bash
 # Navigate to target page
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true,"analyze":true}'
+bash scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true,"analyze":true}'
 
 # Collect web vitals
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+bash scripts/gasoline-call.sh observe '{"what":"vitals"}'
 
 # Capture network waterfall
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
+bash scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
 
 # Timeline of all events
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"timeline"}'
+bash scripts/gasoline-call.sh observe '{"what":"timeline"}'
 
 # Performance analysis
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"performance"}'
+bash scripts/gasoline-call.sh analyze '{"what":"performance"}'
 
 # Save baseline snapshot
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_baseline"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_baseline"}'
 ```
 
 ## Step 3: Execute User Journey
@@ -48,10 +48,10 @@ Run the critical interaction sequence with performance profiling enabled:
 
 ```bash
 # Each interaction with analyze:true for perf profiling
-bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<cta>","analyze":true,"wait_for_stable":true}'
+bash scripts/gasoline-call.sh interact '{"what":"click","selector":"<cta>","analyze":true,"wait_for_stable":true}'
 
 # Capture vitals after each significant interaction
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+bash scripts/gasoline-call.sh observe '{"what":"vitals"}'
 ```
 
 ## Step 4: Capture Candidate Measurement
@@ -60,25 +60,25 @@ Repeat the same sequence on the candidate branch/build:
 
 ```bash
 # Clear and re-run
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+bash scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
 
 # ... repeat exact same sequence ...
 
 # Capture candidate snapshot
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_candidate"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_candidate"}'
 ```
 
 ## Step 5: Compare Deltas
 
 ```bash
 # Session comparison
-bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"perf_baseline","compare_b":"perf_candidate"}'
+bash scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"perf_baseline","compare_b":"perf_candidate"}'
 
 # Network body comparison for API response times
-bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","summary":true}'
+bash scripts/gasoline-call.sh observe '{"what":"network_bodies","summary":true}'
 
 # Third-party impact
-bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
+bash scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
 ```
 
 ## Step 6: Identify Bottlenecks

--- a/claude_skill/gasoline/references/workflow-performance.md
+++ b/claude_skill/gasoline/references/workflow-performance.md
@@ -1,0 +1,111 @@
+# Performance Workflow
+
+Use this workflow for performance triage, regression checks, and optimization validation.
+
+## Inputs
+
+- Feature or page URL
+- Baseline branch or expected performance budget
+- Critical user journey steps
+- Success budget (LCP, TTI, API latency, etc.)
+
+## Step 1: Define Scenario
+
+List the exact navigation and interaction sequence to measure. Keep it deterministic.
+
+```bash
+bash gasoline-browser/scripts/ensure-daemon.sh
+
+# Clear existing data for clean measurement
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+```
+
+## Step 2: Capture Baseline
+
+```bash
+# Navigate to target page
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"navigate","url":"<page_url>","wait_for_stable":true,"analyze":true}'
+
+# Collect web vitals
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+
+# Capture network waterfall
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_waterfall","summary":true}'
+
+# Timeline of all events
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"timeline"}'
+
+# Performance analysis
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"performance"}'
+
+# Save baseline snapshot
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_baseline"}'
+```
+
+## Step 3: Execute User Journey
+
+Run the critical interaction sequence with performance profiling enabled:
+
+```bash
+# Each interaction with analyze:true for perf profiling
+bash gasoline-browser/scripts/gasoline-call.sh interact '{"what":"click","selector":"<cta>","analyze":true,"wait_for_stable":true}'
+
+# Capture vitals after each significant interaction
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"vitals"}'
+```
+
+## Step 4: Capture Candidate Measurement
+
+Repeat the same sequence on the candidate branch/build:
+
+```bash
+# Clear and re-run
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"clear","buffer":"all"}'
+
+# ... repeat exact same sequence ...
+
+# Capture candidate snapshot
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"capture","name":"perf_candidate"}'
+```
+
+## Step 5: Compare Deltas
+
+```bash
+# Session comparison
+bash gasoline-browser/scripts/gasoline-call.sh configure '{"what":"diff_sessions","verif_session_action":"compare","compare_a":"perf_baseline","compare_b":"perf_candidate"}'
+
+# Network body comparison for API response times
+bash gasoline-browser/scripts/gasoline-call.sh observe '{"what":"network_bodies","summary":true}'
+
+# Third-party impact
+bash gasoline-browser/scripts/gasoline-call.sh analyze '{"what":"third_party_audit","summary":true}'
+```
+
+## Step 6: Identify Bottlenecks
+
+| Signal | Tool Call |
+|--------|-----------|
+| Slow API responses | `observe(network_bodies, status_min=200)` — check response times |
+| Large payloads | `observe(network_waterfall, summary=true)` — check transfer sizes |
+| Render blocking | `analyze(performance)` — check blocking resources |
+| Third-party scripts | `analyze(third_party_audit)` — identify heavy external scripts |
+| DOM complexity | `analyze(dom)` — check node count and depth |
+| Layout thrashing | `observe(vitals)` — check CLS metric |
+
+## Step 7: Report
+
+Return:
+- `scenario` — exact steps measured
+- `baseline` — metrics before change
+- `candidate` — metrics after change
+- `regressions` — largest deltas by metric and by request
+- `top_bottleneck` — single biggest performance issue
+- `recommended_fix` — lowest-risk optimization
+- `budget_status` — pass/fail against success budgets
+
+## Troubleshooting
+
+- **Inconsistent measurements:** Clear buffers between runs. Use `wait_for_stable` to ensure page is settled.
+- **Missing vitals:** Some metrics (LCP, FID) require user interaction to trigger. Ensure the journey includes real clicks.
+- **Third-party noise:** Use `noise_rule` to filter out known third-party requests from comparison.
+- **Need visual comparison:** Use `visual_baseline` and `visual_diff` to compare rendered output.

--- a/claude_skill/gasoline/scripts/connection-doctor.sh
+++ b/claude_skill/gasoline/scripts/connection-doctor.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# connection-doctor.sh — Diagnose Gasoline connectivity: daemon → extension → tracked tab
+GASOLINE_PORT="${GASOLINE_PORT:-7890}"
+GASOLINE_URL="http://127.0.0.1:${GASOLINE_PORT}"
+
+echo "=== Gasoline Connection Doctor ==="
+
+# 1. Daemon check
+if ! curl -s --max-time 2 "${GASOLINE_URL}/health" > /dev/null 2>&1; then
+  echo "FAIL: Daemon not running on port ${GASOLINE_PORT}"
+  echo "Fix: bash scripts/ensure-daemon.sh"
+  exit 1
+fi
+echo "OK: Daemon running"
+
+# 2. Extension check
+HEALTH=$(curl -s --max-time 2 "${GASOLINE_URL}/health")
+EXT_CONNECTED=$(echo "$HEALTH" | python3 -c "import sys,json; print(json.load(sys.stdin).get('capture',{}).get('extension_connected',False))" 2>/dev/null)
+if [ "$EXT_CONNECTED" != "True" ]; then
+  echo "FAIL: Chrome extension not connected"
+  echo "Fix: Install/enable Gasoline extension, open a web page"
+  exit 1
+fi
+echo "OK: Extension connected"
+
+# 3. Tracked tab check
+TABS=$(curl -s --max-time 5 -X POST "${GASOLINE_URL}/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"observe","arguments":{"what":"tabs"}}}')
+echo "OK: Connection healthy"
+echo "$HEALTH" | python3 -c "import sys,json; h=json.load(sys.stdin); print(f'Version: {h.get(\"version\",\"?\")}'); print(f'Extension last seen: {h.get(\"capture\",{}).get(\"extension_last_seen\",\"?\")}')" 2>/dev/null

--- a/claude_skill/gasoline/scripts/connection-doctor.sh
+++ b/claude_skill/gasoline/scripts/connection-doctor.sh
@@ -27,5 +27,26 @@ echo "OK: Extension connected"
 TABS=$(curl -s --max-time 5 -X POST "${GASOLINE_URL}/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"observe","arguments":{"what":"tabs"}}}')
-echo "OK: Connection healthy"
+TAB_TRACKED=$(echo "$TABS" | python3 -c "
+import sys, json
+try:
+    r = json.load(sys.stdin)
+    content = r.get('result',{}).get('content',[])
+    for item in content:
+        if item.get('type') == 'text':
+            text = item['text']
+            if 'tracked' in text.lower() and ('true' in text.lower() or '\"tracked\":true' in text.replace(' ','')):
+                print('true')
+                sys.exit(0)
+    print('false')
+except:
+    print('false')
+" 2>/dev/null)
+if [ "$TAB_TRACKED" != "true" ]; then
+  echo "WARN: No tab is being tracked"
+  echo "Fix: Open a page in Chrome, click the Gasoline extension icon, and click 'Track This Tab'"
+fi
+
+echo ""
 echo "$HEALTH" | python3 -c "import sys,json; h=json.load(sys.stdin); print(f'Version: {h.get(\"version\",\"?\")}'); print(f'Extension last seen: {h.get(\"capture\",{}).get(\"extension_last_seen\",\"?\")}')" 2>/dev/null
+echo "Doctor complete."

--- a/claude_skill/gasoline/scripts/ensure-daemon.sh
+++ b/claude_skill/gasoline/scripts/ensure-daemon.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# ensure-daemon.sh — Ensure Gasoline daemon is running. Launches if needed.
+GASOLINE_PORT="${GASOLINE_PORT:-7890}"
+GASOLINE_URL="http://127.0.0.1:${GASOLINE_PORT}"
+
+# Check if already running
+if curl -s --max-time 1 "${GASOLINE_URL}/health" > /dev/null 2>&1; then
+  echo '{"status":"already_running"}'
+  curl -s --max-time 2 "${GASOLINE_URL}/health"
+  exit 0
+fi
+
+# Find binary
+GASOLINE_BIN=$(which gasoline 2>/dev/null || which gasoline-agentic-devtools 2>/dev/null)
+if [ -z "$GASOLINE_BIN" ]; then
+  echo '{"status":"error","message":"gasoline binary not found on PATH. Install: npm install -g gasoline-agentic-browser"}' >&2
+  exit 1
+fi
+
+# Launch daemon in background
+"$GASOLINE_BIN" --port "${GASOLINE_PORT}" > /dev/null 2>&1 &
+
+# Wait for ready (up to 3s)
+for i in $(seq 1 30); do
+  if curl -s --max-time 0.5 "${GASOLINE_URL}/health" > /dev/null 2>&1; then
+    echo '{"status":"started"}'
+    curl -s --max-time 2 "${GASOLINE_URL}/health"
+    exit 0
+  fi
+  sleep 0.1
+done
+
+echo '{"status":"error","message":"daemon failed to start within 3s"}' >&2
+exit 1

--- a/claude_skill/gasoline/scripts/gasoline-call.sh
+++ b/claude_skill/gasoline/scripts/gasoline-call.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# gasoline-call.sh — Call a Gasoline tool via HTTP JSON-RPC.
+# Usage: gasoline-call.sh <tool_name> '<json_arguments>'
+GASOLINE_PORT="${GASOLINE_PORT:-7890}"
+GASOLINE_URL="http://127.0.0.1:${GASOLINE_PORT}"
+TOOL="$1"
+if [ -n "$2" ]; then
+  ARGS="$2"
+else
+  ARGS='{}'
+fi
+
+if [ -z "$TOOL" ]; then
+  echo '{"error":"Usage: gasoline-call.sh <tool_name> <json_arguments>"}' >&2
+  exit 1
+fi
+
+RESPONSE=$(curl -s --max-time 30 -X POST "${GASOLINE_URL}/mcp" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"${TOOL}\",\"arguments\":${ARGS}}}")
+
+# Extract the content from JSON-RPC response for cleaner output
+echo "$RESPONSE" | python3 -c "
+import sys, json
+try:
+    r = json.load(sys.stdin)
+    if 'error' in r:
+        print(json.dumps(r['error'], indent=2))
+    elif 'result' in r:
+        content = r['result'].get('content', [])
+        for item in content:
+            if item.get('type') == 'text':
+                print(item['text'])
+            elif item.get('type') == 'image':
+                print(f'[image: {item.get(\"mimeType\",\"unknown\")}]')
+    else:
+        print(json.dumps(r, indent=2))
+except:
+    print(sys.stdin.read())
+" 2>/dev/null || echo "$RESPONSE"

--- a/claude_skill/gasoline/scripts/gasoline-call.sh
+++ b/claude_skill/gasoline/scripts/gasoline-call.sh
@@ -15,9 +15,26 @@ if [ -z "$TOOL" ]; then
   exit 1
 fi
 
-RESPONSE=$(curl -s --max-time 30 -X POST "${GASOLINE_URL}/mcp" \
+RESPONSE=$(curl -s --max-time 30 -w '\n%{http_code}' -X POST "${GASOLINE_URL}/mcp" \
   -H "Content-Type: application/json" \
-  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"${TOOL}\",\"arguments\":${ARGS}}}")
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"${TOOL}\",\"arguments\":${ARGS}}}" 2>/dev/null) || {
+  echo '{"error":"Failed to connect to Gasoline daemon at '"${GASOLINE_URL}"'. Is the server running?"}' >&2
+  exit 1
+}
+
+# Split response body and HTTP status code
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+if [ -z "$RESPONSE" ] || [ "$HTTP_CODE" = "000" ]; then
+  echo '{"error":"Daemon unreachable at '"${GASOLINE_URL}"'. Run: bash scripts/ensure-daemon.sh"}' >&2
+  exit 1
+fi
+
+if [ "$HTTP_CODE" -ge 400 ] 2>/dev/null; then
+  echo "{\"error\":\"HTTP ${HTTP_CODE} from daemon\",\"body\":$(echo "$RESPONSE" | head -1)}" >&2
+  exit 1
+fi
 
 # Extract the content from JSON-RPC response for cleaner output
 echo "$RESPONSE" | python3 -c "

--- a/claude_skill/install.sh
+++ b/claude_skill/install.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# install.sh — Install the Gasoline Claude Code skill.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_SRC="$SCRIPT_DIR/gasoline"
+
+if [ ! -d "$SKILL_SRC" ]; then
+  echo "Error: gasoline skill directory not found at $SKILL_SRC" >&2
+  exit 1
+fi
+
+# --- Install matching MCP server ---
+install_mcp_server() {
+  if ! command -v npm &>/dev/null; then
+    echo "npm not found — skipping MCP server install."
+    return
+  fi
+
+  echo ""
+  echo "Install the Gasoline MCP server (gasoline-agentic-browser)."
+  echo "  To match your Chrome extension version, check chrome://extensions"
+  echo "  and find the version number next to 'Gasoline Devtools'."
+  echo ""
+  read -rp "Enter extension version to match (or press Enter for latest): " version
+
+  if [ -z "$version" ]; then
+    echo "Installing latest gasoline-agentic-browser..."
+    npm install -g gasoline-agentic-browser
+    return
+  fi
+
+  # Validate version exists on npm
+  echo "Checking if gasoline-agentic-browser@${version} exists on npm..."
+  while true; do
+    if npm view "gasoline-agentic-browser@${version}" version &>/dev/null; then
+      npm install -g "gasoline-agentic-browser@${version}"
+      return
+    else
+      echo "ERROR: Version ${version} not found on npm."
+      echo "  Available versions:"
+      npm view gasoline-agentic-browser versions --json 2>/dev/null \
+        | tr -d '[]",' | xargs -n1 | tail -5 | sed 's/^/    /'
+      echo ""
+      read -rp "Enter a different version (or press Enter for latest): " version
+      if [ -z "$version" ]; then
+        echo "Installing latest gasoline-agentic-browser..."
+        npm install -g gasoline-agentic-browser
+        return
+      fi
+    fi
+  done
+}
+
+# Check if we're inside a git project
+IN_GIT=false
+GIT_ROOT=""
+if git rev-parse --show-toplevel > /dev/null 2>&1; then
+  IN_GIT=true
+  GIT_ROOT="$(git rev-parse --show-toplevel)"
+fi
+
+GLOBAL_DIR="$HOME/.claude/skills/gasoline"
+PROJECT_DIR=""
+if $IN_GIT; then
+  PROJECT_DIR="$GIT_ROOT/.claude/skills/gasoline"
+fi
+
+install_skill() {
+  local dest="$1"
+  if [ -d "$dest" ]; then
+    echo ""
+    echo "WARNING: Existing skill found at $dest"
+    echo "  The previous version will be deleted and replaced."
+    read -rp "Overwrite? [y/N]: " overwrite
+    case "$overwrite" in
+      [Yy]*)
+        rm -rf "$dest"
+        ;;
+      *)
+        echo "Skipping skill install."
+        return
+        ;;
+    esac
+  fi
+  mkdir -p "$dest"
+  cp -r "$SKILL_SRC/"* "$dest/"
+  echo "Installed gasoline skill to $dest"
+}
+
+if $IN_GIT; then
+  echo "You are inside a git project: $GIT_ROOT"
+  echo ""
+  echo "Where do you want to install the Gasoline skill?"
+  echo "  1) Global  (~/.claude/skills/gasoline) — available in all projects"
+  echo "  2) Project (.claude/skills/gasoline)   — this project only"
+  echo ""
+  read -rp "Choose [1/2]: " choice
+
+  case "$choice" in
+    1) install_skill "$GLOBAL_DIR" ;;
+    2) install_skill "$PROJECT_DIR" ;;
+    *)
+      echo "Invalid choice. Aborting." >&2
+      exit 1
+      ;;
+  esac
+else
+  echo "Not inside a git project. Installing globally."
+  install_skill "$GLOBAL_DIR"
+fi
+
+# Install MCP server to match the Chrome extension version
+install_mcp_server


### PR DESCRIPTION
## Summary

- Adds a **Claude Code skill** that packages Gasoline's 5 tools (observe, analyze, generate, configure, interact) as a progressive-disclosure skill, avoiding the ~21K token overhead of loading full MCP schemas into every conversation
- Includes reference docs for all tool modes, workflow guides (debugging, auditing, automation, performance), and helper scripts (daemon management, connection doctor, tool caller)
- Ships an interactive install script (`claude_skill/install.sh`) supporting both global (`~/.claude/skills/`) and project-local (`.claude/skills/`) installation, with version-matching against the Chrome extension

## What's included

```
claude_skill/
├── README.md                          # Setup & usage docs
├── install.sh                         # Interactive installer
└── gasoline/
    ├── SKILL.md                       # Skill entry point with tool quick-reference
    ├── references/
    │   ├── observe-modes.md           # All observe tool modes
    │   ├── analyze-modes.md           # All analyze tool modes
    │   ├── generate-modes.md          # All generate tool modes
    │   ├── configure-modes.md         # All configure tool modes
    │   ├── interact-actions.md        # All interact tool actions
    │   ├── workflow-debug-and-triage.md
    │   ├── workflow-audit-and-security.md
    │   ├── workflow-automate-and-test.md
    │   └── workflow-performance.md
    └── scripts/
        ├── ensure-daemon.sh           # Start daemon if not running
        ├── connection-doctor.sh       # Diagnose connectivity issues
        └── gasoline-call.sh           # Tool invocation helper
```

## How it works

Instead of running as an MCP server (`npx gasoline-mcp` in `.mcp.json`), the skill calls the `gasoline-agentic-browser` binary directly via HTTP. Claude Code loads the SKILL.md on demand when trigger phrases match (e.g. "check my browser", "take a screenshot", "run accessibility audit"), and reference docs are loaded progressively only when needed.

## Test plan

- [ ] Run `bash claude_skill/install.sh` — verify global and project-local install paths
- [ ] Verify skill triggers in Claude Code with phrases like "check my browser for errors"
- [ ] Verify tool calls work: `bash scripts/gasoline-call.sh observe '{"what":"errors"}'`
- [ ] Verify connection doctor: `bash scripts/connection-doctor.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)