### PR TITLE
feat: scaffold wizard — Phase 1 with TDD

### DIFF
--- a/cmd/browser-agent/scaffold_api.go
+++ b/cmd/browser-agent/scaffold_api.go
@@ -1,13 +1,6 @@
-// scaffold_api.go — Handles POST /api/scaffold to initiate project scaffolding.
+// scaffold_api.go — Types and validation for POST /api/scaffold.
 
 package main
-
-import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"time"
-)
 
 // scaffoldRequest is the JSON body for POST /api/scaffold.
 type scaffoldRequest struct {
@@ -28,40 +21,4 @@ var validAudiences = map[string]bool{
 	"just_me": true,
 	"my_team": true,
 	"public":  true,
-}
-
-// handleScaffoldAPI handles POST /api/scaffold.
-func handleScaffoldAPI(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "Method not allowed"})
-		return
-	}
-
-	var req scaffoldRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "Invalid JSON body"})
-		return
-	}
-
-	// Validate required fields.
-	if req.Description == "" {
-		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "description is required"})
-		return
-	}
-	if req.Name == "" {
-		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
-		return
-	}
-	if req.Audience != "" && !validAudiences[req.Audience] {
-		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "audience must be one of: just_me, my_team, public"})
-		return
-	}
-
-	// Generate channel ID.
-	channel := fmt.Sprintf("scaffold-%s-%d", req.Name, time.Now().Unix())
-
-	jsonResponse(w, http.StatusAccepted, scaffoldResponse{
-		Status:  "accepted",
-		Channel: channel,
-	})
 }

--- a/cmd/browser-agent/scaffold_api.go
+++ b/cmd/browser-agent/scaffold_api.go
@@ -1,0 +1,67 @@
+// scaffold_api.go — Handles POST /api/scaffold to initiate project scaffolding.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// scaffoldRequest is the JSON body for POST /api/scaffold.
+type scaffoldRequest struct {
+	Description  string `json:"description"`
+	Audience     string `json:"audience"`
+	FirstFeature string `json:"first_feature"`
+	Name         string `json:"name"`
+}
+
+// scaffoldResponse is the JSON response for POST /api/scaffold.
+type scaffoldResponse struct {
+	Status  string `json:"status"`
+	Channel string `json:"channel"`
+}
+
+// validAudiences is the set of allowed audience values.
+var validAudiences = map[string]bool{
+	"just_me": true,
+	"my_team": true,
+	"public":  true,
+}
+
+// handleScaffoldAPI handles POST /api/scaffold.
+func handleScaffoldAPI(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "Method not allowed"})
+		return
+	}
+
+	var req scaffoldRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "Invalid JSON body"})
+		return
+	}
+
+	// Validate required fields.
+	if req.Description == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "description is required"})
+		return
+	}
+	if req.Name == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	if req.Audience != "" && !validAudiences[req.Audience] {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "audience must be one of: just_me, my_team, public"})
+		return
+	}
+
+	// Generate channel ID.
+	channel := fmt.Sprintf("scaffold-%s-%d", req.Name, time.Now().Unix())
+
+	jsonResponse(w, http.StatusAccepted, scaffoldResponse{
+		Status:  "accepted",
+		Channel: channel,
+	})
+}

--- a/cmd/browser-agent/scaffold_api_test.go
+++ b/cmd/browser-agent/scaffold_api_test.go
@@ -1,0 +1,150 @@
+// scaffold_api_test.go — Tests for POST /api/scaffold endpoint.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ============================================
+// Scaffold API: POST /api/scaffold
+// ============================================
+
+func TestScaffoldAPI_ValidRequest_Returns202(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	body := `{"description":"a todo app","audience":"just_me","first_feature":"drag and drop","name":"todo-app"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("POST /api/scaffold: want 202, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp scaffoldResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("POST /api/scaffold: decode response: %v", err)
+	}
+
+	if resp.Status != "accepted" {
+		t.Errorf("POST /api/scaffold: want status 'accepted', got %q", resp.Status)
+	}
+	if resp.Channel == "" {
+		t.Error("POST /api/scaffold: channel must not be empty")
+	}
+	if !strings.HasPrefix(resp.Channel, "scaffold-todo-app-") {
+		t.Errorf("POST /api/scaffold: channel %q should start with 'scaffold-todo-app-'", resp.Channel)
+	}
+}
+
+func TestScaffoldAPI_MissingName_Returns400(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	body := `{"description":"a todo app","audience":"just_me","first_feature":"drag and drop"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/scaffold missing name: want 400, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_MissingDescription_Returns400(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	body := `{"audience":"just_me","first_feature":"drag and drop","name":"todo-app"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/scaffold missing description: want 400, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_EmptyBody_Returns400(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/scaffold empty body: want 400, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_InvalidJSON_Returns400(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader("{invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/scaffold invalid json: want 400, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_GET_MethodNotAllowed(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/api/scaffold", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET /api/scaffold: want 405, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_InvalidAudience_Returns400(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	body := `{"description":"a todo app","audience":"aliens","first_feature":"drag and drop","name":"todo-app"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/scaffold invalid audience: want 400, got %d", rec.Code)
+	}
+}
+
+func TestScaffoldAPI_ResponseHasSnakeCaseFields(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	body := `{"description":"a todo app","audience":"just_me","first_feature":"drag and drop","name":"todo-app"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	raw := rec.Body.String()
+	if !strings.Contains(raw, `"status"`) {
+		t.Error("response should use snake_case field 'status'")
+	}
+	if !strings.Contains(raw, `"channel"`) {
+		t.Error("response should use snake_case field 'channel'")
+	}
+}

--- a/cmd/browser-agent/scaffold_runner.go
+++ b/cmd/browser-agent/scaffold_runner.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/scaffold"
@@ -15,6 +18,7 @@ import (
 // ScaffoldRunner manages scaffold job execution and progress broadcasting.
 type ScaffoldRunner struct {
 	broadcaster *scaffold.Broadcaster
+	inflight    sync.Map // in-flight project names → struct{}
 }
 
 // NewScaffoldRunner creates a new scaffold runner.
@@ -30,6 +34,9 @@ func (sr *ScaffoldRunner) HandleScaffold(w http.ResponseWriter, r *http.Request)
 		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "Method not allowed"})
 		return
 	}
+
+	// Limit request body to 1 MB.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	var req scaffoldRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -48,6 +55,12 @@ func (sr *ScaffoldRunner) HandleScaffold(w http.ResponseWriter, r *http.Request)
 	}
 	if req.Audience != "" && !validAudiences[req.Audience] {
 		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "audience must be one of: just_me, my_team, public"})
+		return
+	}
+
+	// Concurrency guard: reject if same project name is already scaffolding.
+	if _, loaded := sr.inflight.LoadOrStore(req.Name, struct{}{}); loaded {
+		jsonResponse(w, http.StatusConflict, map[string]string{"error": fmt.Sprintf("project %q is already being scaffolded", req.Name)})
 		return
 	}
 
@@ -73,6 +86,22 @@ func (sr *ScaffoldRunner) HandleScaffold(w http.ResponseWriter, r *http.Request)
 
 // runScaffold executes the scaffold steps in the background.
 func (sr *ScaffoldRunner) runScaffold(cfg scaffold.Config, channel string) {
+	// Always release the concurrency guard when done.
+	defer sr.inflight.Delete(cfg.Name)
+
+	// Panic recovery: broadcast error if a panic occurs.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("scaffold panic for %q: %v\n%s", cfg.Name, r, debug.Stack())
+			sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
+				Step:   "scaffold",
+				Status: "error",
+				Label:  "Scaffold failed (internal error)",
+				Error:  fmt.Sprintf("panic: %v", r),
+			})
+		}
+	}()
+
 	eng, err := scaffold.NewEngine(cfg)
 	if err != nil {
 		sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
@@ -89,7 +118,10 @@ func (sr *ScaffoldRunner) runScaffold(cfg scaffold.Config, channel string) {
 	})
 
 	steps := scaffold.DefaultSteps()
-	ctx := context.Background()
+
+	// Timeout: 5 minutes for the entire scaffold process.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	if err := eng.RunAll(ctx, steps); err != nil {
 		sr.broadcaster.Broadcast(channel, scaffold.StepEvent{

--- a/cmd/browser-agent/scaffold_runner.go
+++ b/cmd/browser-agent/scaffold_runner.go
@@ -1,0 +1,120 @@
+// scaffold_runner.go — Wires the scaffold API endpoint to the scaffold engine.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/scaffold"
+)
+
+// ScaffoldRunner manages scaffold job execution and progress broadcasting.
+type ScaffoldRunner struct {
+	broadcaster *scaffold.Broadcaster
+}
+
+// NewScaffoldRunner creates a new scaffold runner.
+func NewScaffoldRunner() *ScaffoldRunner {
+	return &ScaffoldRunner{
+		broadcaster: scaffold.NewBroadcaster(),
+	}
+}
+
+// HandleScaffold handles POST /api/scaffold.
+func (sr *ScaffoldRunner) HandleScaffold(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "Method not allowed"})
+		return
+	}
+
+	var req scaffoldRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "Invalid JSON body"})
+		return
+	}
+
+	// Validate required fields.
+	if req.Description == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "description is required"})
+		return
+	}
+	if req.Name == "" {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	if req.Audience != "" && !validAudiences[req.Audience] {
+		jsonResponse(w, http.StatusBadRequest, map[string]string{"error": "audience must be one of: just_me, my_team, public"})
+		return
+	}
+
+	// Generate channel ID.
+	channel := fmt.Sprintf("scaffold-%s-%d", req.Name, time.Now().Unix())
+
+	// Create engine config.
+	cfg := scaffold.Config{
+		Description:  req.Description,
+		Audience:     req.Audience,
+		FirstFeature: req.FirstFeature,
+		Name:         req.Name,
+	}
+
+	// Start scaffold in background.
+	go sr.runScaffold(cfg, channel)
+
+	jsonResponse(w, http.StatusAccepted, scaffoldResponse{
+		Status:  "accepted",
+		Channel: channel,
+	})
+}
+
+// runScaffold executes the scaffold steps in the background.
+func (sr *ScaffoldRunner) runScaffold(cfg scaffold.Config, channel string) {
+	eng, err := scaffold.NewEngine(cfg)
+	if err != nil {
+		sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
+			Step:   "init",
+			Status: "error",
+			Label:  "Initialization failed",
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	eng.OnProgress(func(evt scaffold.StepEvent) {
+		sr.broadcaster.Broadcast(channel, evt)
+	})
+
+	steps := scaffold.DefaultSteps()
+	ctx := context.Background()
+
+	if err := eng.RunAll(ctx, steps); err != nil {
+		sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
+			Step:   "scaffold",
+			Status: "error",
+			Label:  "Scaffold failed",
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	// Write AI context files.
+	if err := scaffold.WriteAIContext(eng.ProjectDir(), cfg); err != nil {
+		sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
+			Step:   "ai_context",
+			Status: "error",
+			Label:  "AI context generation failed",
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	sr.broadcaster.Broadcast(channel, scaffold.StepEvent{
+		Step:   "scaffold",
+		Status: "complete",
+		Label:  "Scaffold complete",
+	})
+}

--- a/cmd/browser-agent/scaffold_runner_test.go
+++ b/cmd/browser-agent/scaffold_runner_test.go
@@ -1,0 +1,86 @@
+// scaffold_runner_test.go — Tests for the scaffold runner that wires API to engine.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/scaffold"
+)
+
+// ============================================
+// Scaffold Runner: API → Engine integration
+// ============================================
+
+func TestScaffoldRunner_AcceptsAndTracksJob(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/scaffold", runner.HandleScaffold)
+
+	body := `{"description":"a test app","audience":"just_me","first_feature":"testing","name":"test-runner-app"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp scaffoldResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Channel == "" {
+		t.Error("channel should not be empty")
+	}
+	if resp.Status != "accepted" {
+		t.Errorf("status: want 'accepted', got %q", resp.Status)
+	}
+}
+
+func TestScaffoldRunner_BroadcastsProgress(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	// Subscribe to any channel starting with "scaffold-".
+	ch := runner.broadcaster.Subscribe("scaffold-test-app-0")
+
+	// Manually broadcast an event.
+	runner.broadcaster.Broadcast("scaffold-test-app-0", scaffold.StepEvent{
+		Step:   "create_project",
+		Status: "running",
+		Label:  "Creating project",
+	})
+
+	select {
+	case evt := <-ch:
+		if evt.Step != "create_project" {
+			t.Errorf("want step 'create_project', got %q", evt.Step)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for broadcast")
+	}
+}
+
+func TestScaffoldRunner_RejectsInvalidInput(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/scaffold", runner.HandleScaffold)
+
+	body := `{"description":"","name":""}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}

--- a/cmd/browser-agent/scaffold_runner_test.go
+++ b/cmd/browser-agent/scaffold_runner_test.go
@@ -84,3 +84,93 @@ func TestScaffoldRunner_RejectsInvalidInput(t *testing.T) {
 		t.Errorf("want 400, got %d", rec.Code)
 	}
 }
+
+// ============================================
+// Body Size Limit
+// ============================================
+
+func TestScaffoldRunner_RejectsOversizedBody(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/scaffold", runner.HandleScaffold)
+
+	// Create a body larger than 1 MB.
+	largeBody := strings.Repeat("x", 1<<20+1)
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized body: want 400, got %d", rec.Code)
+	}
+}
+
+// ============================================
+// Concurrency Guard
+// ============================================
+
+func TestScaffoldRunner_RejectsDuplicateProject(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	// Simulate an in-flight scaffold for "dup-project".
+	runner.inflight.Store("dup-project", struct{}{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/scaffold", runner.HandleScaffold)
+
+	body := `{"description":"a test app","audience":"just_me","first_feature":"testing","name":"dup-project"}`
+	req := httptest.NewRequest("POST", "/api/scaffold", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("duplicate project: want 409, got %d", rec.Code)
+	}
+}
+
+// ============================================
+// Panic Recovery
+// ============================================
+
+func TestScaffoldRunner_PanicRecovery(t *testing.T) {
+	runner := NewScaffoldRunner()
+
+	channel := "scaffold-panic-test-0"
+	ch := runner.broadcaster.Subscribe(channel)
+
+	// Directly call runScaffold with a config that will cause NewEngine to succeed
+	// but we'll verify the panic recovery by checking the inflight map is cleaned up.
+	// We can't easily trigger a panic in the engine, so we test the defer cleanup instead.
+	cfg := scaffold.Config{
+		Description:  "test",
+		Name:         "panic-test",
+	}
+
+	// Store in inflight to verify it gets cleaned up.
+	runner.inflight.Store("panic-test", struct{}{})
+
+	// Run scaffold in a goroutine — it will fail because the home directory
+	// scaffold path likely doesn't exist or has permission issues, but should
+	// not panic. The inflight entry should be cleaned up.
+	done := make(chan struct{})
+	go func() {
+		runner.runScaffold(cfg, channel)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Verify inflight was cleaned up.
+		if _, loaded := runner.inflight.Load("panic-test"); loaded {
+			t.Error("inflight entry should be cleaned up after runScaffold completes")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for runScaffold to complete")
+	}
+
+	// Drain any events from the channel.
+	runner.broadcaster.Unsubscribe(ch)
+}

--- a/cmd/browser-agent/scaffold_wizard.go
+++ b/cmd/browser-agent/scaffold_wizard.go
@@ -1,0 +1,25 @@
+// scaffold_wizard.go — Serves the scaffold wizard landing page and registers scaffold routes.
+
+package main
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed scaffold_wizard.html
+var scaffoldWizardHTML []byte
+
+// registerScaffoldRoutes adds scaffold wizard routes to the mux.
+func registerScaffoldRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/launch", handleWizardLaunch)
+}
+
+// handleWizardLaunch serves the scaffold wizard landing page.
+func handleWizardLaunch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{"error": "Method not allowed"})
+		return
+	}
+	serveEmbeddedHTML(w, r, scaffoldWizardHTML, "wizard")
+}

--- a/cmd/browser-agent/scaffold_wizard.go
+++ b/cmd/browser-agent/scaffold_wizard.go
@@ -12,8 +12,9 @@ var scaffoldWizardHTML []byte
 
 // registerScaffoldRoutes adds scaffold wizard routes to the mux.
 func registerScaffoldRoutes(mux *http.ServeMux) {
+	sr := NewScaffoldRunner()
 	mux.HandleFunc("/launch", handleWizardLaunch)
-	mux.HandleFunc("/api/scaffold", handleScaffoldAPI)
+	mux.HandleFunc("/api/scaffold", sr.HandleScaffold)
 }
 
 // handleWizardLaunch serves the scaffold wizard landing page.

--- a/cmd/browser-agent/scaffold_wizard.go
+++ b/cmd/browser-agent/scaffold_wizard.go
@@ -13,6 +13,7 @@ var scaffoldWizardHTML []byte
 // registerScaffoldRoutes adds scaffold wizard routes to the mux.
 func registerScaffoldRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/launch", handleWizardLaunch)
+	mux.HandleFunc("/api/scaffold", handleScaffoldAPI)
 }
 
 // handleWizardLaunch serves the scaffold wizard landing page.

--- a/cmd/browser-agent/scaffold_wizard.html
+++ b/cmd/browser-agent/scaffold_wizard.html
@@ -1,0 +1,531 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Build Something New — Strum</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f1117;
+      --bg-card: #1a1d27;
+      --bg-input: #252836;
+      --border: #2e3241;
+      --text: #e4e6eb;
+      --text-muted: #8b8fa3;
+      --accent: #3b82f6;
+      --accent-hover: #2563eb;
+      --success: #22c55e;
+      --radius: 12px;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    #wizard {
+      max-width: 560px;
+      width: 100%;
+      padding: 2rem;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .subtitle {
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      margin-bottom: 2rem;
+    }
+
+    #progress {
+      display: flex;
+      gap: 6px;
+      margin-bottom: 2rem;
+    }
+
+    .progress-dot {
+      width: 100%;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--border);
+      transition: background 0.3s ease;
+    }
+
+    .progress-dot.active {
+      background: var(--accent);
+    }
+
+    .progress-dot.done {
+      background: var(--success);
+    }
+
+    .step {
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .step.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .step-label {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+
+    .step-hint {
+      color: var(--text-muted);
+      font-size: 0.85rem;
+      margin-bottom: 1rem;
+    }
+
+    input[type="text"], textarea {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    input[type="text"]:focus, textarea:focus {
+      border-color: var(--accent);
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 60px;
+    }
+
+    .audience-options {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .audience-btn {
+      padding: 0.6rem 1.2rem;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+
+    .audience-btn:hover {
+      border-color: var(--accent);
+    }
+
+    .audience-btn.selected {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+
+    .nav-row {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 1.5rem;
+    }
+
+    .btn {
+      padding: 0.7rem 1.5rem;
+      border-radius: var(--radius);
+      border: none;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .btn-next {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .btn-next:hover {
+      background: var(--accent-hover);
+    }
+
+    .btn-next:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .btn-back {
+      background: transparent;
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+    }
+
+    .btn-back:hover {
+      color: var(--text);
+      border-color: var(--text-muted);
+    }
+
+    .btn-create {
+      background: var(--success);
+      color: #fff;
+      width: 100%;
+      padding: 1rem;
+      font-size: 1.1rem;
+    }
+
+    .btn-create:hover {
+      filter: brightness(1.1);
+    }
+
+    .btn-create:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    #summary {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem 1.25rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+      line-height: 1.7;
+    }
+
+    #summary .check {
+      color: var(--success);
+    }
+
+    #phase1-progress {
+      display: none;
+    }
+
+    .step-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 0;
+      font-size: 0.9rem;
+    }
+
+    .step-row .icon {
+      width: 20px;
+      text-align: center;
+    }
+
+    .spinner {
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
+</head>
+<body>
+  <div id="wizard">
+    <h1>Build Something New</h1>
+    <p class="subtitle">Create a new app from scratch with AI</p>
+
+    <div id="progress">
+      <div class="progress-dot active" data-step="1"></div>
+      <div class="progress-dot" data-step="2"></div>
+      <div class="progress-dot" data-step="3"></div>
+      <div class="progress-dot" data-step="4"></div>
+    </div>
+
+    <!-- Step 1: What are you building? -->
+    <div class="step active" data-step="1">
+      <div class="step-label">What are you building?</div>
+      <div class="step-hint">A few words is enough. Examples: "a todo app", "a dashboard for sales data", "a landing page"</div>
+      <input type="text" id="input-description" placeholder="Describe your app..." autofocus>
+      <div class="nav-row">
+        <span></span>
+        <button class="btn btn-next" id="btn-next-1" disabled>Next</button>
+      </div>
+    </div>
+
+    <!-- Step 2: Who is it for? -->
+    <div class="step" data-step="2">
+      <div class="step-label">Who is it for?</div>
+      <div class="step-hint">This shapes how the app is set up — auth, permissions, and deployment</div>
+      <div class="audience-options">
+        <button class="audience-btn" data-audience="just_me">Just me</button>
+        <button class="audience-btn" data-audience="my_team">My team</button>
+        <button class="audience-btn" data-audience="public">Public users</button>
+      </div>
+      <div class="nav-row">
+        <button class="btn btn-back" id="btn-back-2">Back</button>
+        <button class="btn btn-next" id="btn-next-2" disabled>Next</button>
+      </div>
+    </div>
+
+    <!-- Step 3: What's the most important first feature? -->
+    <div class="step" data-step="3">
+      <div class="step-label">What's the most important first feature?</div>
+      <div class="step-hint">Just one thing — the feature you'd show someone first</div>
+      <input type="text" id="input-feature" placeholder="e.g., drag and drop reordering">
+      <div class="nav-row">
+        <button class="btn btn-back" id="btn-back-3">Back</button>
+        <button class="btn btn-next" id="btn-next-3" disabled>Next</button>
+      </div>
+    </div>
+
+    <!-- Step 4: Project name -->
+    <div class="step" data-step="4">
+      <div class="step-label">Project name</div>
+      <div class="step-hint">Auto-generated from your description. Edit if you'd like.</div>
+      <input type="text" id="input-name" placeholder="my-app">
+      <div class="nav-row">
+        <button class="btn btn-back" id="btn-back-4">Back</button>
+        <span></span>
+      </div>
+      <div id="summary" style="margin-top: 1.5rem;"></div>
+      <button class="btn btn-create" id="btn-create" disabled>Create</button>
+    </div>
+
+    <!-- Phase 1 progress -->
+    <div id="phase1-progress">
+      <div class="step-label">Setting up your project...</div>
+      <div id="scaffold-steps"></div>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      'use strict';
+
+      var state = {
+        step: 1,
+        description: '',
+        audience: '',
+        first_feature: '',
+        name: ''
+      };
+
+      var totalSteps = 4;
+
+      // DOM refs
+      var steps = document.querySelectorAll('.step');
+      var dots = document.querySelectorAll('.progress-dot');
+
+      function slugify(text) {
+        return text.toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-|-$/g, '')
+          .substring(0, 40);
+      }
+
+      function showStep(n) {
+        state.step = n;
+        steps.forEach(function(s) {
+          s.classList.toggle('active', parseInt(s.getAttribute('data-step')) === n);
+        });
+        dots.forEach(function(d) {
+          var ds = parseInt(d.getAttribute('data-step'));
+          d.classList.toggle('active', ds === n);
+          d.classList.toggle('done', ds < n);
+        });
+
+        // Auto-focus input on step change
+        var activeStep = document.querySelector('.step.active');
+        if (activeStep) {
+          var input = activeStep.querySelector('input, textarea');
+          if (input) input.focus();
+        }
+
+        if (n === 4) {
+          updateSummary();
+          updateCreateButton();
+        }
+      }
+
+      function updateSummary() {
+        var el = document.getElementById('summary');
+        el.innerHTML =
+          'Ready to create <strong>"' + escapeHTML(state.name) + '"</strong>:<br>' +
+          '<span class="check">&#10003;</span> React + TypeScript + Tailwind + shadcn<br>' +
+          '<span class="check">&#10003;</span> ' + escapeHTML(state.description) + '<br>' +
+          '<span class="check">&#10003;</span> First feature: ' + escapeHTML(state.first_feature) + '<br>' +
+          '<span class="check">&#10003;</span> Audience: ' + escapeHTML(state.audience.replace(/_/g, ' '));
+      }
+
+      function updateCreateButton() {
+        var btn = document.getElementById('btn-create');
+        btn.disabled = !state.name;
+      }
+
+      function escapeHTML(s) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(s));
+        return div.innerHTML;
+      }
+
+      // Step 1: description
+      var descInput = document.getElementById('input-description');
+      var nextBtn1 = document.getElementById('btn-next-1');
+      descInput.addEventListener('input', function() {
+        state.description = descInput.value.trim();
+        nextBtn1.disabled = !state.description;
+      });
+      nextBtn1.addEventListener('click', function() {
+        if (state.description) {
+          // Auto-generate project name
+          state.name = slugify(state.description);
+          document.getElementById('input-name').value = state.name;
+          showStep(2);
+        }
+      });
+
+      // Step 2: audience
+      var audienceBtns = document.querySelectorAll('.audience-btn');
+      var nextBtn2 = document.getElementById('btn-next-2');
+      audienceBtns.forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          audienceBtns.forEach(function(b) { b.classList.remove('selected'); });
+          btn.classList.add('selected');
+          state.audience = btn.getAttribute('data-audience');
+          nextBtn2.disabled = false;
+        });
+      });
+      nextBtn2.addEventListener('click', function() {
+        if (state.audience) showStep(3);
+      });
+      document.getElementById('btn-back-2').addEventListener('click', function() { showStep(1); });
+
+      // Step 3: first feature
+      var featureInput = document.getElementById('input-feature');
+      var nextBtn3 = document.getElementById('btn-next-3');
+      featureInput.addEventListener('input', function() {
+        state.first_feature = featureInput.value.trim();
+        nextBtn3.disabled = !state.first_feature;
+      });
+      nextBtn3.addEventListener('click', function() {
+        if (state.first_feature) showStep(4);
+      });
+      document.getElementById('btn-back-3').addEventListener('click', function() { showStep(2); });
+
+      // Step 4: project name
+      var nameInput = document.getElementById('input-name');
+      nameInput.addEventListener('input', function() {
+        state.name = slugify(nameInput.value.trim());
+        nameInput.value = state.name;
+        updateSummary();
+        updateCreateButton();
+      });
+      document.getElementById('btn-back-4').addEventListener('click', function() { showStep(3); });
+
+      // Create button
+      document.getElementById('btn-create').addEventListener('click', function() {
+        var btn = document.getElementById('btn-create');
+        btn.disabled = true;
+        btn.textContent = 'Creating...';
+
+        var payload = {
+          description: state.description,
+          audience: state.audience,
+          first_feature: state.first_feature,
+          name: state.name
+        };
+
+        fetch('/api/scaffold', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
+        .then(function(resp) { return resp.json(); })
+        .then(function(data) {
+          if (data.channel) {
+            showPhase1(data.channel);
+          }
+        })
+        .catch(function(err) {
+          btn.disabled = false;
+          btn.textContent = 'Create';
+          console.error('scaffold error:', err);
+        });
+      });
+
+      function showPhase1(channel) {
+        document.querySelectorAll('.step').forEach(function(s) { s.classList.remove('active'); });
+        document.getElementById('progress').style.display = 'none';
+        document.getElementById('phase1-progress').style.display = 'block';
+
+        // Connect to WebSocket for progress updates
+        var wsPort = 7891;
+        var ws = new WebSocket('ws://localhost:' + wsPort + '/ws');
+        ws.onmessage = function(evt) {
+          try {
+            var msg = JSON.parse(evt.data);
+            if (msg.channel === 'scaffold') {
+              updateScaffoldStep(msg);
+            }
+          } catch(e) {
+            // ignore parse errors
+          }
+        };
+      }
+
+      function updateScaffoldStep(msg) {
+        var container = document.getElementById('scaffold-steps');
+        var id = 'scaffold-step-' + (msg.step || 'unknown');
+        var row = document.getElementById(id);
+        if (!row) {
+          row = document.createElement('div');
+          row.id = id;
+          row.className = 'step-row';
+          container.appendChild(row);
+        }
+
+        var icon = msg.status === 'done' ? '<span class="check" style="color:var(--success)">&#10003;</span>' :
+                   msg.status === 'running' ? '<span class="spinner"></span>' :
+                   '<span style="color:var(--text-muted)">&#9675;</span>';
+
+        row.innerHTML = '<span class="icon">' + icon + '</span> ' + escapeHTML(msg.label || msg.step || '');
+      }
+
+      // Enter key advances steps
+      descInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && !nextBtn1.disabled) nextBtn1.click();
+      });
+      featureInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && !nextBtn3.disabled) nextBtn3.click();
+      });
+      nameInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') {
+          var createBtn = document.getElementById('btn-create');
+          if (!createBtn.disabled) createBtn.click();
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/cmd/browser-agent/scaffold_wizard_test.go
+++ b/cmd/browser-agent/scaffold_wizard_test.go
@@ -1,0 +1,76 @@
+// scaffold_wizard_test.go — Tests for the scaffold wizard landing page and API endpoint.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ============================================
+// Wizard Landing Page: GET /launch
+// ============================================
+
+func TestWizardLaunch_GET_Returns200WithHTML(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/launch", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /launch: want status 200, got %d", rec.Code)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("GET /launch: want Content-Type text/html, got %q", ct)
+	}
+}
+
+func TestWizardLaunch_GET_ContainsExpectedStructure(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/launch", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"html tag", "<html"},
+		{"wizard container", `id="wizard"`},
+		{"step 1 prompt", "What are you building"},
+		{"step 2 prompt", "Who is it for"},
+		{"step 3 prompt", "most important first feature"},
+		{"step 4 prompt", "Project name"},
+		{"create button", "Create"},
+		{"progress bar", `id="progress"`},
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(body, c.contains) {
+			t.Errorf("GET /launch: body missing %s (expected %q)", c.label, c.contains)
+		}
+	}
+}
+
+func TestWizardLaunch_POST_MethodNotAllowed(t *testing.T) {
+	mux := http.NewServeMux()
+	registerScaffoldRoutes(mux)
+
+	req := httptest.NewRequest("POST", "/launch", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /launch: want status 405, got %d", rec.Code)
+	}
+}

--- a/cmd/browser-agent/server_routes.go
+++ b/cmd/browser-agent/server_routes.go
@@ -191,6 +191,9 @@ func registerCoreRoutes(mux *http.ServeMux, server *Server, cap *capture.Store) 
 		handleActiveCodebase(w, r, server)
 	})))
 
+	// NOT MCP — Scaffold wizard (browser) — create new projects from /launch
+	registerScaffoldRoutes(mux)
+
 	// NOT MCP — HTML dashboard (browser) with JSON fallback (Accept: application/json)
 	mux.HandleFunc("/", corsMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		server.handleDashboard(w, r)

--- a/internal/scaffold/ai_context.go
+++ b/internal/scaffold/ai_context.go
@@ -1,0 +1,160 @@
+// ai_context.go — Generates AI context files (CLAUDE.md, bootstrap skill, hooks, .mcp.json).
+
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteAIContext generates AI context files based on the wizard configuration.
+func WriteAIContext(projectDir string, cfg Config) error {
+	files := []struct {
+		path    string
+		content string
+	}{
+		{".claude/CLAUDE.md", generateClaudeMD(cfg)},
+		{".claude/skills/strum-dev/SKILL.md", generateBootstrapSkill()},
+		{".claude/hooks/session-start.js", generateSessionStartHook()},
+		{".mcp.json", mcpJSON},
+	}
+
+	for _, f := range files {
+		path := filepath.Join(projectDir, f.path)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("create directory for %s: %w", f.path, err)
+		}
+		if err := os.WriteFile(path, []byte(f.content), 0644); err != nil {
+			return fmt.Errorf("write %s: %w", f.path, err)
+		}
+	}
+
+	return nil
+}
+
+func generateClaudeMD(cfg Config) string {
+	return fmt.Sprintf(`# %s
+
+## Project
+
+- **Description:** %s
+- **Audience:** %s
+- **Current focus:** %s
+
+## Stack
+
+React 19 + Vite + TypeScript (strict) + Tailwind CSS v4 + shadcn/ui + Lucide icons
+
+## Directories
+
+| Path | Contents |
+|------|----------|
+| src/components/ | UI components (shadcn/ui in src/components/ui/) |
+| src/lib/ | Shared utilities |
+| src/App.tsx | Main entry point |
+| scripts/ | Build and quality scripts |
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| pnpm dev | Start dev server |
+| pnpm build | Production build |
+| pnpm lint | Run ESLint |
+| pnpm tsc | Type check |
+| pnpm test | Run tests |
+
+## Conventions
+
+1. **Tailwind-first** — Use Tailwind classes, never inline styles or CSS modules
+2. **shadcn-first** — Use shadcn/ui components when available, don't build custom equivalents
+3. **Theme tokens** — Use bg-primary, text-foreground etc. Never hardcode hex colors
+4. **Lucide icons** — Use lucide-react for all icons. No inline SVGs
+5. **@/ imports** — Always use @/components/... path aliases, never ../
+6. **200 LOC max** — Extract when a component exceeds 200 lines
+7. **One test per component** — Every .tsx gets a .test.tsx
+8. **Responsive from birth** — Every component must work at 375px width
+9. **Accessible by default** — Labels on inputs, alt on images, focus states on interactive elements
+`, cfg.Name, cfg.Description, cfg.Audience, cfg.FirstFeature)
+}
+
+func generateBootstrapSkill() string {
+	return `# Strum Dev Skill
+
+## Overview
+
+Bootstrap skill for Strum-scaffolded projects. Teaches the AI agent project conventions
+and how to use annotation mode for visual editing.
+
+## Anti-Slop Invariants
+
+These rules are enforced by pre-commit hooks. Do not rationalize around them.
+
+| Rule | Enforcement | Blocked Rationalization |
+|------|-------------|----------------------|
+| **Tailwind-first** | No inline style={}. No CSS modules. | "Just a quick inline style" |
+| **shadcn-first** | Use shadcn components when available. | "I'll build a custom button" |
+| **Theme tokens only** | Use bg-primary, text-foreground. No hex. | "I'll use the hex directly" |
+| **Lucide icons only** | Use lucide-react. No inline SVGs. | "Just one inline SVG" |
+| **200 LOC max** | Extract when exceeding 200 lines. | "Keep it all in one file" |
+| **No barrel exports** | Import from component files directly. | "Add an index.ts" |
+| **@/ imports** | Use path aliases. Never ../../../. | "Relative path is fine" |
+| **One test per component** | Every .tsx gets a .test.tsx. | "Add tests later" |
+| **Responsive from birth** | Must not break at 375px width. | "Handle mobile later" |
+| **Accessible by default** | Labels, alt text, focus states. | "Accessibility later" |
+
+## Annotation Mode
+
+Use Gasoline's annotation mode to visually inspect and edit components:
+1. Click any element in the browser to see its source code
+2. Edit Tailwind classes for instant visual feedback via HMR
+3. Components in src/components/ui/ are editable shadcn source files
+
+## MCP Tools
+
+- observe: Read browser state (console, network, screenshot)
+- interact: Navigate, click, type, resize
+- analyze: Accessibility audit, security scan, annotations
+- generate: CSP headers, test plans
+- configure: Health checks, settings
+`
+}
+
+func generateSessionStartHook() string {
+	return `// session-start.js — Bootstrap context injection hook.
+// Injects the bootstrap skill as additional context on session start,
+// /clear, and context compaction so the AI always knows project conventions.
+
+const fs = require('fs')
+const path = require('path')
+
+const skillPath = path.join(__dirname, '..', 'skills', 'strum-dev', 'SKILL.md')
+
+module.exports = {
+  event: 'SessionStart',
+  handler: () => {
+    try {
+      const skill = fs.readFileSync(skillPath, 'utf-8')
+      return {
+        additionalContext: skill,
+      }
+    } catch (err) {
+      // Skill file missing — don't block session start.
+      return {}
+    }
+  },
+}
+`
+}
+
+const mcpJSON = `{
+  "mcpServers": {
+    "gasoline": {
+      "command": "gasoline-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+`

--- a/internal/scaffold/ai_context.go
+++ b/internal/scaffold/ai_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // WriteAIContext generates AI context files based on the wizard configuration.
@@ -34,13 +35,24 @@ func WriteAIContext(projectDir string, cfg Config) error {
 }
 
 func generateClaudeMD(cfg Config) string {
-	return fmt.Sprintf(`# %s
+	// Use strings.NewReplacer instead of fmt.Sprintf to avoid format string
+	// injection from user-provided values.
+	r := strings.NewReplacer(
+		"{{NAME}}", cfg.Name,
+		"{{DESCRIPTION}}", cfg.Description,
+		"{{AUDIENCE}}", cfg.Audience,
+		"{{FIRST_FEATURE}}", cfg.FirstFeature,
+	)
+	return r.Replace(claudeMDTemplate)
+}
+
+const claudeMDTemplate = `# {{NAME}}
 
 ## Project
 
-- **Description:** %s
-- **Audience:** %s
-- **Current focus:** %s
+- **Description:** {{DESCRIPTION}}
+- **Audience:** {{AUDIENCE}}
+- **Current focus:** {{FIRST_FEATURE}}
 
 ## Stack
 
@@ -76,8 +88,7 @@ React 19 + Vite + TypeScript (strict) + Tailwind CSS v4 + shadcn/ui + Lucide ico
 7. **One test per component** — Every .tsx gets a .test.tsx
 8. **Responsive from birth** — Every component must work at 375px width
 9. **Accessible by default** — Labels on inputs, alt on images, focus states on interactive elements
-`, cfg.Name, cfg.Description, cfg.Audience, cfg.FirstFeature)
-}
+`
 
 func generateBootstrapSkill() string {
 	return `# Strum Dev Skill

--- a/internal/scaffold/ai_context_test.go
+++ b/internal/scaffold/ai_context_test.go
@@ -1,0 +1,185 @@
+// ai_context_test.go — Tests for AI context file generation (CLAUDE.md, skill, hooks, .mcp.json).
+
+package scaffold
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ============================================
+// AI Context Generation
+// ============================================
+
+func TestWriteAIContext_CreatesClaudeMD(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "a todo app with drag and drop",
+		Audience:     "just_me",
+		FirstFeature: "drag and drop reordering",
+		Name:         "todo-app",
+	}
+
+	if err := WriteAIContext(dir, cfg); err != nil {
+		t.Fatalf("WriteAIContext: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	body := string(content)
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"project name", "todo-app"},
+		{"description", "a todo app with drag and drop"},
+		{"audience", "just_me"},
+		{"first feature", "drag and drop reordering"},
+		{"stack info", "React"},
+		{"stack info", "TypeScript"},
+		{"stack info", "Tailwind"},
+		{"stack info", "shadcn"},
+		{"dev command", "pnpm dev"},
+		{"tailwind-first rule", "Tailwind"},
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(body, c.contains) {
+			t.Errorf("CLAUDE.md missing %s (expected %q)", c.label, c.contains)
+		}
+	}
+}
+
+func TestWriteAIContext_CreatesBootstrapSkill(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "a todo app",
+		Audience:     "just_me",
+		FirstFeature: "drag and drop",
+		Name:         "todo-app",
+	}
+
+	if err := WriteAIContext(dir, cfg); err != nil {
+		t.Fatalf("WriteAIContext: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "strum-dev", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+
+	body := string(content)
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"tailwind-first", "Tailwind"},
+		{"shadcn-first", "shadcn"},
+		{"lucide icons", "lucide"},
+		{"no inline styles", "style"},
+		{"200 LOC limit", "200"},
+		{"path alias", "@/"},
+	}
+
+	for _, c := range checks {
+		if !strings.Contains(body, c.contains) {
+			t.Errorf("SKILL.md missing %s (expected %q)", c.label, c.contains)
+		}
+	}
+}
+
+func TestWriteAIContext_CreatesSessionStartHook(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "a todo app",
+		Audience:     "just_me",
+		FirstFeature: "drag and drop",
+		Name:         "todo-app",
+	}
+
+	if err := WriteAIContext(dir, cfg); err != nil {
+		t.Fatalf("WriteAIContext: %v", err)
+	}
+
+	path := filepath.Join(dir, ".claude", "hooks", "session-start.js")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read session-start.js: %v", err)
+	}
+
+	body := string(content)
+	if !strings.Contains(body, "additionalContext") && !strings.Contains(body, "SKILL.md") {
+		t.Error("session-start.js should reference bootstrap skill or additionalContext")
+	}
+}
+
+func TestWriteAIContext_CreatesMCPJson(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "a todo app",
+		Audience:     "just_me",
+		FirstFeature: "drag and drop",
+		Name:         "todo-app",
+	}
+
+	if err := WriteAIContext(dir, cfg); err != nil {
+		t.Fatalf("WriteAIContext: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("read .mcp.json: %v", err)
+	}
+
+	var cfg2 map[string]any
+	if err := json.Unmarshal(content, &cfg2); err != nil {
+		t.Fatalf(".mcp.json is not valid JSON: %v", err)
+	}
+
+	servers, ok := cfg2["mcpServers"]
+	if !ok {
+		t.Fatal(".mcp.json should have mcpServers key")
+	}
+
+	serversMap, ok := servers.(map[string]any)
+	if !ok {
+		t.Fatal(".mcp.json mcpServers should be an object")
+	}
+
+	if _, ok := serversMap["gasoline"]; !ok {
+		t.Error(".mcp.json should have a 'gasoline' server configured")
+	}
+}
+
+func TestWriteAIContext_AllFilesExist(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "a todo app",
+		Audience:     "just_me",
+		FirstFeature: "drag and drop",
+		Name:         "todo-app",
+	}
+
+	if err := WriteAIContext(dir, cfg); err != nil {
+		t.Fatalf("WriteAIContext: %v", err)
+	}
+
+	expectedFiles := []string{
+		".claude/CLAUDE.md",
+		".claude/skills/strum-dev/SKILL.md",
+		".claude/hooks/session-start.js",
+		".mcp.json",
+	}
+
+	for _, f := range expectedFiles {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("missing expected file: %s", f)
+		}
+	}
+}

--- a/internal/scaffold/devserver.go
+++ b/internal/scaffold/devserver.go
@@ -1,0 +1,114 @@
+// devserver.go — Dev server port detection from Vite stdout with fallback polling.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// vitePortRegex matches Vite's "Local: http://localhost:PORT" output.
+var vitePortRegex = regexp.MustCompile(`Local:\s+http://localhost:(\d+)`)
+
+// ParseVitePort extracts the port number from a Vite stdout line.
+// Returns the port and true if found, or 0 and false otherwise.
+func ParseVitePort(line string) (int, bool) {
+	matches := vitePortRegex.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	port, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, false
+	}
+	return port, true
+}
+
+// PollForDevServer polls ports in the given range for an HTTP 200 response.
+// Returns the first port that responds, or an error if the context expires.
+func PollForDevServer(ctx context.Context, startPort, endPort int) (int, error) {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("dev server not found on ports %d-%d: %w", startPort, endPort, ctx.Err())
+		default:
+		}
+
+		for port := startPort; port <= endPort; port++ {
+			url := fmt.Sprintf("http://localhost:%d", port)
+			resp, err := client.Get(url)
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return port, nil
+			}
+		}
+
+		// Brief pause before next poll cycle.
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("dev server not found on ports %d-%d: %w", startPort, endPort, ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// DevServerDetector detects the dev server port via stdout parsing and fallback polling.
+type DevServerDetector struct {
+	mu   sync.Mutex
+	port int
+	ok   bool
+}
+
+// NewDevServerDetector creates a new dev server detector.
+func NewDevServerDetector() *DevServerDetector {
+	return &DevServerDetector{}
+}
+
+// FeedLine feeds a line of stdout output for port detection.
+func (d *DevServerDetector) FeedLine(line string) {
+	port, found := ParseVitePort(line)
+	if found {
+		d.mu.Lock()
+		d.port = port
+		d.ok = true
+		d.mu.Unlock()
+	}
+}
+
+// DetectedPort returns the detected port if available.
+func (d *DevServerDetector) DetectedPort() (int, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.port, d.ok
+}
+
+// WaitForReady waits for the dev server to be ready.
+// First checks if stdout parsing found a port, then falls back to polling.
+func (d *DevServerDetector) WaitForReady(ctx context.Context, startPort, endPort int) (int, error) {
+	// Check if stdout already detected the port.
+	if port, ok := d.DetectedPort(); ok {
+		// Verify the port is actually responding.
+		client := &http.Client{Timeout: 2 * time.Second}
+		url := fmt.Sprintf("http://localhost:%d", port)
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return port, nil
+			}
+		}
+	}
+
+	// Fall back to polling.
+	return PollForDevServer(ctx, startPort, endPort)
+}

--- a/internal/scaffold/devserver_test.go
+++ b/internal/scaffold/devserver_test.go
@@ -1,0 +1,236 @@
+// devserver_test.go — Tests for dev server port detection from Vite stdout.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// ============================================
+// Vite stdout port parsing
+// ============================================
+
+func TestParseVitePort_StandardOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		want  int
+		found bool
+	}{
+		{
+			name:  "standard vite output",
+			line:  "  ➜  Local:   http://localhost:5173/",
+			want:  5173,
+			found: true,
+		},
+		{
+			name:  "alternate port",
+			line:  "  ➜  Local:   http://localhost:5174/",
+			want:  5174,
+			found: true,
+		},
+		{
+			name:  "without trailing slash",
+			line:  "  ➜  Local:   http://localhost:5173",
+			want:  5173,
+			found: true,
+		},
+		{
+			name:  "with spaces",
+			line:  "    Local:   http://localhost:3000/",
+			want:  3000,
+			found: true,
+		},
+		{
+			name:  "no match - network line",
+			line:  "  ➜  Network: http://192.168.1.1:5173/",
+			want:  0,
+			found: false,
+		},
+		{
+			name:  "no match - random text",
+			line:  "vite v5.0.0 building for development...",
+			want:  0,
+			found: false,
+		},
+		{
+			name:  "no match - empty",
+			line:  "",
+			want:  0,
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, found := ParseVitePort(tt.line)
+			if found != tt.found {
+				t.Errorf("ParseVitePort(%q): found=%v, want %v", tt.line, found, tt.found)
+			}
+			if port != tt.want {
+				t.Errorf("ParseVitePort(%q): port=%d, want %d", tt.line, port, tt.want)
+			}
+		})
+	}
+}
+
+// ============================================
+// Port polling fallback
+// ============================================
+
+func TestPollForDevServer_FindsListeningPort(t *testing.T) {
+	// Start a temporary HTTP server.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	found, err := PollForDevServer(ctx, port, port)
+	if err != nil {
+		t.Fatalf("PollForDevServer: %v", err)
+	}
+	if found != port {
+		t.Errorf("PollForDevServer: want port %d, got %d", port, found)
+	}
+}
+
+func TestPollForDevServer_TimeoutWhenNoServer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Use an unlikely port range.
+	_, err := PollForDevServer(ctx, 59990, 59991)
+	if err == nil {
+		t.Error("PollForDevServer should return error on timeout")
+	}
+}
+
+func TestPollForDevServer_FindsPortInRange(t *testing.T) {
+	// Start server on a specific port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Search a range that includes the port.
+	found, err := PollForDevServer(ctx, port-2, port+2)
+	if err != nil {
+		t.Fatalf("PollForDevServer: %v", err)
+	}
+	if found != port {
+		t.Errorf("PollForDevServer: want port %d, got %d", port, found)
+	}
+}
+
+// ============================================
+// DevServerDetector integration
+// ============================================
+
+func TestDevServerDetector_ParsesLineAndReturnsPort(t *testing.T) {
+	d := NewDevServerDetector()
+
+	// Feed Vite output lines.
+	d.FeedLine("vite v5.0.0 building for development...")
+	d.FeedLine("  ➜  Local:   http://localhost:5173/")
+
+	port, ok := d.DetectedPort()
+	if !ok {
+		t.Fatal("expected port to be detected")
+	}
+	if port != 5173 {
+		t.Errorf("want port 5173, got %d", port)
+	}
+}
+
+func TestDevServerDetector_NoPortBeforeReady(t *testing.T) {
+	d := NewDevServerDetector()
+
+	d.FeedLine("vite v5.0.0 building for development...")
+
+	_, ok := d.DetectedPort()
+	if ok {
+		t.Error("port should not be detected before Local line appears")
+	}
+}
+
+func TestDevServerDetector_FallbackPolling(t *testing.T) {
+	// Start a temporary HTTP server.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	d := NewDevServerDetector()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := d.WaitForReady(ctx, port, port)
+	if err != nil {
+		t.Fatalf("WaitForReady: %v", err)
+	}
+	if got != port {
+		t.Errorf("WaitForReady: want port %d, got %d", port, got)
+	}
+}
+
+func TestDevServerDetector_StdoutTakesPrecedence(t *testing.T) {
+	// Start a temporary HTTP server on some port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	d := NewDevServerDetector()
+	d.FeedLine(fmt.Sprintf("  ➜  Local:   http://localhost:%d/", port))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got, err := d.WaitForReady(ctx, 59990, 59991) // Wrong range, but stdout should win.
+	if err != nil {
+		t.Fatalf("WaitForReady: %v", err)
+	}
+	if got != port {
+		t.Errorf("WaitForReady: want port %d (from stdout), got %d", port, got)
+	}
+}

--- a/internal/scaffold/engine.go
+++ b/internal/scaffold/engine.go
@@ -125,7 +125,11 @@ func (e *Engine) RunStep(ctx context.Context, step Step) error {
 }
 
 // RunAll executes all steps in sequence.
+// Returns an error if the project directory already exists.
 func (e *Engine) RunAll(ctx context.Context, steps []Step) error {
+	if _, err := os.Stat(e.projectDir); err == nil {
+		return fmt.Errorf("project directory already exists: %s", e.projectDir)
+	}
 	for _, step := range steps {
 		if err := e.RunStep(ctx, step); err != nil {
 			return err

--- a/internal/scaffold/engine.go
+++ b/internal/scaffold/engine.go
@@ -1,0 +1,135 @@
+// engine.go — Scaffold engine: executes scaffold steps with verification gates.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Config holds the user's wizard inputs for scaffolding.
+type Config struct {
+	Description  string `json:"description"`
+	Audience     string `json:"audience"`
+	FirstFeature string `json:"first_feature"`
+	Name         string `json:"name"`
+	BaseDir      string `json:"base_dir"` // defaults to ~/strum-projects
+}
+
+// Validate checks that required fields are present.
+func (c *Config) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if c.Description == "" {
+		return fmt.Errorf("description is required")
+	}
+	return nil
+}
+
+// StepEvent is a progress update for a single scaffold step.
+type StepEvent struct {
+	Step   string `json:"step"`
+	Status string `json:"status"` // running, done, error, retrying
+	Label  string `json:"label"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Step defines a single scaffold step with a run function and verification gate.
+type Step struct {
+	Name   string
+	Label  string
+	Run    func(ctx context.Context, projectDir string) error
+	Verify func(projectDir string) error
+}
+
+// ProgressFunc is called for each step progress update.
+type ProgressFunc func(StepEvent)
+
+// Engine orchestrates scaffold step execution.
+type Engine struct {
+	cfg        Config
+	projectDir string
+	onProgress ProgressFunc
+}
+
+// NewEngine creates a scaffold engine with the given config.
+func NewEngine(cfg Config) (*Engine, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	baseDir := cfg.BaseDir
+	if baseDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine home directory: %w", err)
+		}
+		baseDir = filepath.Join(home, "strum-projects")
+	}
+
+	return &Engine{
+		cfg:        cfg,
+		projectDir: filepath.Join(baseDir, cfg.Name),
+	}, nil
+}
+
+// ProjectDir returns the full path to the project directory.
+func (e *Engine) ProjectDir() string {
+	return e.projectDir
+}
+
+// OnProgress sets the progress callback.
+func (e *Engine) OnProgress(fn ProgressFunc) {
+	e.onProgress = fn
+}
+
+// emitProgress sends a progress event if a callback is registered.
+func (e *Engine) emitProgress(evt StepEvent) {
+	if e.onProgress != nil {
+		e.onProgress(evt)
+	}
+}
+
+// RunStep executes a single step with verification. Retries once on verify failure.
+func (e *Engine) RunStep(ctx context.Context, step Step) error {
+	e.emitProgress(StepEvent{Step: step.Name, Status: "running", Label: step.Label})
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			e.emitProgress(StepEvent{Step: step.Name, Status: "retrying", Label: step.Label})
+		}
+
+		if err := step.Run(ctx, e.projectDir); err != nil {
+			e.emitProgress(StepEvent{Step: step.Name, Status: "error", Label: step.Label, Error: err.Error()})
+			return fmt.Errorf("step %q run failed: %w", step.Name, err)
+		}
+
+		if err := step.Verify(e.projectDir); err != nil {
+			if attempt == 0 {
+				// First failure: retry.
+				continue
+			}
+			e.emitProgress(StepEvent{Step: step.Name, Status: "error", Label: step.Label, Error: err.Error()})
+			return fmt.Errorf("step %q verification failed after retry: %w", step.Name, err)
+		}
+
+		e.emitProgress(StepEvent{Step: step.Name, Status: "done", Label: step.Label})
+		return nil
+	}
+
+	// Unreachable, but satisfies the compiler.
+	return fmt.Errorf("step %q: unexpected loop exit", step.Name)
+}
+
+// RunAll executes all steps in sequence.
+func (e *Engine) RunAll(ctx context.Context, steps []Step) error {
+	for _, step := range steps {
+		if err := e.RunStep(ctx, step); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/scaffold/engine_test.go
+++ b/internal/scaffold/engine_test.go
@@ -45,7 +45,6 @@ func TestStepDefinitions_ExpectedStepNames(t *testing.T) {
 		"add_shadcn",
 		"quality_baseline",
 		"git_init",
-		"start_dev_server",
 	}
 
 	for _, name := range expected {
@@ -219,6 +218,47 @@ func TestNewEngine_DefaultBaseDir(t *testing.T) {
 	expected := filepath.Join(home, "strum-projects", "test-app")
 	if eng.ProjectDir() != expected {
 		t.Errorf("ProjectDir: want %q, got %q", expected, eng.ProjectDir())
+	}
+}
+
+// ============================================
+// RunAll: directory existence check
+// ============================================
+
+func TestEngine_RunAll_RejectsExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "existing-app",
+		BaseDir:      dir,
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Pre-create the project directory.
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	steps := []Step{
+		{
+			Name:  "should_not_run",
+			Label: "Should Not Run",
+			Run: func(ctx context.Context, pd string) error {
+				t.Error("step should not have been executed")
+				return nil
+			},
+			Verify: func(pd string) error { return nil },
+		},
+	}
+
+	err = eng.RunAll(context.Background(), steps)
+	if err == nil {
+		t.Error("RunAll should fail when project directory already exists")
 	}
 }
 

--- a/internal/scaffold/engine_test.go
+++ b/internal/scaffold/engine_test.go
@@ -1,0 +1,388 @@
+// engine_test.go — Tests for the scaffold engine step execution and verification.
+
+package scaffold
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ============================================
+// Step definitions and verification gates
+// ============================================
+
+func TestStepDefinitions_AllStepsHaveVerification(t *testing.T) {
+	steps := DefaultSteps()
+	if len(steps) == 0 {
+		t.Fatal("DefaultSteps must return at least one step")
+	}
+	for _, s := range steps {
+		if s.Name == "" {
+			t.Error("step has empty Name")
+		}
+		if s.Label == "" {
+			t.Errorf("step %q has empty Label", s.Name)
+		}
+		if s.Verify == nil {
+			t.Errorf("step %q has no Verify function", s.Name)
+		}
+	}
+}
+
+func TestStepDefinitions_ExpectedStepNames(t *testing.T) {
+	steps := DefaultSteps()
+	names := make(map[string]bool)
+	for _, s := range steps {
+		names[s.Name] = true
+	}
+
+	expected := []string{
+		"create_project",
+		"install_deps",
+		"add_tailwind",
+		"add_shadcn",
+		"quality_baseline",
+		"git_init",
+		"start_dev_server",
+	}
+
+	for _, name := range expected {
+		if !names[name] {
+			t.Errorf("missing expected step %q", name)
+		}
+	}
+}
+
+// ============================================
+// Verification gates (unit-testable)
+// ============================================
+
+func TestVerifyDirectoryExists(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := VerifyDirectoryExists(dir); err != nil {
+		t.Errorf("VerifyDirectoryExists on existing dir: %v", err)
+	}
+
+	if err := VerifyDirectoryExists(filepath.Join(dir, "nonexistent")); err == nil {
+		t.Error("VerifyDirectoryExists on nonexistent dir: want error, got nil")
+	}
+}
+
+func TestVerifyFileExists(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := VerifyFileExists(file); err != nil {
+		t.Errorf("VerifyFileExists on existing file: %v", err)
+	}
+
+	if err := VerifyFileExists(filepath.Join(dir, "nope.txt")); err == nil {
+		t.Error("VerifyFileExists on nonexistent file: want error, got nil")
+	}
+}
+
+func TestVerifyPackageInstalled(t *testing.T) {
+	dir := t.TempDir()
+
+	// No node_modules at all.
+	if err := VerifyPackageInstalled(dir, "react"); err == nil {
+		t.Error("VerifyPackageInstalled with no node_modules: want error, got nil")
+	}
+
+	// Create fake node_modules/react.
+	pkgDir := filepath.Join(dir, "node_modules", "react")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := VerifyPackageInstalled(dir, "react"); err != nil {
+		t.Errorf("VerifyPackageInstalled with package present: %v", err)
+	}
+}
+
+func TestVerifyGitInitialized(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := VerifyGitInitialized(dir); err == nil {
+		t.Error("VerifyGitInitialized with no .git: want error, got nil")
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := VerifyGitInitialized(dir); err != nil {
+		t.Errorf("VerifyGitInitialized with .git: %v", err)
+	}
+}
+
+// ============================================
+// Config validation
+// ============================================
+
+func TestNewConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: Config{
+				Description:  "a todo app",
+				Audience:     "just_me",
+				FirstFeature: "drag and drop",
+				Name:         "todo-app",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			cfg: Config{
+				Description:  "a todo app",
+				Audience:     "just_me",
+				FirstFeature: "drag and drop",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing description",
+			cfg: Config{
+				Name:         "todo-app",
+				Audience:     "just_me",
+				FirstFeature: "drag and drop",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty config",
+			cfg:     Config{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Error("want error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("want no error, got %v", err)
+			}
+		})
+	}
+}
+
+// ============================================
+// Engine creation
+// ============================================
+
+func TestNewEngine_SetsProjectDir(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      t.TempDir(),
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	expected := filepath.Join(cfg.BaseDir, "test-app")
+	if eng.ProjectDir() != expected {
+		t.Errorf("ProjectDir: want %q, got %q", expected, eng.ProjectDir())
+	}
+}
+
+func TestNewEngine_DefaultBaseDir(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, "strum-projects", "test-app")
+	if eng.ProjectDir() != expected {
+		t.Errorf("ProjectDir: want %q, got %q", expected, eng.ProjectDir())
+	}
+}
+
+// ============================================
+// Progress callback
+// ============================================
+
+func TestEngine_ProgressCallback(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      t.TempDir(),
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	var events []StepEvent
+	eng.OnProgress(func(evt StepEvent) {
+		events = append(events, evt)
+	})
+
+	// Emit a test event.
+	eng.emitProgress(StepEvent{Step: "test", Status: "running", Label: "Testing"})
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Step != "test" || events[0].Status != "running" {
+		t.Errorf("unexpected event: %+v", events[0])
+	}
+}
+
+// ============================================
+// Step execution with mock runner
+// ============================================
+
+func TestEngine_RunStep_SuccessPath(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      t.TempDir(),
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Create the project dir so verify passes.
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	step := Step{
+		Name:  "test_step",
+		Label: "Test Step",
+		Run: func(ctx context.Context, projectDir string) error {
+			return nil
+		},
+		Verify: func(projectDir string) error {
+			return VerifyDirectoryExists(projectDir)
+		},
+	}
+
+	var events []StepEvent
+	eng.OnProgress(func(evt StepEvent) {
+		events = append(events, evt)
+	})
+
+	err = eng.RunStep(context.Background(), step)
+	if err != nil {
+		t.Fatalf("RunStep: %v", err)
+	}
+
+	// Should have "running" and "done" events.
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+	if events[0].Status != "running" {
+		t.Errorf("first event status: want 'running', got %q", events[0].Status)
+	}
+	if events[len(events)-1].Status != "done" {
+		t.Errorf("last event status: want 'done', got %q", events[len(events)-1].Status)
+	}
+}
+
+func TestEngine_RunStep_VerifyFailRetry(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      t.TempDir(),
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	runCount := 0
+	step := Step{
+		Name:  "flaky_step",
+		Label: "Flaky Step",
+		Run: func(ctx context.Context, projectDir string) error {
+			runCount++
+			if runCount == 2 {
+				// Second run: create the directory so verify passes.
+				return os.MkdirAll(filepath.Join(projectDir, "success"), 0755)
+			}
+			return nil
+		},
+		Verify: func(projectDir string) error {
+			return VerifyDirectoryExists(filepath.Join(projectDir, "success"))
+		},
+	}
+
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err = eng.RunStep(context.Background(), step)
+	if err != nil {
+		t.Fatalf("RunStep with retry: %v", err)
+	}
+	if runCount != 2 {
+		t.Errorf("expected 2 runs (1 retry), got %d", runCount)
+	}
+}
+
+func TestEngine_RunStep_VerifyFailTwice_ReturnsError(t *testing.T) {
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      t.TempDir(),
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	step := Step{
+		Name:  "always_fails",
+		Label: "Always Fails",
+		Run: func(ctx context.Context, projectDir string) error {
+			return nil
+		},
+		Verify: func(projectDir string) error {
+			return VerifyDirectoryExists(filepath.Join(projectDir, "never-exists"))
+		},
+	}
+
+	err = eng.RunStep(context.Background(), step)
+	if err == nil {
+		t.Error("RunStep should fail when verify fails twice")
+	}
+}

--- a/internal/scaffold/navigate.go
+++ b/internal/scaffold/navigate.go
@@ -1,0 +1,18 @@
+// navigate.go — Auto-navigate to dev server after it's ready.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+)
+
+// NavigateFunc is a function that navigates the browser to a URL.
+// This is a dependency injection point for the MCP interact(navigate) call.
+type NavigateFunc func(ctx context.Context, url string) error
+
+// AutoNavigate navigates the browser to the dev server on the given port.
+func AutoNavigate(ctx context.Context, port int, navigate NavigateFunc) error {
+	url := fmt.Sprintf("http://localhost:%d", port)
+	return navigate(ctx, url)
+}

--- a/internal/scaffold/navigate_test.go
+++ b/internal/scaffold/navigate_test.go
@@ -1,0 +1,74 @@
+// navigate_test.go — Tests for auto-navigate after dev server detection.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// ============================================
+// Auto-Navigate
+// ============================================
+
+func TestAutoNavigate_CallsNavigateWithCorrectURL(t *testing.T) {
+	var navigatedURL string
+	navigateFn := func(ctx context.Context, url string) error {
+		navigatedURL = url
+		return nil
+	}
+
+	err := AutoNavigate(context.Background(), 5173, navigateFn)
+	if err != nil {
+		t.Fatalf("AutoNavigate: %v", err)
+	}
+
+	expected := "http://localhost:5173"
+	if navigatedURL != expected {
+		t.Errorf("navigated to %q, want %q", navigatedURL, expected)
+	}
+}
+
+func TestAutoNavigate_PropagatesError(t *testing.T) {
+	navigateFn := func(ctx context.Context, url string) error {
+		return fmt.Errorf("navigation failed")
+	}
+
+	err := AutoNavigate(context.Background(), 5173, navigateFn)
+	if err == nil {
+		t.Error("AutoNavigate should propagate navigate error")
+	}
+}
+
+func TestAutoNavigate_RespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	navigateFn := func(ctx context.Context, url string) error {
+		return ctx.Err()
+	}
+
+	err := AutoNavigate(ctx, 5173, navigateFn)
+	if err == nil {
+		t.Error("AutoNavigate should fail with cancelled context")
+	}
+}
+
+func TestAutoNavigate_CustomPort(t *testing.T) {
+	var navigatedURL string
+	navigateFn := func(ctx context.Context, url string) error {
+		navigatedURL = url
+		return nil
+	}
+
+	err := AutoNavigate(context.Background(), 3000, navigateFn)
+	if err != nil {
+		t.Fatalf("AutoNavigate: %v", err)
+	}
+
+	expected := "http://localhost:3000"
+	if navigatedURL != expected {
+		t.Errorf("navigated to %q, want %q", navigatedURL, expected)
+	}
+}

--- a/internal/scaffold/orchestrator_test.go
+++ b/internal/scaffold/orchestrator_test.go
@@ -29,16 +29,17 @@ func TestOrchestrator_RunsAllMockSteps(t *testing.T) {
 	}
 
 	projectDir := eng.ProjectDir()
-	if err := os.MkdirAll(projectDir, 0755); err != nil {
-		t.Fatal(err)
-	}
 
 	// Create mock steps that create marker files.
+	// The first step creates the project directory (simulating create_project).
 	steps := []Step{
 		{
 			Name:  "step_1",
 			Label: "Step 1",
 			Run: func(ctx context.Context, pd string) error {
+				if err := os.MkdirAll(pd, 0755); err != nil {
+					return err
+				}
 				return os.WriteFile(filepath.Join(pd, "step1.marker"), []byte("done"), 0644)
 			},
 			Verify: func(pd string) error {
@@ -85,7 +86,7 @@ func TestOrchestrator_StopsOnError(t *testing.T) {
 		Description:  "test app",
 		Audience:     "just_me",
 		FirstFeature: "testing",
-		Name:         "test-app",
+		Name:         "stop-on-error-app",
 		BaseDir:      dir,
 	}
 
@@ -94,17 +95,16 @@ func TestOrchestrator_StopsOnError(t *testing.T) {
 		t.Fatalf("NewEngine: %v", err)
 	}
 
-	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
-		t.Fatal(err)
-	}
-
 	step2Ran := false
 	steps := []Step{
 		{
 			Name:  "failing_step",
 			Label: "Failing Step",
 			Run: func(ctx context.Context, pd string) error {
-				return nil // runs, but verify will fail
+				// Create the dir so we get past the existence check,
+				// but verify will fail because the marker file won't exist.
+				os.MkdirAll(pd, 0755)
+				return nil
 			},
 			Verify: func(pd string) error {
 				return VerifyFileExists(filepath.Join(pd, "never-exists"))
@@ -137,17 +137,13 @@ func TestOrchestrator_ContextCancellation(t *testing.T) {
 		Description:  "test app",
 		Audience:     "just_me",
 		FirstFeature: "testing",
-		Name:         "test-app",
+		Name:         "ctx-cancel-app",
 		BaseDir:      dir,
 	}
 
 	eng, err := NewEngine(cfg)
 	if err != nil {
 		t.Fatalf("NewEngine: %v", err)
-	}
-
-	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
-		t.Fatal(err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/scaffold/orchestrator_test.go
+++ b/internal/scaffold/orchestrator_test.go
@@ -1,0 +1,171 @@
+// orchestrator_test.go — Tests for the scaffold orchestrator that wires engine + progress + API.
+
+package scaffold
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ============================================
+// Orchestrator: Full scaffold flow with mock steps
+// ============================================
+
+func TestOrchestrator_RunsAllMockSteps(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      dir,
+	}
+
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	projectDir := eng.ProjectDir()
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock steps that create marker files.
+	steps := []Step{
+		{
+			Name:  "step_1",
+			Label: "Step 1",
+			Run: func(ctx context.Context, pd string) error {
+				return os.WriteFile(filepath.Join(pd, "step1.marker"), []byte("done"), 0644)
+			},
+			Verify: func(pd string) error {
+				return VerifyFileExists(filepath.Join(pd, "step1.marker"))
+			},
+		},
+		{
+			Name:  "step_2",
+			Label: "Step 2",
+			Run: func(ctx context.Context, pd string) error {
+				return os.WriteFile(filepath.Join(pd, "step2.marker"), []byte("done"), 0644)
+			},
+			Verify: func(pd string) error {
+				return VerifyFileExists(filepath.Join(pd, "step2.marker"))
+			},
+		},
+	}
+
+	var events []StepEvent
+	eng.OnProgress(func(evt StepEvent) {
+		events = append(events, evt)
+	})
+
+	if err := eng.RunAll(context.Background(), steps); err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+
+	// Verify both marker files exist.
+	for _, f := range []string{"step1.marker", "step2.marker"} {
+		if _, err := os.Stat(filepath.Join(projectDir, f)); err != nil {
+			t.Errorf("missing marker file: %s", f)
+		}
+	}
+
+	// Verify we got events for both steps.
+	if len(events) < 4 { // 2 running + 2 done
+		t.Errorf("expected at least 4 events, got %d", len(events))
+	}
+}
+
+func TestOrchestrator_StopsOnError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      dir,
+	}
+
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	step2Ran := false
+	steps := []Step{
+		{
+			Name:  "failing_step",
+			Label: "Failing Step",
+			Run: func(ctx context.Context, pd string) error {
+				return nil // runs, but verify will fail
+			},
+			Verify: func(pd string) error {
+				return VerifyFileExists(filepath.Join(pd, "never-exists"))
+			},
+		},
+		{
+			Name:  "should_not_run",
+			Label: "Should Not Run",
+			Run: func(ctx context.Context, pd string) error {
+				step2Ran = true
+				return nil
+			},
+			Verify: func(pd string) error { return nil },
+		},
+	}
+
+	err = eng.RunAll(context.Background(), steps)
+	if err == nil {
+		t.Error("RunAll should fail when a step fails")
+	}
+
+	if step2Ran {
+		t.Error("step 2 should not have run after step 1 failed")
+	}
+}
+
+func TestOrchestrator_ContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Description:  "test app",
+		Audience:     "just_me",
+		FirstFeature: "testing",
+		Name:         "test-app",
+		BaseDir:      dir,
+	}
+
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if err := os.MkdirAll(eng.ProjectDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	steps := []Step{
+		{
+			Name:  "cancels",
+			Label: "Cancels Mid-Run",
+			Run: func(ctx context.Context, pd string) error {
+				cancel()
+				return ctx.Err()
+			},
+			Verify: func(pd string) error { return nil },
+		},
+	}
+
+	err = eng.RunAll(ctx, steps)
+	if err == nil {
+		t.Error("RunAll should fail when context is cancelled")
+	}
+}

--- a/internal/scaffold/progress.go
+++ b/internal/scaffold/progress.go
@@ -1,0 +1,84 @@
+// progress.go — Scaffold progress broadcaster for WebSocket streaming.
+
+package scaffold
+
+import (
+	"sync"
+)
+
+// subscriber holds a channel subscription with its target channel name.
+type subscriber struct {
+	channel string
+	ch      chan StepEvent
+}
+
+// Broadcaster distributes scaffold progress events to WebSocket subscribers.
+// Thread-safe. Non-blocking on slow consumers (events dropped if buffer full).
+type Broadcaster struct {
+	mu          sync.RWMutex
+	subscribers map[<-chan StepEvent]*subscriber
+	closed      bool
+}
+
+// NewBroadcaster creates a new progress broadcaster.
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{
+		subscribers: make(map[<-chan StepEvent]*subscriber),
+	}
+}
+
+// Subscribe registers a new subscriber for the given channel name.
+// Returns a read-only channel that receives events for that channel.
+func (b *Broadcaster) Subscribe(channel string) <-chan StepEvent {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan StepEvent, 64)
+	sub := &subscriber{channel: channel, ch: ch}
+	b.subscribers[ch] = sub
+	return ch
+}
+
+// Unsubscribe removes a subscriber and closes its channel.
+func (b *Broadcaster) Unsubscribe(ch <-chan StepEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if sub, ok := b.subscribers[ch]; ok {
+		close(sub.ch)
+		delete(b.subscribers, ch)
+	}
+}
+
+// Broadcast sends an event to all subscribers on the given channel.
+// Non-blocking: if a subscriber's buffer is full, the event is dropped.
+func (b *Broadcaster) Broadcast(channel string, evt StepEvent) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, sub := range b.subscribers {
+		if sub.channel != channel {
+			continue
+		}
+		select {
+		case sub.ch <- evt:
+		default:
+			// Drop event for slow consumer.
+		}
+	}
+}
+
+// Close shuts down the broadcaster and closes all subscriber channels.
+func (b *Broadcaster) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for ch, sub := range b.subscribers {
+		close(sub.ch)
+		delete(b.subscribers, ch)
+	}
+}

--- a/internal/scaffold/progress.go
+++ b/internal/scaffold/progress.go
@@ -29,6 +29,10 @@ func NewBroadcaster() *Broadcaster {
 
 // Subscribe registers a new subscriber for the given channel name.
 // Returns a read-only channel that receives events for that channel.
+//
+// IMPORTANT: The caller MUST call Unsubscribe on disconnect (e.g., when the
+// WebSocket connection closes) to prevent subscriber leaks. If the provided
+// context is cancelled, the caller should treat that as a signal to unsubscribe.
 func (b *Broadcaster) Subscribe(channel string) <-chan StepEvent {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/scaffold/progress_test.go
+++ b/internal/scaffold/progress_test.go
@@ -1,0 +1,143 @@
+// progress_test.go — Tests for scaffold progress broadcasting.
+
+package scaffold
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// ============================================
+// Progress Broadcaster
+// ============================================
+
+func TestBroadcaster_SubscribeReceivesEvents(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	ch := b.Subscribe("test-channel")
+	defer b.Unsubscribe(ch)
+
+	evt := StepEvent{Step: "create_project", Status: "running", Label: "Creating project"}
+	b.Broadcast("test-channel", evt)
+
+	select {
+	case got := <-ch:
+		if got.Step != "create_project" {
+			t.Errorf("want step 'create_project', got %q", got.Step)
+		}
+		if got.Status != "running" {
+			t.Errorf("want status 'running', got %q", got.Status)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for broadcast event")
+	}
+}
+
+func TestBroadcaster_OnlyReceivesMatchingChannel(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	ch1 := b.Subscribe("channel-1")
+	defer b.Unsubscribe(ch1)
+	ch2 := b.Subscribe("channel-2")
+	defer b.Unsubscribe(ch2)
+
+	b.Broadcast("channel-1", StepEvent{Step: "test", Status: "done", Label: "Test"})
+
+	select {
+	case <-ch1:
+		// Good, channel-1 got it.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channel-1 should have received the event")
+	}
+
+	select {
+	case <-ch2:
+		t.Fatal("channel-2 should NOT have received the event")
+	case <-time.After(50 * time.Millisecond):
+		// Good, timed out.
+	}
+}
+
+func TestBroadcaster_MultipleSubscribers(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	ch1 := b.Subscribe("shared")
+	defer b.Unsubscribe(ch1)
+	ch2 := b.Subscribe("shared")
+	defer b.Unsubscribe(ch2)
+
+	b.Broadcast("shared", StepEvent{Step: "test", Status: "done", Label: "Test"})
+
+	for _, ch := range []<-chan StepEvent{ch1, ch2} {
+		select {
+		case <-ch:
+			// Good.
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("subscriber should have received the event")
+		}
+	}
+}
+
+func TestBroadcaster_UnsubscribedChannelDoesNotReceive(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	ch := b.Subscribe("test")
+	b.Unsubscribe(ch)
+
+	b.Broadcast("test", StepEvent{Step: "test", Status: "done", Label: "Test"})
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("unsubscribed channel should not receive events")
+		}
+	case <-time.After(50 * time.Millisecond):
+		// Good, timed out — channel was closed by Unsubscribe.
+	}
+}
+
+func TestBroadcaster_ConcurrentSafety(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch := b.Subscribe("concurrent")
+			defer b.Unsubscribe(ch)
+			b.Broadcast("concurrent", StepEvent{Step: "test", Status: "done", Label: "Test"})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestBroadcaster_SlowConsumerDoesNotBlock(t *testing.T) {
+	b := NewBroadcaster()
+	defer b.Close()
+
+	// Subscribe but never read.
+	_ = b.Subscribe("slow")
+
+	// Broadcast many events — should not block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			b.Broadcast("slow", StepEvent{Step: "test", Status: "done", Label: "Test"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good, didn't block.
+	case <-time.After(1 * time.Second):
+		t.Fatal("broadcaster blocked on slow consumer")
+	}
+}

--- a/internal/scaffold/quality_baseline.go
+++ b/internal/scaffold/quality_baseline.go
@@ -1,0 +1,36 @@
+// quality_baseline.go — Writes quality config files (prettier, eslint, vitest) into the scaffolded project.
+
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteQualityBaseline writes quality configuration files to the project directory.
+func WriteQualityBaseline(projectDir string) error {
+	files := map[string]string{
+		".prettierrc": prettierConfig,
+	}
+
+	for name, content := range files {
+		path := filepath.Join(projectDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const prettierConfig = `{
+  "singleQuote": true,
+  "semi": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100
+}
+`

--- a/internal/scaffold/quality_baseline.go
+++ b/internal/scaffold/quality_baseline.go
@@ -9,16 +9,25 @@ import (
 
 // WriteQualityBaseline writes quality configuration files to the project directory.
 func WriteQualityBaseline(projectDir string) error {
-	files := map[string]string{
-		".prettierrc": prettierConfig,
+	files := []struct {
+		path    string
+		content string
+		mode    os.FileMode
+	}{
+		{".prettierrc", prettierConfig, 0644},
+		{"vitest.config.ts", vitestConfig, 0644},
+		{"scripts/check-components.sh", componentInvariantScript, 0755},
+		{"src/App.tsx", appShell, 0644},
+		{"src/App.test.tsx", appTestFile, 0644},
+		{"src/index.css", indexCSS, 0644},
 	}
 
-	for name, content := range files {
-		path := filepath.Join(projectDir, name)
+	for _, f := range files {
+		path := filepath.Join(projectDir, f.path)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(f.content), f.mode); err != nil {
 			return err
 		}
 	}
@@ -32,5 +41,121 @@ const prettierConfig = `{
   "tabWidth": 2,
   "trailingComma": "all",
   "printWidth": 100
+}
+`
+
+const vitestConfig = `import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      thresholds: {
+        lines: 60,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@/': path.resolve(__dirname, './src/'),
+    },
+  },
+})
+`
+
+const componentInvariantScript = `#!/usr/bin/env bash
+# check-components.sh — Component invariant checker.
+# Enforces: no inline style=, no any types, no ../ imports,
+# no hardcoded hex colors, no files over 200 LOC.
+
+set -euo pipefail
+
+ERRORS=0
+SRC="src/components"
+
+if [ ! -d "$SRC" ]; then
+  echo "No components directory found, skipping."
+  exit 0
+fi
+
+# Check for inline style= attributes
+if grep -rn 'style=' "$SRC" --include="*.tsx" --include="*.ts" 2>/dev/null; then
+  echo "ERROR: Inline style= found. Use Tailwind classes instead."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check for 'any' type annotations
+if grep -rn ': any' "$SRC" --include="*.tsx" --include="*.ts" 2>/dev/null; then
+  echo "ERROR: 'any' type found. Use specific types."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check for ../ relative imports
+if grep -rn "from '\.\.\/" "$SRC" --include="*.tsx" --include="*.ts" 2>/dev/null; then
+  echo "ERROR: Relative ../ imports found. Use @/ path aliases."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check for hardcoded hex colors in className
+if grep -rn '#[0-9a-fA-F]\{3,8\}' "$SRC" --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v '\.css' | grep -v '//' ; then
+  echo "ERROR: Hardcoded hex colors found. Use theme tokens."
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check for files over 200 LOC
+for f in $(find "$SRC" -name "*.tsx" -o -name "*.ts"); do
+  lines=$(wc -l < "$f")
+  if [ "$lines" -gt 200 ]; then
+    echo "ERROR: $f has $lines lines (max 200)."
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "Component invariant check failed with $ERRORS error(s)."
+  exit 1
+fi
+
+echo "Component invariant check passed."
+`
+
+const appShell = `function App() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold">Welcome</h1>
+        <p className="mt-2 text-muted-foreground">Your app is ready. Start building.</p>
+      </main>
+    </div>
+  )
+}
+
+export default App
+`
+
+const appTestFile = `import { describe, it, expect } from 'vitest'
+
+describe('App', () => {
+  it('should be importable', async () => {
+    const mod = await import('./App')
+    expect(mod.default).toBeDefined()
+  })
+})
+`
+
+const indexCSS = `@import 'tailwindcss';
+
+@theme {
+  --color-primary: #2563eb;
+  --color-secondary: #64748b;
+  --color-accent: #f59e0b;
+  --color-background: #ffffff;
+  --color-foreground: #0f172a;
+  --color-muted: #f1f5f9;
+  --color-muted-foreground: #64748b;
 }
 `

--- a/internal/scaffold/quality_baseline.go
+++ b/internal/scaffold/quality_baseline.go
@@ -15,6 +15,9 @@ func WriteQualityBaseline(projectDir string) error {
 		mode    os.FileMode
 	}{
 		{".prettierrc", prettierConfig, 0644},
+		{"eslint.config.js", eslintConfig, 0644},
+		{"tsconfig.json", tsconfigOverrides, 0644},
+		{"vite.config.ts", viteConfig, 0644},
 		{"vitest.config.ts", vitestConfig, 0644},
 		{"scripts/check-components.sh", componentInvariantScript, 0755},
 		{"src/App.tsx", appShell, 0644},
@@ -144,6 +147,68 @@ describe('App', () => {
     const mod = await import('./App')
     expect(mod.default).toBeDefined()
   })
+})
+`
+
+const eslintConfig = `import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import reactHooks from 'eslint-plugin-react-hooks'
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/'],
+  },
+)
+`
+
+const tsconfigOverrides = `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}
+`
+
+const viteConfig = `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 })
 `
 

--- a/internal/scaffold/quality_baseline_test.go
+++ b/internal/scaffold/quality_baseline_test.go
@@ -151,6 +151,81 @@ func TestWriteQualityBaseline_CreatesIndexCSS(t *testing.T) {
 	}
 }
 
+func TestWriteQualityBaseline_CreatesEslintConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "eslint.config.js"))
+	if err != nil {
+		t.Fatalf("read eslint.config.js: %v", err)
+	}
+
+	body := string(content)
+	checks := []string{
+		"@eslint/js",
+		"typescript-eslint",
+		"react-hooks",
+	}
+	for _, c := range checks {
+		if !strings.Contains(body, c) {
+			t.Errorf("eslint.config.js should reference %q", c)
+		}
+	}
+}
+
+func TestWriteQualityBaseline_CreatesTsconfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "tsconfig.json"))
+	if err != nil {
+		t.Fatalf("read tsconfig.json: %v", err)
+	}
+
+	body := string(content)
+	checks := []string{
+		`"strict": true`,
+		`"noUncheckedIndexedAccess": true`,
+		`"noUnusedLocals": true`,
+		`"noUnusedParameters": true`,
+		`"@/*"`,
+	}
+	for _, c := range checks {
+		if !strings.Contains(body, c) {
+			t.Errorf("tsconfig.json should contain %q", c)
+		}
+	}
+}
+
+func TestWriteQualityBaseline_CreatesViteConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "vite.config.ts"))
+	if err != nil {
+		t.Fatalf("read vite.config.ts: %v", err)
+	}
+
+	body := string(content)
+	checks := []string{
+		"resolve",
+		"alias",
+		"@",
+		"path.resolve",
+	}
+	for _, c := range checks {
+		if !strings.Contains(body, c) {
+			t.Errorf("vite.config.ts should contain %q", c)
+		}
+	}
+}
+
 func TestWriteQualityBaseline_AllFilesValid(t *testing.T) {
 	dir := t.TempDir()
 	// Create directories that WriteQualityBaseline expects.
@@ -166,6 +241,9 @@ func TestWriteQualityBaseline_AllFilesValid(t *testing.T) {
 
 	expectedFiles := []string{
 		".prettierrc",
+		"eslint.config.js",
+		"tsconfig.json",
+		"vite.config.ts",
 		"vitest.config.ts",
 		"scripts/check-components.sh",
 		"src/App.tsx",

--- a/internal/scaffold/quality_baseline_test.go
+++ b/internal/scaffold/quality_baseline_test.go
@@ -1,0 +1,182 @@
+// quality_baseline_test.go — Tests for quality baseline config file generation.
+
+package scaffold
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ============================================
+// Quality Baseline: File Generation
+// ============================================
+
+func TestWriteQualityBaseline_CreatesPrettierRC(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".prettierrc"))
+	if err != nil {
+		t.Fatalf("read .prettierrc: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(content, &cfg); err != nil {
+		t.Fatalf(".prettierrc is not valid JSON: %v", err)
+	}
+
+	if cfg["singleQuote"] != true {
+		t.Error(".prettierrc: singleQuote should be true")
+	}
+	if cfg["semi"] != false {
+		t.Error(".prettierrc: semi should be false")
+	}
+}
+
+func TestWriteQualityBaseline_CreatesVitestConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "vitest.config.ts"))
+	if err != nil {
+		t.Fatalf("read vitest.config.ts: %v", err)
+	}
+
+	body := string(content)
+	if !strings.Contains(body, "happy-dom") {
+		t.Error("vitest.config.ts should reference happy-dom")
+	}
+	if !strings.Contains(body, "@/") {
+		t.Error("vitest.config.ts should include path alias @/")
+	}
+}
+
+func TestWriteQualityBaseline_CreatesComponentInvariantScript(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "scripts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "scripts", "check-components.sh"))
+	if err != nil {
+		t.Fatalf("read check-components.sh: %v", err)
+	}
+
+	body := string(content)
+	checks := []string{
+		"style=",    // checks for inline styles
+		"any",       // checks for any type
+		"../",       // checks for relative imports
+	}
+	for _, c := range checks {
+		if !strings.Contains(body, c) {
+			t.Errorf("check-components.sh should check for %q", c)
+		}
+	}
+}
+
+func TestWriteQualityBaseline_CreatesExampleTest(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "src", "App.test.tsx"))
+	if err != nil {
+		t.Fatalf("read App.test.tsx: %v", err)
+	}
+
+	body := string(content)
+	if !strings.Contains(body, "describe") {
+		t.Error("App.test.tsx should contain a describe block")
+	}
+	if !strings.Contains(body, "expect") {
+		t.Error("App.test.tsx should contain expect assertions")
+	}
+}
+
+func TestWriteQualityBaseline_CreatesAppShell(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "src", "App.tsx"))
+	if err != nil {
+		t.Fatalf("read App.tsx: %v", err)
+	}
+
+	body := string(content)
+	if !strings.Contains(body, "export default") {
+		t.Error("App.tsx should have a default export")
+	}
+}
+
+func TestWriteQualityBaseline_CreatesIndexCSS(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "src", "index.css"))
+	if err != nil {
+		t.Fatalf("read index.css: %v", err)
+	}
+
+	body := string(content)
+	if !strings.Contains(body, "@theme") {
+		t.Error("index.css should contain @theme block with design tokens")
+	}
+	if !strings.Contains(body, "--color-primary") {
+		t.Error("index.css should define --color-primary design token")
+	}
+}
+
+func TestWriteQualityBaseline_AllFilesValid(t *testing.T) {
+	dir := t.TempDir()
+	// Create directories that WriteQualityBaseline expects.
+	for _, d := range []string{"src", "scripts"} {
+		if err := os.MkdirAll(filepath.Join(dir, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := WriteQualityBaseline(dir); err != nil {
+		t.Fatalf("WriteQualityBaseline: %v", err)
+	}
+
+	expectedFiles := []string{
+		".prettierrc",
+		"vitest.config.ts",
+		"scripts/check-components.sh",
+		"src/App.tsx",
+		"src/App.test.tsx",
+		"src/index.css",
+	}
+
+	for _, f := range expectedFiles {
+		path := filepath.Join(dir, f)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("missing expected file: %s", f)
+		}
+	}
+}

--- a/internal/scaffold/steps.go
+++ b/internal/scaffold/steps.go
@@ -5,6 +5,7 @@ package scaffold
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -61,6 +62,12 @@ func DefaultSteps() []Step {
 				if err := init.Run(); err != nil {
 					return fmt.Errorf("shadcn init: %w", err)
 				}
+				// Install lucide-react for icons.
+				lucide := exec.CommandContext(ctx, "pnpm", "add", "lucide-react")
+				lucide.Dir = projectDir
+				if err := lucide.Run(); err != nil {
+					return fmt.Errorf("lucide-react install: %w", err)
+				}
 				// Install core components.
 				components := []string{
 					"button", "card", "input", "label", "select", "checkbox",
@@ -74,7 +81,8 @@ func DefaultSteps() []Step {
 				return add.Run()
 			},
 			Verify: func(projectDir string) error {
-				return VerifyDirectoryExists(filepath.Join(projectDir, "src", "components", "ui"))
+				// Verify a specific component file exists, not just the directory.
+				return VerifyFileExists(filepath.Join(projectDir, "src", "components", "ui", "button.tsx"))
 			},
 		},
 		{
@@ -101,6 +109,18 @@ func DefaultSteps() []Step {
 			Name:  "git_init",
 			Label: "Initializing Git repository",
 			Run: func(ctx context.Context, projectDir string) error {
+				// Check if .git already exists (idempotency).
+				if _, err := os.Stat(filepath.Join(projectDir, ".git")); err == nil {
+					// Already initialized — skip git init, just stage and commit.
+					add := exec.CommandContext(ctx, "git", "add", "-A")
+					add.Dir = projectDir
+					if err := add.Run(); err != nil {
+						return err
+					}
+					commit := exec.CommandContext(ctx, "git", "commit", "-m", "scaffold: initial project", "--allow-empty")
+					commit.Dir = projectDir
+					return commit.Run()
+				}
 				init := exec.CommandContext(ctx, "git", "init")
 				init.Dir = projectDir
 				if err := init.Run(); err != nil {
@@ -119,19 +139,9 @@ func DefaultSteps() []Step {
 				return VerifyGitInitialized(projectDir)
 			},
 		},
-		{
-			Name:  "start_dev_server",
-			Label: "Starting dev server",
-			Run: func(ctx context.Context, projectDir string) error {
-				// Dev server is started asynchronously — handled by the engine caller.
-				// This step is a placeholder for the run; the real logic is in the caller.
-				return nil
-			},
-			Verify: func(projectDir string) error {
-				// Verification is done externally via dev server detection.
-				// For the step itself, just verify package.json has a dev script.
-				return VerifyFileExists(filepath.Join(projectDir, "package.json"))
-			},
-		},
+		// NOTE: start_dev_server is intentionally excluded from DefaultSteps.
+		// Dev server startup is handled externally by the caller using
+		// DevServerDetector after scaffolding completes. It requires a long-running
+		// background process that doesn't fit the step/verify model.
 	}
 }

--- a/internal/scaffold/steps.go
+++ b/internal/scaffold/steps.go
@@ -1,0 +1,137 @@
+// steps.go — Default scaffold step definitions.
+
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// DefaultSteps returns the standard scaffold steps in execution order.
+func DefaultSteps() []Step {
+	return []Step{
+		{
+			Name:  "create_project",
+			Label: "Creating project",
+			Run: func(ctx context.Context, projectDir string) error {
+				cmd := exec.CommandContext(ctx, "pnpm", "create", "vite", projectDir, "--template", "react-ts")
+				cmd.Dir = filepath.Dir(projectDir)
+				return cmd.Run()
+			},
+			Verify: func(projectDir string) error {
+				if err := VerifyDirectoryExists(projectDir); err != nil {
+					return err
+				}
+				return VerifyFileExists(filepath.Join(projectDir, "package.json"))
+			},
+		},
+		{
+			Name:  "install_deps",
+			Label: "Installing dependencies",
+			Run: func(ctx context.Context, projectDir string) error {
+				cmd := exec.CommandContext(ctx, "pnpm", "install")
+				cmd.Dir = projectDir
+				return cmd.Run()
+			},
+			Verify: func(projectDir string) error {
+				return VerifyDirectoryExists(filepath.Join(projectDir, "node_modules"))
+			},
+		},
+		{
+			Name:  "add_tailwind",
+			Label: "Adding Tailwind CSS",
+			Run: func(ctx context.Context, projectDir string) error {
+				cmd := exec.CommandContext(ctx, "pnpm", "add", "tailwindcss", "@tailwindcss/vite")
+				cmd.Dir = projectDir
+				return cmd.Run()
+			},
+			Verify: func(projectDir string) error {
+				return VerifyPackageInstalled(projectDir, "tailwindcss")
+			},
+		},
+		{
+			Name:  "add_shadcn",
+			Label: "Adding shadcn/ui components",
+			Run: func(ctx context.Context, projectDir string) error {
+				// Init shadcn.
+				init := exec.CommandContext(ctx, "pnpm", "dlx", "shadcn@latest", "init", "--defaults")
+				init.Dir = projectDir
+				if err := init.Run(); err != nil {
+					return fmt.Errorf("shadcn init: %w", err)
+				}
+				// Install core components.
+				components := []string{
+					"button", "card", "input", "label", "select", "checkbox",
+					"textarea", "separator", "sheet", "tabs", "scroll-area",
+					"alert", "badge", "toast", "skeleton", "navigation-menu",
+					"dropdown-menu", "avatar",
+				}
+				args := append([]string{"dlx", "shadcn@latest", "add"}, components...)
+				add := exec.CommandContext(ctx, "pnpm", args...)
+				add.Dir = projectDir
+				return add.Run()
+			},
+			Verify: func(projectDir string) error {
+				return VerifyDirectoryExists(filepath.Join(projectDir, "src", "components", "ui"))
+			},
+		},
+		{
+			Name:  "quality_baseline",
+			Label: "Applying quality baseline",
+			Run: func(ctx context.Context, projectDir string) error {
+				// Quality baseline writes config files — implemented in quality_baseline.go
+				return WriteQualityBaseline(projectDir)
+			},
+			Verify: func(projectDir string) error {
+				// Verify key config files exist.
+				files := []string{
+					".prettierrc",
+				}
+				for _, f := range files {
+					if err := VerifyFileExists(filepath.Join(projectDir, f)); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+		{
+			Name:  "git_init",
+			Label: "Initializing Git repository",
+			Run: func(ctx context.Context, projectDir string) error {
+				init := exec.CommandContext(ctx, "git", "init")
+				init.Dir = projectDir
+				if err := init.Run(); err != nil {
+					return err
+				}
+				add := exec.CommandContext(ctx, "git", "add", "-A")
+				add.Dir = projectDir
+				if err := add.Run(); err != nil {
+					return err
+				}
+				commit := exec.CommandContext(ctx, "git", "commit", "-m", "scaffold: initial project")
+				commit.Dir = projectDir
+				return commit.Run()
+			},
+			Verify: func(projectDir string) error {
+				return VerifyGitInitialized(projectDir)
+			},
+		},
+		{
+			Name:  "start_dev_server",
+			Label: "Starting dev server",
+			Run: func(ctx context.Context, projectDir string) error {
+				// Dev server is started asynchronously — handled by the engine caller.
+				// This step is a placeholder for the run; the real logic is in the caller.
+				return nil
+			},
+			Verify: func(projectDir string) error {
+				// Verification is done externally via dev server detection.
+				// For the step itself, just verify package.json has a dev script.
+				return VerifyFileExists(filepath.Join(projectDir, "package.json"))
+			},
+		},
+	}
+}

--- a/internal/scaffold/verify.go
+++ b/internal/scaffold/verify.go
@@ -1,0 +1,44 @@
+// verify.go — Verification gate functions for scaffold steps.
+
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// VerifyDirectoryExists checks that a directory exists at the given path.
+func VerifyDirectoryExists(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("directory does not exist: %s", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", path)
+	}
+	return nil
+}
+
+// VerifyFileExists checks that a file exists at the given path.
+func VerifyFileExists(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("file does not exist: %s", path)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path is a directory, not a file: %s", path)
+	}
+	return nil
+}
+
+// VerifyPackageInstalled checks that a package exists in node_modules.
+func VerifyPackageInstalled(projectDir, pkg string) error {
+	pkgDir := filepath.Join(projectDir, "node_modules", pkg)
+	return VerifyDirectoryExists(pkgDir)
+}
+
+// VerifyGitInitialized checks that .git exists in the project directory.
+func VerifyGitInitialized(projectDir string) error {
+	return VerifyDirectoryExists(filepath.Join(projectDir, ".git"))
+}


### PR DESCRIPTION
## Summary
Phase 1 of the Scaffold Wizard feature — automated project scaffolding with verification gates.

- Wizard landing page at `GET /launch` (conversational 4-step flow)
- Scaffold API at `POST /api/scaffold` (accepts wizard JSON, returns 202 + channel ID)
- Scaffold engine with per-step verification gates and single retry
- Progress broadcaster for WebSocket streaming (multiplexed channels)
- Quality baseline generator (prettier, vitest, component invariants, Tailwind tokens)
- AI context generator (CLAUDE.md, bootstrap skill, session-start hook, .mcp.json)
- Dev server detection (Vite stdout parsing + fallback port polling)
- Auto-navigate to dev server after ready

All code review criticals fixed: real handler wired, body size limit, concurrency guard, directory existence check, panic recovery, timeout, ESLint/tsconfig/vite configs generated.

## Tests
- 75 tests passing (14 handler + 61 engine)
- Strict TDD: every component test-first

## Test plan
- [x] `go build ./cmd/browser-agent/`
- [x] `go test ./cmd/browser-agent/ -run Scaffold`
- [x] `go test ./internal/scaffold/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)