### PR TITLE
feat: analytics — install ID, usage counter, 10-min beacon loop

### DIFF
--- a/cmd/browser-agent/handler.go
+++ b/cmd/browser-agent/handler.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/capture"
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/telemetry"
 )
 
 // serverInstructions is sent once per session in the initialize response.
@@ -89,4 +90,13 @@ func NewMCPHandler(server *Server, version string) *MCPHandler {
 // - Intended for one-time startup wiring; runtime swapping is unsupported.
 func (h *MCPHandler) SetToolHandler(th ToolHandlerInterface) {
 	h.toolHandler = th
+}
+
+// GetUsageCounter returns the usage counter from the underlying ToolHandler, if available.
+// Returns nil if the tool handler is not a ToolHandler or has no counter.
+func (h *MCPHandler) GetUsageCounter() *telemetry.UsageCounter {
+	if th, ok := h.toolHandler.(*ToolHandler); ok {
+		return th.usageCounter
+	}
+	return nil
 }

--- a/cmd/browser-agent/handler.go
+++ b/cmd/browser-agent/handler.go
@@ -92,8 +92,8 @@ func (h *MCPHandler) SetToolHandler(th ToolHandlerInterface) {
 	h.toolHandler = th
 }
 
-// GetUsageCounter returns the usage counter from the underlying ToolHandler, if available.
-// Returns nil if the tool handler is not a ToolHandler or has no counter.
+// GetUsageCounter returns the usage counter from the concrete ToolHandler.
+// Returns nil if toolHandler is a test double.
 func (h *MCPHandler) GetUsageCounter() *telemetry.UsageCounter {
 	if th, ok := h.toolHandler.(*ToolHandler); ok {
 		return th.usageCounter

--- a/cmd/browser-agent/handler_tools_call_usage_test.go
+++ b/cmd/browser-agent/handler_tools_call_usage_test.go
@@ -1,0 +1,81 @@
+// handler_tools_call_usage_test.go — Tests for usage counter wiring in tool call handler.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/telemetry"
+)
+
+func TestHandleToolCall_IncrementsUsageCounter(t *testing.T) {
+	handler := createTestToolHandler(t)
+
+	counter := telemetry.NewUsageCounter()
+	handler.usageCounter = counter
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	// Call observe with what=errors — should increment "observe:errors".
+	args := json.RawMessage(`{"what":"errors"}`)
+	resp, handled := handler.HandleToolCall(req, "observe", args)
+	if !handled {
+		t.Fatal("observe tool was not handled")
+	}
+	// The tool may return an error (no extension) but the counter should still increment.
+	_ = resp
+
+	counts := counter.SwapAndReset()
+	if counts["observe:errors"] != 1 {
+		t.Fatalf("observe:errors count = %d, want 1", counts["observe:errors"])
+	}
+}
+
+func TestHandleToolCall_IncrementsUsageCounter_NoWhatParam(t *testing.T) {
+	handler := createTestToolHandler(t)
+
+	counter := telemetry.NewUsageCounter()
+	handler.usageCounter = counter
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	// Call configure with no "what" — should increment "configure:unknown".
+	args := json.RawMessage(`{"key":"value"}`)
+	resp, handled := handler.HandleToolCall(req, "configure", args)
+	if !handled {
+		t.Fatal("configure tool was not handled")
+	}
+	_ = resp
+
+	counts := counter.SwapAndReset()
+	if counts["configure:unknown"] != 1 {
+		t.Fatalf("configure:unknown count = %d, want 1", counts["configure:unknown"])
+	}
+}
+
+func TestHandleToolCall_NilUsageCounter_NoPanic(t *testing.T) {
+	handler := createTestToolHandler(t)
+	// usageCounter is nil by default — should not panic.
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	args := json.RawMessage(`{"what":"errors"}`)
+	_, handled := handler.HandleToolCall(req, "observe", args)
+	if !handled {
+		t.Fatal("observe tool was not handled")
+	}
+	// If we got here without panic, the test passes.
+}

--- a/cmd/browser-agent/handler_tools_call_usage_test.go
+++ b/cmd/browser-agent/handler_tools_call_usage_test.go
@@ -9,6 +9,106 @@ import (
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/telemetry"
 )
 
+func TestExtractWhatParam(t *testing.T) {
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want string
+	}{
+		{
+			name: "valid args with what=errors",
+			args: json.RawMessage(`{"what":"errors"}`),
+			want: "errors",
+		},
+		{
+			name: "missing what key",
+			args: json.RawMessage(`{"key":"value"}`),
+			want: "",
+		},
+		{
+			name: "empty args object",
+			args: json.RawMessage(`{}`),
+			want: "",
+		},
+		{
+			name: "malformed JSON",
+			args: json.RawMessage(`{not valid json`),
+			want: "",
+		},
+		{
+			name: "nil args",
+			args: nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractWhatParam(tt.args)
+			if got != tt.want {
+				t.Errorf("extractWhatParam(%s) = %q, want %q", string(tt.args), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetUsageCounter(t *testing.T) {
+	t.Run("happy path returns counter", func(t *testing.T) {
+		handler := createTestToolHandler(t)
+		counter := telemetry.NewUsageCounter()
+		handler.usageCounter = counter
+
+		mcpHandler := NewMCPHandler(nil, "test")
+		mcpHandler.SetToolHandler(handler)
+
+		got := mcpHandler.GetUsageCounter()
+		if got != counter {
+			t.Fatalf("GetUsageCounter() = %p, want %p", got, counter)
+		}
+	})
+
+	t.Run("nil tool handler returns nil", func(t *testing.T) {
+		mcpHandler := NewMCPHandler(nil, "test")
+		// toolHandler is nil — should return nil.
+		got := mcpHandler.GetUsageCounter()
+		if got != nil {
+			t.Fatalf("GetUsageCounter() = %p, want nil when toolHandler is nil", got)
+		}
+	})
+
+	t.Run("test double returns nil", func(t *testing.T) {
+		mcpHandler := NewMCPHandler(nil, "test")
+		mcpHandler.SetToolHandler(&fakeToolHandlerForMCP{})
+		got := mcpHandler.GetUsageCounter()
+		if got != nil {
+			t.Fatalf("GetUsageCounter() = %p, want nil for test double", got)
+		}
+	})
+}
+
+func TestHandleToolCall_NilUsageCounter(t *testing.T) {
+	handler := createTestToolHandler(t)
+	// usageCounter is nil by default.
+
+	req := JSONRPCRequest{
+		JSONRPC: JSONRPCVersion,
+		ID:      1,
+		Method:  "tools/call",
+	}
+
+	// Verify tool dispatch works when usageCounter is nil.
+	args := json.RawMessage(`{"what":"errors"}`)
+	resp, handled := handler.HandleToolCall(req, "observe", args)
+	if !handled {
+		t.Fatal("observe tool was not handled with nil usageCounter")
+	}
+
+	// Verify the response is a valid JSON-RPC response (tool ran, not a panic).
+	if resp.JSONRPC != JSONRPCVersion {
+		t.Errorf("response JSONRPC = %q, want %q", resp.JSONRPC, JSONRPCVersion)
+	}
+}
+
 func TestHandleToolCall_IncrementsUsageCounter(t *testing.T) {
 	handler := createTestToolHandler(t)
 

--- a/cmd/browser-agent/main_connection_mcp.go
+++ b/cmd/browser-agent/main_connection_mcp.go
@@ -85,6 +85,11 @@ func runMCPMode(server *Server, port int, apiKey string, opts daemonLaunchOption
 		"port": fmt.Sprintf("%d", port),
 	})
 
+	// Start periodic usage beacon loop (aggregated tool counts every 10 minutes).
+	if usageCounter := mcpHandler.GetUsageCounter(); usageCounter != nil {
+		telemetry.StartUsageBeaconLoop(ctx, usageCounter)
+	}
+
 	awaitShutdownSignal(server, srv, port, httpDone, termSrv, termDone, mcpHandler)
 	return nil
 }

--- a/cmd/browser-agent/tools_core.go
+++ b/cmd/browser-agent/tools_core.go
@@ -19,6 +19,7 @@ import (
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/security"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/session"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/streaming"
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/telemetry"
 )
 
 // Note: Response helpers, error codes, and validation functions have been moved to:
@@ -128,6 +129,10 @@ type ToolHandler struct {
 	// issueCommandRunner overrides the exec runner for issue submission.
 	// When nil, issuereport.ExecRunner{} is used. Set in tests to inject a fake.
 	issueCommandRunner issuereport.CommandRunner
+
+	// usageCounter tracks tool:action call counts for periodic usage beacons.
+	// When nil, usage counting is disabled (backwards compatible).
+	usageCounter *telemetry.UsageCounter
 }
 
 // maybeWaitForCommand, formatCommandResult, and related async infrastructure
@@ -178,6 +183,15 @@ func (h *ToolHandler) HandleToolCall(req JSONRPCRequest, name string, args json.
 
 	h.recordAuditToolCall(req, name, args, resp, start)
 
+	// Increment usage counter for periodic beacon aggregation.
+	if h.usageCounter != nil {
+		what := extractWhatParam(args)
+		if what == "" {
+			what = "unknown"
+		}
+		h.usageCounter.Increment(name + ":" + what)
+	}
+
 	return resp, true
 }
 
@@ -191,6 +205,21 @@ func (h *ToolHandler) ensureToolModules() {
 	h.toolModulesOnce.Do(func() {
 		h.toolModules = h.buildToolModuleRegistry()
 	})
+}
+
+// extractWhatParam extracts the "what" string from raw JSON args.
+// Returns empty string if missing or unparseable.
+func extractWhatParam(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var parsed struct {
+		What string `json:"what"`
+	}
+	if json.Unmarshal(args, &parsed) != nil {
+		return ""
+	}
+	return parsed.What
 }
 
 func (h *ToolHandler) ensureToolSchemas() {

--- a/cmd/browser-agent/tools_core_constructor.go
+++ b/cmd/browser-agent/tools_core_constructor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/security"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/session"
 	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/streaming"
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/telemetry"
 )
 
 // defaultColdStartTimeout is how long requireExtension waits for the extension
@@ -53,6 +54,9 @@ func NewToolHandler(server *Server, capture *capture.Store) *MCPHandler {
 		playbackSessions: newPlaybackSessionsMap(),
 		networkRecording: &networkRecordingState{},
 	}
+
+	// Initialize usage counter for periodic telemetry beacons.
+	handler.usageCounter = telemetry.NewUsageCounter()
 
 	// Initialize health metrics.
 	handler.healthMetrics = NewHealthMetrics()

--- a/internal/telemetry/beacon.go
+++ b/internal/telemetry/beacon.go
@@ -22,8 +22,13 @@ const defaultEndpoint = "https://t.getstrum.dev/v1/event"
 // endpoint is the telemetry ingest URL. Overridable for tests.
 var endpoint = defaultEndpoint
 
+// maxConcurrentBeacons caps in-flight beacon goroutines. Chosen to allow burst
+// traffic (startup + first tool calls) without unbounded goroutine growth.
+// A dropped beacon is harmless — telemetry is best-effort.
+const maxConcurrentBeacons = 50
+
 // sem caps the number of concurrent beacon goroutines to prevent runaway growth.
-var sem = make(chan struct{}, 50)
+var sem = make(chan struct{}, maxConcurrentBeacons)
 
 // BeaconError fires an anonymous error event to the telemetry endpoint.
 // Fire-and-forget: backgrounded, 2s timeout, never blocks caller, never panics.

--- a/internal/telemetry/beacon.go
+++ b/internal/telemetry/beacon.go
@@ -46,6 +46,7 @@ func beacon(event string, props map[string]string) {
 		"event": event,
 		"v":     Version,
 		"os":    runtime.GOOS + "-" + runtime.GOARCH,
+		"iid":   GetInstallID(),
 	}
 	if props != nil {
 		payload["props"] = props

--- a/internal/telemetry/beacon_test.go
+++ b/internal/telemetry/beacon_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -89,6 +90,15 @@ func TestBeaconError_FormatsJSON(t *testing.T) {
 	}
 	if props["port"] != "7890" {
 		t.Errorf("props.port = %v, want 7890", props["port"])
+	}
+
+	// Verify install ID is present and is 12-char hex.
+	iid, ok := body["iid"].(string)
+	if !ok {
+		t.Fatalf("missing or non-string 'iid' field in beacon payload")
+	}
+	if !regexp.MustCompile(`^[0-9a-f]{12}$`).MatchString(iid) {
+		t.Errorf("iid = %q, want 12-char hex string", iid)
 	}
 }
 

--- a/internal/telemetry/beacon_test.go
+++ b/internal/telemetry/beacon_test.go
@@ -1,4 +1,5 @@
 // beacon_test.go — Tests for anonymous telemetry beacons.
+// Tests in this package must NOT use t.Parallel() due to shared package-level state.
 
 package telemetry
 
@@ -148,6 +149,68 @@ func TestBeaconError_IgnoresHTTPFailure(t *testing.T) {
 	BeaconError("unreachable", map[string]string{"key": "val"})
 	time.Sleep(100 * time.Millisecond)
 	// If we got here without panic, the test passes.
+}
+
+func TestBeacon_SemaphoreBackpressure(t *testing.T) {
+	// Point at a real server so beacons would succeed if they ran.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	overrideEndpoint(srv.URL)
+	defer resetEndpoint()
+
+	// Fill all semaphore slots with blocking goroutines.
+	blockers := make(chan struct{})
+	for i := 0; i < maxConcurrentBeacons; i++ {
+		sem <- struct{}{}
+	}
+
+	// Fire a 51st beacon — should be silently dropped (no panic, no block).
+	done := make(chan struct{})
+	go func() {
+		BeaconEvent("overflow_test", map[string]string{"seq": "51"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — beacon was dropped without blocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("BeaconEvent blocked when semaphore was full — should drop silently")
+	}
+
+	// Release all slots and verify cleanup.
+	close(blockers)
+	for i := 0; i < maxConcurrentBeacons; i++ {
+		<-sem
+	}
+
+	// Verify beacon works again after draining.
+	received := make(chan struct{}, 1)
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv2.Close()
+	overrideEndpoint(srv2.URL)
+
+	resetInstallIDState()
+	dir := t.TempDir()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	BeaconEvent("post_drain", nil)
+	select {
+	case <-received:
+		// Good — beacon fired after slots were freed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("beacon did not fire after semaphore slots were freed")
+	}
 }
 
 func TestBeaconError_NilProps(t *testing.T) {

--- a/internal/telemetry/install_id.go
+++ b/internal/telemetry/install_id.go
@@ -1,0 +1,83 @@
+// install_id.go — Random install ID for anonymous session correlation.
+
+package telemetry
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// strumDir is the directory where install_id is persisted. Overridable for tests.
+var strumDir = defaultStrumDir()
+
+// cachedInstallID holds the in-memory cached value after first load.
+var cachedInstallID string
+
+// installIDOnce ensures the install ID is loaded/generated exactly once.
+var installIDOnce sync.Once
+
+func defaultStrumDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".strum")
+	}
+	return filepath.Join(home, ".strum")
+}
+
+// GetInstallID returns the persistent anonymous install ID.
+// On first call, reads from ~/.strum/install_id or generates a new 12-char hex string.
+// Thread-safe via sync.Once. Never returns an error — falls back to a fresh random ID.
+func GetInstallID() string {
+	installIDOnce.Do(func() {
+		cachedInstallID = loadOrGenerateInstallID()
+	})
+	return cachedInstallID
+}
+
+func loadOrGenerateInstallID() string {
+	idPath := filepath.Join(strumDir, "install_id")
+
+	// Try to read existing file.
+	data, err := os.ReadFile(idPath)
+	if err == nil && len(data) > 0 {
+		return string(data)
+	}
+
+	// Generate a new random ID.
+	id := generateRandomID()
+
+	// Best-effort persist: create dir and write file.
+	if err := os.MkdirAll(strumDir, 0700); err == nil {
+		_ = os.WriteFile(idPath, []byte(id), 0600)
+	}
+
+	return id
+}
+
+func generateRandomID() string {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: return a zero-filled ID rather than failing.
+		return "000000000000"
+	}
+	return hex.EncodeToString(b)
+}
+
+// overrideStrumDir sets a custom directory for testing.
+func overrideStrumDir(dir string) {
+	strumDir = dir
+}
+
+// resetStrumDir restores the default strum directory after testing.
+func resetStrumDir() {
+	strumDir = defaultStrumDir()
+}
+
+// resetInstallIDState clears the cached install ID and sync.Once for testing.
+func resetInstallIDState() {
+	installIDOnce = sync.Once{}
+	cachedInstallID = ""
+}

--- a/internal/telemetry/install_id_test.go
+++ b/internal/telemetry/install_id_test.go
@@ -1,4 +1,5 @@
 // install_id_test.go — Tests for random install ID generation and persistence.
+// Tests in this package must NOT use t.Parallel() due to shared package-level state.
 
 package telemetry
 
@@ -6,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"testing"
 )
 
@@ -81,5 +83,28 @@ func TestGetInstallID_CreatesDirectory(t *testing.T) {
 	}
 	if string(data) != id {
 		t.Fatalf("file content = %q, want %q", string(data), id)
+	}
+}
+
+func TestGetInstallID_ReadFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 000 not effective on Windows")
+	}
+
+	dir := t.TempDir()
+	resetInstallIDState()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	// Create a directory where the install_id file would be, making ReadFile fail.
+	idPath := filepath.Join(dir, "install_id")
+	if err := os.Mkdir(idPath, 0000); err != nil {
+		t.Fatalf("failed to create blocking dir: %v", err)
+	}
+	defer os.Chmod(idPath, 0700) // cleanup
+
+	id := GetInstallID()
+	if !hexPattern.MatchString(id) {
+		t.Fatalf("GetInstallID() = %q, want 12-char hex string even on read failure", id)
 	}
 }

--- a/internal/telemetry/install_id_test.go
+++ b/internal/telemetry/install_id_test.go
@@ -1,0 +1,85 @@
+// install_id_test.go — Tests for random install ID generation and persistence.
+
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+var hexPattern = regexp.MustCompile(`^[0-9a-f]{12}$`)
+
+func TestGetInstallID_GeneratesOnFirstCall(t *testing.T) {
+	dir := t.TempDir()
+	resetInstallIDState()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	id := GetInstallID()
+	if !hexPattern.MatchString(id) {
+		t.Fatalf("GetInstallID() = %q, want 12-char hex string", id)
+	}
+}
+
+func TestGetInstallID_PersistsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	resetInstallIDState()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	id1 := GetInstallID()
+	id2 := GetInstallID()
+	if id1 != id2 {
+		t.Fatalf("GetInstallID() returned different values: %q vs %q", id1, id2)
+	}
+}
+
+func TestGetInstallID_ReadsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	resetInstallIDState()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	// Pre-write a known ID file.
+	knownID := "aabbccddeeff"
+	if err := os.WriteFile(filepath.Join(dir, "install_id"), []byte(knownID), 0600); err != nil {
+		t.Fatalf("failed to write test install_id: %v", err)
+	}
+
+	id := GetInstallID()
+	if id != knownID {
+		t.Fatalf("GetInstallID() = %q, want %q (from file)", id, knownID)
+	}
+}
+
+func TestGetInstallID_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", ".strum")
+	resetInstallIDState()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	id := GetInstallID()
+	if !hexPattern.MatchString(id) {
+		t.Fatalf("GetInstallID() = %q, want 12-char hex string", id)
+	}
+
+	// Verify directory was created.
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("strum dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("strum dir path is not a directory")
+	}
+
+	// Verify file was written.
+	data, err := os.ReadFile(filepath.Join(dir, "install_id"))
+	if err != nil {
+		t.Fatalf("install_id file not written: %v", err)
+	}
+	if string(data) != id {
+		t.Fatalf("file content = %q, want %q", string(data), id)
+	}
+}

--- a/internal/telemetry/usage_beacon.go
+++ b/internal/telemetry/usage_beacon.go
@@ -1,0 +1,47 @@
+// usage_beacon.go — Periodic aggregated usage beacon.
+
+package telemetry
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/brennhill/gasoline-agentic-browser-devtools-mcp/internal/util"
+)
+
+// usageBeaconInterval is the default interval for aggregated usage beacons.
+const usageBeaconInterval = 10 * time.Minute
+
+// StartUsageBeaconLoop starts a background goroutine that fires a usage_summary
+// beacon every 10 minutes if there was activity. Respects ctx.Done() for clean shutdown.
+func StartUsageBeaconLoop(ctx context.Context, counter *UsageCounter) {
+	util.SafeGo(func() {
+		startUsageBeaconLoopWithInterval(ctx, counter, usageBeaconInterval)
+	})
+}
+
+// startUsageBeaconLoopWithInterval runs the beacon loop with a configurable interval.
+// Blocks until ctx is cancelled. Used directly in tests with short intervals.
+func startUsageBeaconLoopWithInterval(ctx context.Context, counter *UsageCounter, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			snapshot := counter.SwapAndReset()
+			if len(snapshot) == 0 {
+				continue // no activity, skip beacon
+			}
+			props := make(map[string]string)
+			props["window_m"] = "10"
+			for key, count := range snapshot {
+				props[key] = strconv.Itoa(count)
+			}
+			BeaconEvent("usage_summary", props)
+		}
+	}
+}

--- a/internal/telemetry/usage_beacon.go
+++ b/internal/telemetry/usage_beacon.go
@@ -21,6 +21,10 @@ func StartUsageBeaconLoop(ctx context.Context, counter *UsageCounter) {
 	})
 }
 
+// onTick is a test hook called after each tick iteration completes.
+// When nil (production), no notification is sent.
+var onTick func()
+
 // startUsageBeaconLoopWithInterval runs the beacon loop with a configurable interval.
 // Blocks until ctx is cancelled. Used directly in tests with short intervals.
 func startUsageBeaconLoopWithInterval(ctx context.Context, counter *UsageCounter, interval time.Duration) {
@@ -34,14 +38,20 @@ func startUsageBeaconLoopWithInterval(ctx context.Context, counter *UsageCounter
 		case <-ticker.C:
 			snapshot := counter.SwapAndReset()
 			if len(snapshot) == 0 {
+				if onTick != nil {
+					onTick()
+				}
 				continue // no activity, skip beacon
 			}
 			props := make(map[string]string)
-			props["window_m"] = "10"
+			props["window_m"] = strconv.Itoa(int(interval.Minutes()))
 			for key, count := range snapshot {
 				props[key] = strconv.Itoa(count)
 			}
 			BeaconEvent("usage_summary", props)
+			if onTick != nil {
+				onTick()
+			}
 		}
 	}
 }

--- a/internal/telemetry/usage_beacon_test.go
+++ b/internal/telemetry/usage_beacon_test.go
@@ -1,0 +1,136 @@
+// usage_beacon_test.go — Tests for periodic aggregated usage beacon.
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestUsageBeaconLoop_FiresOnActivity(t *testing.T) {
+	received := make(chan map[string]any, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case received <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	overrideEndpoint(srv.URL)
+	defer resetEndpoint()
+
+	// Reset install ID state so it generates fresh for this test.
+	resetInstallIDState()
+	dir := t.TempDir()
+	overrideStrumDir(dir)
+	defer resetStrumDir()
+
+	counter := NewUsageCounter()
+	counter.Increment("observe:errors")
+	counter.Increment("observe:errors")
+	counter.Increment("interact:click")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startUsageBeaconLoopWithInterval(ctx, counter, 50*time.Millisecond)
+
+	var body map[string]any
+	select {
+	case body = <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("usage beacon not received within timeout")
+	}
+
+	if body["event"] != "usage_summary" {
+		t.Errorf("event = %v, want usage_summary", body["event"])
+	}
+
+	props, ok := body["props"].(map[string]any)
+	if !ok {
+		t.Fatalf("props is not a map: %T", body["props"])
+	}
+	if props["window_m"] != "10" {
+		t.Errorf("window_m = %v, want 10", props["window_m"])
+	}
+	if props["observe:errors"] != "2" {
+		t.Errorf("observe:errors = %v, want 2", props["observe:errors"])
+	}
+	if props["interact:click"] != "1" {
+		t.Errorf("interact:click = %v, want 1", props["interact:click"])
+	}
+}
+
+func TestUsageBeaconLoop_SkipsWhenIdle(t *testing.T) {
+	var mu sync.Mutex
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	overrideEndpoint(srv.URL)
+	defer resetEndpoint()
+
+	counter := NewUsageCounter()
+	// Don't increment — should skip.
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go startUsageBeaconLoopWithInterval(ctx, counter, 30*time.Millisecond)
+
+	// Wait for a few tick cycles.
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+
+	if count != 0 {
+		t.Fatalf("beacon fired %d times, want 0 (no activity)", count)
+	}
+}
+
+func TestUsageBeaconLoop_StopsOnContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	overrideEndpoint(srv.URL)
+	defer resetEndpoint()
+
+	counter := NewUsageCounter()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		startUsageBeaconLoopWithInterval(ctx, counter, 50*time.Millisecond)
+		close(done)
+	}()
+
+	// Cancel context and verify goroutine exits.
+	cancel()
+
+	select {
+	case <-done:
+		// Good — goroutine exited.
+	case <-time.After(2 * time.Second):
+		t.Fatal("beacon loop did not stop after context cancel")
+	}
+}

--- a/internal/telemetry/usage_beacon_test.go
+++ b/internal/telemetry/usage_beacon_test.go
@@ -60,8 +60,8 @@ func TestUsageBeaconLoop_FiresOnActivity(t *testing.T) {
 	if !ok {
 		t.Fatalf("props is not a map: %T", body["props"])
 	}
-	if props["window_m"] != "10" {
-		t.Errorf("window_m = %v, want 10", props["window_m"])
+	if props["window_m"] != "0" {
+		t.Errorf("window_m = %v, want 0 (sub-minute test interval)", props["window_m"])
 	}
 	if props["observe:errors"] != "2" {
 		t.Errorf("observe:errors = %v, want 2", props["observe:errors"])
@@ -86,15 +86,33 @@ func TestUsageBeaconLoop_SkipsWhenIdle(t *testing.T) {
 	overrideEndpoint(srv.URL)
 	defer resetEndpoint()
 
+	// Use onTick hook to wait for a known number of tick cycles.
+	tickCh := make(chan struct{}, 10)
+	onTick = func() {
+		select {
+		case tickCh <- struct{}{}:
+		default:
+		}
+	}
+	defer func() { onTick = nil }()
+
 	counter := NewUsageCounter()
 	// Don't increment — should skip.
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	go startUsageBeaconLoopWithInterval(ctx, counter, 30*time.Millisecond)
+	go startUsageBeaconLoopWithInterval(ctx, counter, 10*time.Millisecond)
 
-	// Wait for a few tick cycles.
-	time.Sleep(150 * time.Millisecond)
+	// Wait for 3 tick cycles to complete.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-tickCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for tick")
+		}
+	}
+
 	cancel()
 
 	mu.Lock()
@@ -103,6 +121,62 @@ func TestUsageBeaconLoop_SkipsWhenIdle(t *testing.T) {
 
 	if count != 0 {
 		t.Fatalf("beacon fired %d times, want 0 (no activity)", count)
+	}
+}
+
+func TestUsageBeaconLoop_RespectsOptOut(t *testing.T) {
+	t.Setenv("STRUM_TELEMETRY", "off")
+
+	var mu sync.Mutex
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	overrideEndpoint(srv.URL)
+	defer resetEndpoint()
+
+	// Use onTick hook to wait for a known number of tick cycles.
+	tickCh := make(chan struct{}, 10)
+	onTick = func() {
+		select {
+		case tickCh <- struct{}{}:
+		default:
+		}
+	}
+	defer func() { onTick = nil }()
+
+	counter := NewUsageCounter()
+	counter.Increment("observe:errors")
+	counter.Increment("interact:click")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startUsageBeaconLoopWithInterval(ctx, counter, 10*time.Millisecond)
+
+	// Wait for 3 tick cycles to complete.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-tickCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for tick")
+		}
+	}
+
+	cancel()
+
+	mu.Lock()
+	count := callCount
+	mu.Unlock()
+
+	if count != 0 {
+		t.Fatalf("beacon fired %d times with STRUM_TELEMETRY=off, want 0", count)
 	}
 }
 

--- a/internal/telemetry/usage_counter.go
+++ b/internal/telemetry/usage_counter.go
@@ -1,0 +1,34 @@
+// usage_counter.go — Aggregated tool usage counters for periodic beacon.
+
+package telemetry
+
+import "sync"
+
+// UsageCounter is a thread-safe counter map that tracks tool:action call counts.
+type UsageCounter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+// NewUsageCounter creates a new empty usage counter.
+func NewUsageCounter() *UsageCounter {
+	return &UsageCounter{
+		counts: make(map[string]int),
+	}
+}
+
+// Increment adds 1 to the count for the given key (e.g., "observe:errors").
+func (u *UsageCounter) Increment(key string) {
+	u.mu.Lock()
+	u.counts[key]++
+	u.mu.Unlock()
+}
+
+// SwapAndReset atomically returns the current counts and replaces with an empty map.
+func (u *UsageCounter) SwapAndReset() map[string]int {
+	u.mu.Lock()
+	old := u.counts
+	u.counts = make(map[string]int)
+	u.mu.Unlock()
+	return old
+}

--- a/internal/telemetry/usage_counter_test.go
+++ b/internal/telemetry/usage_counter_test.go
@@ -1,0 +1,81 @@
+// usage_counter_test.go — Tests for aggregated tool usage counters.
+
+package telemetry
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestUsageCounter_Increment(t *testing.T) {
+	c := NewUsageCounter()
+	c.Increment("observe:errors")
+	c.Increment("observe:errors")
+	c.Increment("observe:errors")
+
+	counts := c.SwapAndReset()
+	if counts["observe:errors"] != 3 {
+		t.Fatalf("count = %d, want 3", counts["observe:errors"])
+	}
+}
+
+func TestUsageCounter_SwapAndReset(t *testing.T) {
+	c := NewUsageCounter()
+	c.Increment("observe:errors")
+	c.Increment("interact:click")
+
+	old := c.SwapAndReset()
+	if old["observe:errors"] != 1 {
+		t.Fatalf("old[observe:errors] = %d, want 1", old["observe:errors"])
+	}
+	if old["interact:click"] != 1 {
+		t.Fatalf("old[interact:click] = %d, want 1", old["interact:click"])
+	}
+
+	// After swap, new map should be empty.
+	fresh := c.SwapAndReset()
+	if len(fresh) != 0 {
+		t.Fatalf("fresh map has %d entries, want 0", len(fresh))
+	}
+}
+
+func TestUsageCounter_ConcurrentIncrement(t *testing.T) {
+	c := NewUsageCounter()
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			c.Increment("concurrent:key")
+		}()
+	}
+	wg.Wait()
+
+	counts := c.SwapAndReset()
+	if counts["concurrent:key"] != goroutines {
+		t.Fatalf("count = %d, want %d", counts["concurrent:key"], goroutines)
+	}
+}
+
+func TestUsageCounter_MultipleKeys(t *testing.T) {
+	c := NewUsageCounter()
+	c.Increment("observe:errors")
+	c.Increment("observe:errors")
+	c.Increment("interact:click")
+	c.Increment("analyze:performance")
+	c.Increment("analyze:performance")
+	c.Increment("analyze:performance")
+
+	counts := c.SwapAndReset()
+	if counts["observe:errors"] != 2 {
+		t.Fatalf("observe:errors = %d, want 2", counts["observe:errors"])
+	}
+	if counts["interact:click"] != 1 {
+		t.Fatalf("interact:click = %d, want 1", counts["interact:click"])
+	}
+	if counts["analyze:performance"] != 3 {
+		t.Fatalf("analyze:performance = %d, want 3", counts["analyze:performance"])
+	}
+}

--- a/internal/telemetry/usage_counter_test.go
+++ b/internal/telemetry/usage_counter_test.go
@@ -59,6 +59,71 @@ func TestUsageCounter_ConcurrentIncrement(t *testing.T) {
 	}
 }
 
+func TestUsageCounter_ConcurrentSwapAndIncrement(t *testing.T) {
+	c := NewUsageCounter()
+	const incrementors = 100
+	const incrementsEach = 50
+
+	var wg sync.WaitGroup
+	var swapResults []map[string]int
+	var swapMu sync.Mutex
+
+	// Start incrementor goroutines.
+	wg.Add(incrementors)
+	for i := 0; i < incrementors; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsEach; j++ {
+				c.Increment("key")
+			}
+		}()
+	}
+
+	// Start a swapper goroutine that runs concurrently with incrementors.
+	stopSwapper := make(chan struct{})
+	swapperDone := make(chan struct{})
+	go func() {
+		defer close(swapperDone)
+		for {
+			select {
+			case <-stopSwapper:
+				return
+			default:
+				snapshot := c.SwapAndReset()
+				if len(snapshot) > 0 {
+					swapMu.Lock()
+					swapResults = append(swapResults, snapshot)
+					swapMu.Unlock()
+				}
+			}
+		}
+	}()
+
+	// Wait for all incrementors to finish.
+	wg.Wait()
+
+	// Signal the swapper to stop.
+	close(stopSwapper)
+	<-swapperDone
+
+	// Collect the final snapshot.
+	finalSnapshot := c.SwapAndReset()
+	if len(finalSnapshot) > 0 {
+		swapResults = append(swapResults, finalSnapshot)
+	}
+
+	// Sum all counts across all swap results.
+	total := 0
+	for _, snapshot := range swapResults {
+		total += snapshot["key"]
+	}
+
+	expected := incrementors * incrementsEach
+	if total != expected {
+		t.Fatalf("total count = %d, want %d (counts were lost)", total, expected)
+	}
+}
+
 func TestUsageCounter_MultipleKeys(t *testing.T) {
 	c := NewUsageCounter()
 	c.Increment("observe:errors")


### PR DESCRIPTION
## Summary
Implements the analytics telemetry system in the daemon:

- **Install ID** — random 12-char hex generated once at first startup, stored at `~/.strum/install_id`. Included in every beacon as `iid`. Not derived from hardware/identity.
- **Usage counter** — thread-safe `tool:action` counter with atomic swap-and-reset
- **Beacon loop** — fires `usage_summary` event every 10 minutes if there was activity. Skips when idle.
- **Tool call wiring** — every tool dispatch increments the counter with `toolName:whatParam`

## Tests
- 17 telemetry tests passing (install ID, counter, beacon loop, concurrency)
- All TDD — test first, then implementation

## Test plan
- [x] `go build ./cmd/browser-agent/`
- [x] `go test ./internal/telemetry/ -count=1`
- [x] Concurrency test: 100 goroutines incrementing simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)