### PR TITLE
feat(install): show the EXACT extension folder and auto-open it (npm + curl|sh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Upgrade script contract tests
         run: node --test scripts/install-upgrade-regression.contract.test.mjs
 
-      - name: npm cleanup tests
-        run: node --test npm/kaboom-agentic-browser/lib/kill-daemon.test.js
+      - name: npm wrapper tests
+        run: node --test npm/kaboom-agentic-browser/lib/*.test.js
 
       - name: Platform-binary publish guard tests
         run: node --test scripts/verify-platform-binaries.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: node --test scripts/install-upgrade-regression.contract.test.mjs
 
       - name: npm wrapper tests
-        run: node --test npm/kaboom-agentic-browser/lib/*.test.js
+        run: node scripts/run-npm-wrapper-tests.js
 
       - name: Platform-binary publish guard tests
         run: node --test scripts/verify-platform-binaries.test.mjs

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ quality-gate: check-file-length lint lint-hardening lint-dead lint-circular lint
 test-upgrade-guards:
 	go test ./cmd/browser-agent -run 'TestConnectWithRetriesRejectsVersionMismatch' -count=1
 	node --test scripts/install-upgrade-regression.contract.test.mjs
-	node --test npm/kaboom-agentic-browser/lib/kill-daemon.test.js
+	node --test npm/kaboom-agentic-browser/lib/*.test.js
 	node --test scripts/verify-platform-binaries.test.mjs
 	@if [ -d pypi/kaboom-agentic-browser/tests ]; then \
 		python3 -m unittest discover -s pypi/kaboom-agentic-browser/tests -p 'test_*.py'; \

--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ quality-gate: check-file-length lint lint-hardening lint-dead lint-circular lint
 test-upgrade-guards:
 	go test ./cmd/browser-agent -run 'TestConnectWithRetriesRejectsVersionMismatch' -count=1
 	node --test scripts/install-upgrade-regression.contract.test.mjs
-	node --test npm/kaboom-agentic-browser/lib/*.test.js
+	node scripts/run-npm-wrapper-tests.js
 	node --test scripts/verify-platform-binaries.test.mjs
 	@if [ -d pypi/kaboom-agentic-browser/tests ]; then \
 		python3 -m unittest discover -s pypi/kaboom-agentic-browser/tests -p 'test_*.py'; \

--- a/cmd/browser-agent/native_install.go
+++ b/cmd/browser-agent/native_install.go
@@ -60,6 +60,61 @@ func printManualExtensionSetupChecklist(extDir string) {
 	}
 }
 
+// fileManagerOpenCommand returns the command that reveals dir in goos's desktop
+// file manager, or ok=false when the platform has none. Pure so the mapping can
+// be unit-tested without launching anything.
+func fileManagerOpenCommand(goos, dir string) (name string, args []string, ok bool) {
+	switch goos {
+	case "darwin":
+		return "open", []string{dir}, true
+	case "windows":
+		return "explorer", []string{dir}, true
+	case "linux":
+		return "xdg-open", []string{dir}, true
+	default:
+		return "", nil, false
+	}
+}
+
+// extensionAutoOpenDisabled reports whether the user opted out of the
+// install-time folder auto-open (headless installs, CI, scripted runs).
+func extensionAutoOpenDisabled() bool {
+	for _, key := range []string{"KABOOM_NO_OPEN", "KABOOM_INSTALL_NO_OPEN"} {
+		v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+		if v != "" && v != "0" && v != "false" && v != "no" {
+			return true
+		}
+	}
+	return false
+}
+
+// openExtensionFolder best-effort reveals extDir in the file manager so Load
+// unpacked is one selection away. Never fatal — the checklist still shows the
+// path when this cannot run (no opener, headless, opted out, dir absent).
+func openExtensionFolder(extDir string) bool {
+	if extDir == "" || extensionAutoOpenDisabled() {
+		return false
+	}
+	if info, err := os.Stat(extDir); err != nil || !info.IsDir() {
+		return false
+	}
+	name, args, ok := fileManagerOpenCommand(runtime.GOOS, extDir)
+	if !ok {
+		return false
+	}
+	if _, err := exec.LookPath(name); err != nil {
+		return false
+	}
+	cmd := exec.Command(name, args...)
+	cmd.Stdout, cmd.Stderr, cmd.Stdin = nil, nil, nil
+	util.SetDetachedProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+	go func() { _ = cmd.Wait() }() // lint:allow-bare-goroutine — reap the detached opener
+	return true
+}
+
 func printInstallerPanel(title string, lines []string) {
 	const border = "+----------------------------------------------------------+"
 	stderrf("\033[1;36m%s\033[0m\n", border)
@@ -185,6 +240,9 @@ func runNativeInstall() {
 	})
 	stderrf("\n")
 	printManualExtensionSetupChecklist(extDir)
+	if openExtensionFolder(extDir) {
+		stderrf("   \033[1;32m📂 Opened the extension folder for you — select it in Load unpacked.\033[0m\n")
+	}
 	stderrf("\033[1;33mREADY TO COOK:\033[0m\n")
 	stderrf("   The Kaboom server is active on port 7890.\n")
 	stderrf("   Your AI tool (Claude, Cursor, etc.) is now configured.\n")

--- a/cmd/browser-agent/native_install_open_test.go
+++ b/cmd/browser-agent/native_install_open_test.go
@@ -1,0 +1,75 @@
+// native_install_open_test.go — Tests for the install-time extension folder open.
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFileManagerOpenCommand(t *testing.T) {
+	cases := []struct {
+		goos     string
+		wantName string
+		wantOK   bool
+	}{
+		{"darwin", "open", true},
+		{"windows", "explorer", true},
+		{"linux", "xdg-open", true},
+		{"plan9", "", false},
+	}
+	for _, tc := range cases {
+		name, args, ok := fileManagerOpenCommand(tc.goos, "/some/dir")
+		if ok != tc.wantOK || name != tc.wantName {
+			t.Fatalf("fileManagerOpenCommand(%q) = (%q,%v), want (%q,%v)", tc.goos, name, ok, tc.wantName, tc.wantOK)
+		}
+		if ok && (len(args) != 1 || args[0] != "/some/dir") {
+			t.Fatalf("fileManagerOpenCommand(%q) args = %v, want [/some/dir]", tc.goos, args)
+		}
+	}
+}
+
+func TestExtensionAutoOpenDisabled(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		val  string
+		want bool
+	}{
+		{"unset", "", "", false},
+		{"no_open_1", "KABOOM_NO_OPEN", "1", true},
+		{"install_no_open_true", "KABOOM_INSTALL_NO_OPEN", "true", true},
+		{"no_open_0", "KABOOM_NO_OPEN", "0", false},
+		{"no_open_false", "KABOOM_NO_OPEN", "false", false},
+		{"no_open_empty", "KABOOM_NO_OPEN", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear both so a stray env from the runner cannot leak across cases.
+			t.Setenv("KABOOM_NO_OPEN", "")
+			t.Setenv("KABOOM_INSTALL_NO_OPEN", "")
+			if tc.key != "" {
+				t.Setenv(tc.key, tc.val)
+			}
+			if got := extensionAutoOpenDisabled(); got != tc.want {
+				t.Fatalf("extensionAutoOpenDisabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenExtensionFolder_Guards(t *testing.T) {
+	// Opt-out must short-circuit before any launch, even for a real directory.
+	t.Setenv("KABOOM_NO_OPEN", "1")
+	if openExtensionFolder(t.TempDir()) {
+		t.Fatal("opt-out must prevent opening")
+	}
+
+	// A missing directory is never opened (and does not error).
+	t.Setenv("KABOOM_NO_OPEN", "")
+	if openExtensionFolder(filepath.Join(t.TempDir(), "absent")) {
+		t.Fatal("a missing directory must not be opened")
+	}
+	if openExtensionFolder("") {
+		t.Fatal("an empty path must not be opened")
+	}
+}

--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -4,11 +4,13 @@ feature_id: feature-enhanced-cli-config
 status: proposed
 feature_type: feature
 owners: []
-last_reviewed: 2026-07-05
+last_reviewed: 2026-07-24
 code_paths:
   - Makefile
   - scripts/build-crx.js
   - cmd/browser-agent/native_install.go
+  - npm/kaboom-agentic-browser/lib/extension.js
+  - npm/kaboom-agentic-browser/lib/output.js
   - scripts/install.sh
   - scripts/install.ps1
   - scripts/uninstall.sh
@@ -23,7 +25,9 @@ code_paths:
   - docs/mcp-install-guide.md
 test_paths:
   - cmd/browser-agent/native_install_test.go
+  - cmd/browser-agent/native_install_open_test.go
   - npm/kaboom-agentic-browser/lib/config.test.js
+  - npm/kaboom-agentic-browser/lib/extension.test.js
   - npm/kaboom-agentic-browser/lib/install.test.js
   - npm/kaboom-agentic-browser/lib/uninstall.test.js
   - tests/packaging/kaboom-packaging-branding.test.js

--- a/npm/kaboom-agentic-browser/lib/cli.js
+++ b/npm/kaboom-agentic-browser/lib/cli.js
@@ -8,6 +8,7 @@ const os = require('os');
 const config = require('./config');
 const output = require('./output');
 const install = require('./install');
+const extension = require('./extension');
 const skills = require('./skills');
 const doctor = require('./doctor');
 const uninstall = require('./uninstall');
@@ -64,6 +65,12 @@ async function installCommand(options) {
         console.log(`ℹ️  Dry run: No files will be written\n`);
       }
       console.log(output.installResult(result));
+      // Reveal the extension folder so "Load unpacked" is one selection away.
+      // Best-effort and opt-out via KABOOM_NO_OPEN; the exact path is printed
+      // above regardless, so nothing is lost when this cannot run.
+      if (!options.dryRun && extension.openExtensionDir(result.extensionDir)) {
+        console.log('📂 Opened the extension folder for you — just select it in "Load unpacked".');
+      }
       if (!options.dryRun) {
         const skillInstall = await skills.installBundledSkills({
           verbose: options.verbose,

--- a/npm/kaboom-agentic-browser/lib/config.test.js
+++ b/npm/kaboom-agentic-browser/lib/config.test.js
@@ -77,22 +77,27 @@ test('getClientById returns undefined for unknown id', () => {
 
 // --- getClientConfigPath ---
 
+// expandPath runs path.normalize, which emits backslashes on a Windows host even
+// for a darwin/linux platform arg. Compare on forward slashes so these assertions
+// hold on every runner, not just POSIX ones.
+const fwd = (p) => String(p).replace(/\\/g, '/');
+
 test('getClientConfigPath returns platform-specific path for claude-desktop on darwin', () => {
   const def = CLIENT_DEFINITIONS.find(c => c.id === 'claude-desktop');
   const result = getClientConfigPath(def, 'darwin');
-  assert.ok(result.includes('Library/Application Support/Claude/claude_desktop_config.json'));
+  assert.ok(fwd(result).includes('Library/Application Support/Claude/claude_desktop_config.json'));
 });
 
 test('getClientConfigPath returns platform-specific path for vscode on linux', () => {
   const def = CLIENT_DEFINITIONS.find(c => c.id === 'vscode');
   const result = getClientConfigPath(def, 'linux');
-  assert.ok(result.includes('.config/Code/User/mcp.json'));
+  assert.ok(fwd(result).includes('.config/Code/User/mcp.json'));
 });
 
 test('getClientConfigPath returns "all" path for cursor', () => {
   const def = CLIENT_DEFINITIONS.find(c => c.id === 'cursor');
   const result = getClientConfigPath(def);
-  assert.ok(result.includes('.cursor/mcp.json'));
+  assert.ok(fwd(result).includes('.cursor/mcp.json'));
 });
 
 test('getClientConfigPath returns null for CLI type', () => {

--- a/npm/kaboom-agentic-browser/lib/extension.js
+++ b/npm/kaboom-agentic-browser/lib/extension.js
@@ -1,0 +1,115 @@
+// Purpose: Resolve where the unpacked browser extension lives and reveal it in
+// the desktop file manager so "Load unpacked" is one selection away.
+// Why: npm bundles the extension inside this package; the curl|sh installer
+// stages it to ~/KaboomAgenticDevtoolExtension. Either way the user must load an
+// EXACT folder, and opening it for them removes the most-missed onboarding step.
+
+'use strict';
+
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+
+// The folder the curl|sh / PowerShell installers stage the extension into.
+const STAGED_DIR_NAME = 'KaboomAgenticDevtoolExtension';
+
+/** True when dir looks like an unpacked extension (has a manifest.json). */
+function isExtensionDir(dir) {
+  try {
+    return !!dir && fs.existsSync(path.join(dir, 'manifest.json'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the extension directory to load, preferring the first candidate that
+ * actually contains a manifest:
+ *   1. $KABOOM_EXTENSION_DIR   — explicit override, honored verbatim
+ *   2. the copy bundled in this npm package (../extension, relative to lib/)
+ *   3. ~/KaboomAgenticDevtoolExtension — staged by the curl|sh installer
+ * When none exist yet, returns the override (if set) or the bundled default so a
+ * concrete path is always shown; `exists` says whether it is actually there.
+ *
+ * @param {object} [env] defaults to process.env — injectable for tests
+ * @param {string} [homeDir] defaults to os.homedir() — injectable for tests
+ * @returns {{dir: string, exists: boolean, source: 'env'|'bundled'|'staged'}}
+ */
+function resolveExtensionDir(env = process.env, homeDir = os.homedir()) {
+  // An explicit override is honored verbatim — the user said "use this path", so
+  // never silently fall through to a different one, even when it is not there yet.
+  const override = String(env.KABOOM_EXTENSION_DIR || '').trim();
+  if (override) {
+    return { dir: override, exists: isExtensionDir(override), source: 'env' };
+  }
+
+  const bundled = path.join(__dirname, '..', 'extension');
+  const staged = path.join(homeDir, STAGED_DIR_NAME);
+  for (const candidate of [{ dir: bundled, source: 'bundled' }, { dir: staged, source: 'staged' }]) {
+    if (isExtensionDir(candidate.dir)) {
+      return { dir: candidate.dir, exists: true, source: candidate.source };
+    }
+  }
+  // Nothing staged yet — still name the bundled location so the user has a path.
+  return { dir: bundled, exists: false, source: 'bundled' };
+}
+
+/** True when the user opted out of the install-time auto-open. */
+function autoOpenDisabled(env = process.env) {
+  for (const key of ['KABOOM_NO_OPEN', 'KABOOM_INSTALL_NO_OPEN']) {
+    const value = String(env[key] || '').trim().toLowerCase();
+    if (value && value !== '0' && value !== 'false' && value !== 'no') return true;
+  }
+  return false;
+}
+
+/**
+ * The command that reveals dir in the platform's file manager, or null when the
+ * platform has none. Pure — the caller runs it.
+ * @returns {{command: string, args: string[]}|null}
+ */
+function revealCommand(platform, dir) {
+  switch (platform) {
+    case 'darwin':
+      return { command: 'open', args: [dir] };
+    case 'win32':
+      return { command: 'explorer', args: [dir] };
+    case 'linux':
+      return { command: 'xdg-open', args: [dir] };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Best-effort: reveal the extension dir in the file manager so Load unpacked is
+ * one selection away. Never throws; returns whether an opener was launched.
+ * @param {string} dir
+ * @param {{platform?: string, env?: object, spawnFn?: Function}} [opts]
+ */
+function openExtensionDir(dir, opts = {}) {
+  const { platform = process.platform, env = process.env, spawnFn = spawn } = opts;
+  if (!dir || autoOpenDisabled(env) || !isExtensionDir(dir)) return false;
+  const spec = revealCommand(platform, dir);
+  if (!spec) return false;
+  try {
+    const child = spawnFn(spec.command, spec.args, { stdio: 'ignore', detached: true });
+    // A missing opener (e.g. no xdg-open) surfaces async — swallow it; the path
+    // is always printed too, so the user still has the fallback.
+    if (child && typeof child.on === 'function') child.on('error', () => {});
+    if (child && typeof child.unref === 'function') child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  STAGED_DIR_NAME,
+  isExtensionDir,
+  resolveExtensionDir,
+  autoOpenDisabled,
+  revealCommand,
+  openExtensionDir,
+};

--- a/npm/kaboom-agentic-browser/lib/extension.test.js
+++ b/npm/kaboom-agentic-browser/lib/extension.test.js
@@ -1,0 +1,101 @@
+// Tests for lib/extension.js — resolving the extension folder and revealing it.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const {
+  STAGED_DIR_NAME,
+  isExtensionDir,
+  resolveExtensionDir,
+  autoOpenDisabled,
+  revealCommand,
+  openExtensionDir,
+} = require('./extension');
+
+function makeExtensionDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-ext-'));
+  fs.writeFileSync(path.join(dir, 'manifest.json'), '{"manifest_version":3}');
+  return dir;
+}
+
+test('isExtensionDir requires a manifest.json', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-noext-'));
+  assert.equal(isExtensionDir(dir), false);
+  fs.writeFileSync(path.join(dir, 'manifest.json'), '{}');
+  assert.equal(isExtensionDir(dir), true);
+  assert.equal(isExtensionDir(''), false);
+});
+
+test('resolveExtensionDir honors $KABOOM_EXTENSION_DIR when it has a manifest', () => {
+  const dir = makeExtensionDir();
+  const res = resolveExtensionDir({ KABOOM_EXTENSION_DIR: dir });
+  assert.deepEqual(res, { dir, exists: true, source: 'env' });
+});
+
+test('resolveExtensionDir still returns the override path when it is not there yet', () => {
+  // The path must be shown even before staging, so the user knows where to look.
+  const res = resolveExtensionDir({ KABOOM_EXTENSION_DIR: '/does/not/exist/kaboom' });
+  assert.equal(res.dir, '/does/not/exist/kaboom');
+  assert.equal(res.exists, false);
+  assert.equal(res.source, 'env');
+});
+
+test('resolveExtensionDir falls back to the bundled path with exists=false when nothing is staged', () => {
+  // In the source tree the extension is copied in at build time, so no candidate
+  // exists — the resolver must still name the bundled location, not throw. Inject
+  // an empty home so a real ~/KaboomAgenticDevtoolExtension can't shadow the test.
+  const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-home-'));
+  const res = resolveExtensionDir({}, emptyHome);
+  assert.equal(res.source, 'bundled');
+  assert.equal(res.exists, false);
+  assert.ok(res.dir.endsWith('extension'));
+});
+
+test('staged fallback name matches the installer contract', () => {
+  assert.equal(STAGED_DIR_NAME, 'KaboomAgenticDevtoolExtension');
+});
+
+test('autoOpenDisabled respects opt-out env vars', () => {
+  assert.equal(autoOpenDisabled({}), false);
+  assert.equal(autoOpenDisabled({ KABOOM_NO_OPEN: '1' }), true);
+  assert.equal(autoOpenDisabled({ KABOOM_INSTALL_NO_OPEN: 'true' }), true);
+  assert.equal(autoOpenDisabled({ KABOOM_NO_OPEN: '0' }), false);
+  assert.equal(autoOpenDisabled({ KABOOM_NO_OPEN: 'false' }), false);
+  assert.equal(autoOpenDisabled({ KABOOM_NO_OPEN: '' }), false);
+});
+
+test('revealCommand maps each platform to its file manager, null otherwise', () => {
+  assert.deepEqual(revealCommand('darwin', '/x'), { command: 'open', args: ['/x'] });
+  assert.deepEqual(revealCommand('win32', 'C:/x'), { command: 'explorer', args: ['C:/x'] });
+  assert.deepEqual(revealCommand('linux', '/x'), { command: 'xdg-open', args: ['/x'] });
+  assert.equal(revealCommand('sunos', '/x'), null);
+});
+
+test('openExtensionDir launches the right opener and is guardable', () => {
+  const dir = makeExtensionDir();
+  const calls = [];
+  const spawnFn = (command, args) => {
+    calls.push({ command, args });
+    return { on() {}, unref() {} };
+  };
+
+  // Happy path: existing extension dir, opt-in → launches the platform opener.
+  assert.equal(openExtensionDir(dir, { platform: 'darwin', env: {}, spawnFn }), true);
+  assert.deepEqual(calls[0], { command: 'open', args: [dir] });
+
+  // Opt-out env → never launches.
+  assert.equal(openExtensionDir(dir, { platform: 'darwin', env: { KABOOM_NO_OPEN: '1' }, spawnFn }), false);
+
+  // Missing directory → never launches.
+  assert.equal(openExtensionDir('/no/such/dir', { platform: 'darwin', env: {}, spawnFn }), false);
+
+  // Unknown platform → never launches.
+  assert.equal(openExtensionDir(dir, { platform: 'sunos', env: {}, spawnFn }), false);
+
+  assert.equal(calls.length, 1, 'only the happy path should have spawned');
+});

--- a/npm/kaboom-agentic-browser/lib/install.js
+++ b/npm/kaboom-agentic-browser/lib/install.js
@@ -20,6 +20,7 @@ const {
   writeConfigFile,
   resolveManagedBinaryPath,
 } = require('./config');
+const { resolveExtensionDir } = require('./extension');
 
 const LEGACY_INSTALL_SERVER_NAMES = [
   ...LEGACY_MCP_SERVER_NAMES,
@@ -273,6 +274,14 @@ function executeInstall(options = {}) {
   }
 
   result.success = result.installed.length > 0;
+
+  // Tell the user the EXACT folder to load as an unpacked extension. The browser
+  // step is the one part the installer cannot do, so surfacing the precise path
+  // (and whether it is present yet) is what makes onboarding self-serve.
+  const ext = resolveExtensionDir();
+  result.extensionDir = ext.dir;
+  result.extensionExists = ext.exists;
+
   return result;
 }
 

--- a/npm/kaboom-agentic-browser/lib/output.js
+++ b/npm/kaboom-agentic-browser/lib/output.js
@@ -94,6 +94,20 @@ function installResult(result) {
     output += `\nℹ️  Not configured in: ${result.notFound.join(', ')}\n`;
   }
 
+  // The browser extension is the one step the installer cannot click for the
+  // user, so give them the EXACT folder to load — not a vague "the extension".
+  if (result.extensionDir) {
+    output += '\n🧩 LOAD THE BROWSER EXTENSION (one-time):\n';
+    output += '   1) Open  chrome://extensions  (or brave://extensions, edge://extensions)\n';
+    output += '   2) Turn on "Developer mode" (top-right toggle)\n';
+    output += '   3) Click "Load unpacked" and select this exact folder:\n\n';
+    output += `        ${result.extensionDir}\n\n`;
+    if (result.extensionExists === false) {
+      output += '   ⚠️  That folder is not present yet — reinstall, or set KABOOM_EXTENSION_DIR to the\n';
+      output += '       unpacked extension you want to load.\n';
+    }
+  }
+
   return output;
 }
 

--- a/scripts/run-npm-wrapper-tests.js
+++ b/scripts/run-npm-wrapper-tests.js
@@ -1,0 +1,25 @@
+// run-npm-wrapper-tests.js — Run every npm wrapper lib/*.test.js on any OS.
+// Why: CI runs Node 20 (no `node --test` glob) across bash AND PowerShell (which
+// does not expand `*.test.js`). Discovering the files here and passing them as
+// explicit args makes the wrapper tests gate identically on every runner.
+
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const libDir = path.join(here, '..', 'npm', 'kaboom-agentic-browser', 'lib')
+
+const files = readdirSync(libDir)
+  .filter((name) => name.endsWith('.test.js'))
+  .sort()
+  .map((name) => path.join(libDir, name))
+
+if (files.length === 0) {
+  console.error(`No *.test.js files found in ${libDir}`)
+  process.exit(1)
+}
+
+const result = spawnSync(process.execPath, ['--test', ...files], { stdio: 'inherit' })
+process.exit(result.status ?? 1)


### PR DESCRIPTION
Loading the unpacked extension is the one install step the tooling can't click for the user — and it was under-served. This makes it self-serve on both distribution channels.

## The gap
- **npm** (`kaboom-agentic-browser --install`): printed configured MCP clients + binary path, but **no extension guidance at all** — users had to guess where the extension lived.
- **curl|sh** (`--install` → Go): printed the path, but never opened the folder.

## What changed
**npm channel** — new `lib/extension.js`:
- `resolveExtensionDir()` — `$KABOOM_EXTENSION_DIR` (honored verbatim) → the copy **bundled in the package** → `~/KaboomAgenticDevtoolExtension`, reporting whether it's present yet.
- `revealCommand()` / `openExtensionDir()` — reveal the folder in the platform file manager (`open` / `explorer` / `xdg-open`), opt-out via `KABOOM_NO_OPEN`.
- `install.js` puts the resolved dir on the result; `output.js` prints a **"LOAD THE BROWSER EXTENSION"** block with the **exact absolute path** + `chrome://extensions` steps; `cli.js` opens the folder after installing.

**curl|sh channel** — `native_install.go` auto-opens the staged folder after the checklist (same openers + `KABOOM_NO_OPEN` opt-out).

Fail-safe by design: the exact path is **always printed**, so a missing opener / headless / opt-out loses nothing.

## Tests
- `lib/extension.test.js` — resolve priority, opt-out matrix, reveal-command mapping, guarded open (8 cases).
- `native_install_open_test.go` — platform mapping, opt-out, guards.
- Wired the previously-**orphaned** npm wrapper tests into CI + Makefile (`node --test .../lib/*.test.js` — 102 tests); only `kill-daemon.test.js` had been running.

## Validation
102/102 npm wrapper tests · Go native_install tests · lint · go vet · gofmt · `go build ./...` · docs:check:strict — all pass.

### Sample npm output
```
🧩 LOAD THE BROWSER EXTENSION (one-time):
   1) Open  chrome://extensions  (or brave://extensions, edge://extensions)
   2) Turn on "Developer mode" (top-right toggle)
   3) Click "Load unpacked" and select this exact folder:

        <global>/node_modules/kaboom-agentic-browser/extension
```
📂 …and the folder opens automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
