### PR TITLE
feat(install): connect confirmation loop + browser-aware page open + live --doctor

### DIFF
--- a/cmd/browser-agent/native_install.go
+++ b/cmd/browser-agent/native_install.go
@@ -76,16 +76,23 @@ func fileManagerOpenCommand(goos, dir string) (name string, args []string, ok bo
 	}
 }
 
-// extensionAutoOpenDisabled reports whether the user opted out of the
-// install-time folder auto-open (headless installs, CI, scripted runs).
-func extensionAutoOpenDisabled() bool {
-	for _, key := range []string{"KABOOM_NO_OPEN", "KABOOM_INSTALL_NO_OPEN"} {
+// envFlagEnabled reports whether any of the named env vars is set to a truthy
+// opt-in value. Unset/empty/"0"/"false"/"no" all count as off. Shared source of
+// truth for the install-time opt-outs so their accepted values never drift.
+func envFlagEnabled(keys ...string) bool {
+	for _, key := range keys {
 		v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
 		if v != "" && v != "0" && v != "false" && v != "no" {
 			return true
 		}
 	}
 	return false
+}
+
+// extensionAutoOpenDisabled reports whether the user opted out of the
+// install-time folder auto-open (headless installs, CI, scripted runs).
+func extensionAutoOpenDisabled() bool {
+	return envFlagEnabled("KABOOM_NO_OPEN", "KABOOM_INSTALL_NO_OPEN")
 }
 
 // openExtensionFolder best-effort reveals extDir in the file manager so Load
@@ -243,6 +250,8 @@ func runNativeInstall() {
 	if openExtensionFolder(extDir) {
 		stderrf("   \033[1;32m📂 Opened the extension folder for you — select it in Load unpacked.\033[0m\n")
 	}
+	// Confirm the extension actually connects to the daemon we just started.
+	runExtensionConnectWait(7890, extDir)
 	stderrf("\033[1;33mREADY TO COOK:\033[0m\n")
 	stderrf("   The Kaboom server is active on port 7890.\n")
 	stderrf("   Your AI tool (Claude, Cursor, etc.) is now configured.\n")

--- a/cmd/browser-agent/native_install_connect.go
+++ b/cmd/browser-agent/native_install_connect.go
@@ -1,0 +1,172 @@
+// native_install_connect.go — Post-install "did the extension connect?" loop.
+// After the installer starts the daemon, poll /health until the browser
+// extension connects, showing live status and a targeted hint on timeout. The
+// loop's clock, fetch, and output sink are injected so it is unit-testable
+// without a real daemon or real time.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	connectWaitTimeout = 30 * time.Second
+	connectPollEvery   = 750 * time.Millisecond
+	connectHealthRead  = 800 * time.Millisecond
+)
+
+// installHealth is the slice of /health the connect loop cares about.
+type installHealth struct {
+	reachable          bool
+	extensionConnected bool
+	version            string
+}
+
+// connectPhase classifies a health snapshot into a connect phase.
+func connectPhase(h installHealth) string {
+	if h.extensionConnected {
+		return "connected"
+	}
+	if h.reachable {
+		return "waiting_extension"
+	}
+	return "daemon_unreachable"
+}
+
+// connectProgressLine is the one-time line shown when the loop enters a phase,
+// or "" for phases that need no narration (connected has its own final line).
+func connectProgressLine(phase string) string {
+	switch phase {
+	case "daemon_unreachable":
+		return "   … waiting for the Kaboom server to come up"
+	case "waiting_extension":
+		return "   … server is up — load the extension in your browser to finish"
+	default:
+		return ""
+	}
+}
+
+// connectHintLine is the targeted next step when the loop times out. Pure.
+func connectHintLine(lastPhase string, port int, extDir string) string {
+	if lastPhase == "waiting_extension" {
+		return fmt.Sprintf(
+			"The Kaboom server is running on port %d, but the extension has not connected yet.\n"+
+				"   Open chrome://extensions, enable Developer mode, click Load unpacked, and select:\n   %s",
+			port, extDir)
+	}
+	return fmt.Sprintf(
+		"The Kaboom server is not answering on port %d yet.\n"+
+			"   Re-run the installer, or start Kaboom manually, then load the extension.",
+		port)
+}
+
+// connectWaitDeps are the injectable seams for waitForExtensionConnected.
+type connectWaitDeps struct {
+	fetch func(port int) installHealth
+	now   func() time.Time
+	sleep func(time.Duration)
+	sink  func(string) // progress narration; nil to stay silent
+}
+
+type connectResult struct {
+	connected bool
+	lastPhase string
+}
+
+// waitForExtensionConnected polls until the extension connects or the deadline
+// passes, narrating each new phase exactly once via deps.sink.
+func waitForExtensionConnected(port int, timeout, poll time.Duration, deps connectWaitDeps) connectResult {
+	start := deps.now()
+	rendered := ""
+	for {
+		phase := connectPhase(deps.fetch(port))
+		if phase != rendered {
+			rendered = phase
+			if deps.sink != nil {
+				if line := connectProgressLine(phase); line != "" {
+					deps.sink(line)
+				}
+			}
+		}
+		if phase == "connected" {
+			return connectResult{connected: true, lastPhase: phase}
+		}
+		if deps.now().Sub(start) >= timeout {
+			return connectResult{connected: false, lastPhase: phase}
+		}
+		deps.sleep(poll)
+	}
+}
+
+// fetchInstallHealth reads /health once. Never errors — an unreachable daemon
+// yields reachable=false; a non-200 or unparseable body counts as reachable.
+func fetchInstallHealth(port int, timeout time.Duration) installHealth {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		return installHealth{}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return installHealth{reachable: true}
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return installHealth{reachable: true}
+	}
+	var parsed struct {
+		Version string `json:"version"`
+		Capture struct {
+			ExtensionConnected bool `json:"extension_connected"`
+		} `json:"capture"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return installHealth{reachable: true}
+	}
+	return installHealth{reachable: true, extensionConnected: parsed.Capture.ExtensionConnected, version: parsed.Version}
+}
+
+// installWaitDisabled reports whether the user opted out of the connect wait.
+func installWaitDisabled() bool {
+	return envFlagEnabled("KABOOM_NO_WAIT", "KABOOM_INSTALL_NO_WAIT")
+}
+
+// isTerminal reports whether f is an interactive terminal (stdlib only, so the
+// zero-deps rule holds). Used to skip the blocking wait for piped/CI installs.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// runExtensionConnectWait runs the connect loop against the real daemon and
+// prints progress + outcome. Skipped for opted-out or non-interactive installs
+// (the daemon is already running either way).
+func runExtensionConnectWait(port int, extDir string) {
+	if installWaitDisabled() || !isTerminal(os.Stderr) {
+		return
+	}
+	stderrf("\n\033[1;33m⏳ Waiting for the browser extension to connect (Ctrl-C to skip)…\033[0m\n")
+	res := waitForExtensionConnected(port, connectWaitTimeout, connectPollEvery, connectWaitDeps{
+		fetch: func(p int) installHealth { return fetchInstallHealth(p, connectHealthRead) },
+		now:   time.Now,
+		sleep: time.Sleep,
+		sink:  func(line string) { stderrf("%s\n", line) },
+	})
+	if res.connected {
+		stderrf("\033[1;32m✅ Extension connected — Kaboom is fully wired up!\033[0m\n")
+	} else {
+		stderrf("\033[1;33m⚠️  %s\033[0m\n", connectHintLine(res.lastPhase, port, extDir))
+	}
+}

--- a/cmd/browser-agent/native_install_connect_test.go
+++ b/cmd/browser-agent/native_install_connect_test.go
@@ -1,0 +1,147 @@
+// native_install_connect_test.go — Tests for the post-install extension connect loop.
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConnectPhase(t *testing.T) {
+	cases := []struct {
+		h    installHealth
+		want string
+	}{
+		{installHealth{}, "daemon_unreachable"},
+		{installHealth{reachable: true}, "waiting_extension"},
+		{installHealth{reachable: true, extensionConnected: true}, "connected"},
+	}
+	for _, tc := range cases {
+		if got := connectPhase(tc.h); got != tc.want {
+			t.Fatalf("connectPhase(%+v) = %q, want %q", tc.h, got, tc.want)
+		}
+	}
+}
+
+// fakeClock advances virtual time on every sleep so the loop terminates without
+// real timers.
+func fakeClock() (func() time.Time, func(time.Duration)) {
+	t := time.Unix(0, 0)
+	now := func() time.Time { return t }
+	sleep := func(d time.Duration) { t = t.Add(d) }
+	return now, sleep
+}
+
+func TestWaitForExtensionConnected_ConnectsAfterPolls(t *testing.T) {
+	now, sleep := fakeClock()
+	// unreachable → up-but-waiting → connected
+	seq := []installHealth{
+		{},
+		{reachable: true},
+		{reachable: true, extensionConnected: true},
+	}
+	i := 0
+	var lines []string
+	res := waitForExtensionConnected(7890, 30*time.Second, 750*time.Millisecond, connectWaitDeps{
+		fetch: func(int) installHealth {
+			h := seq[i]
+			if i < len(seq)-1 {
+				i++
+			}
+			return h
+		},
+		now:   now,
+		sleep: sleep,
+		sink:  func(s string) { lines = append(lines, s) },
+	})
+	if !res.connected {
+		t.Fatalf("expected connected, got %+v", res)
+	}
+	// Only the two non-connected phases narrate, each once.
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 progress lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "server to come up") || !strings.Contains(lines[1], "load the extension") {
+		t.Fatalf("unexpected progress lines: %v", lines)
+	}
+}
+
+func TestWaitForExtensionConnected_Timeout(t *testing.T) {
+	now, sleep := fakeClock()
+	res := waitForExtensionConnected(7890, 2*time.Second, 750*time.Millisecond, connectWaitDeps{
+		fetch: func(int) installHealth { return installHealth{reachable: true} },
+		now:   now,
+		sleep: sleep,
+	})
+	if res.connected {
+		t.Fatal("expected timeout, got connected")
+	}
+	if res.lastPhase != "waiting_extension" {
+		t.Fatalf("lastPhase = %q, want waiting_extension", res.lastPhase)
+	}
+}
+
+func TestWaitForExtensionConnected_TimeoutUnreachable(t *testing.T) {
+	now, sleep := fakeClock()
+	res := waitForExtensionConnected(7890, 1500*time.Millisecond, 750*time.Millisecond, connectWaitDeps{
+		fetch: func(int) installHealth { return installHealth{} },
+		now:   now,
+		sleep: sleep,
+	})
+	if res.connected || res.lastPhase != "daemon_unreachable" {
+		t.Fatalf("expected unreachable timeout, got %+v", res)
+	}
+}
+
+func TestConnectHintLine(t *testing.T) {
+	waiting := connectHintLine("waiting_extension", 7890, "/x/ext")
+	unreachable := connectHintLine("daemon_unreachable", 7890, "/x/ext")
+	if waiting == unreachable {
+		t.Fatal("hints for the two phases must differ")
+	}
+	if !strings.Contains(waiting, "/x/ext") {
+		t.Fatalf("waiting hint must name the extension folder: %q", waiting)
+	}
+	if !strings.Contains(unreachable, "7890") {
+		t.Fatalf("unreachable hint must name the port: %q", unreachable)
+	}
+}
+
+func TestInstallWaitDisabled(t *testing.T) {
+	cases := []struct {
+		key  string
+		val  string
+		want bool
+	}{
+		{"", "", false},
+		{"KABOOM_NO_WAIT", "1", true},
+		{"KABOOM_INSTALL_NO_WAIT", "true", true},
+		{"KABOOM_NO_WAIT", "0", false},
+		{"KABOOM_NO_WAIT", "false", false},
+	}
+	for _, tc := range cases {
+		t.Setenv("KABOOM_NO_WAIT", "")
+		t.Setenv("KABOOM_INSTALL_NO_WAIT", "")
+		if tc.key != "" {
+			t.Setenv(tc.key, tc.val)
+		}
+		if got := installWaitDisabled(); got != tc.want {
+			t.Fatalf("installWaitDisabled(%s=%q) = %v, want %v", tc.key, tc.val, got, tc.want)
+		}
+	}
+}
+
+func TestIsTerminal_PipeIsNotATerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = r.Close(); _ = w.Close() }()
+	if isTerminal(r) {
+		t.Fatal("a pipe must not be reported as a terminal")
+	}
+	if isTerminal(nil) {
+		t.Fatal("nil must not be reported as a terminal")
+	}
+}

--- a/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
+++ b/docs/architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
@@ -2,7 +2,7 @@
 doc_type: flow_map
 flow_id: installer-binary-path-and-manual-extension-handoff
 status: active
-last_reviewed: 2026-03-28
+last_reviewed: 2026-07-24
 owners:
   - Brenn
 entrypoints:
@@ -10,7 +10,9 @@ entrypoints:
   - scripts/install.ps1
   - scripts/build-crx.js
   - cmd/browser-agent/native_install.go:runNativeInstall
+  - cmd/browser-agent/native_install_connect.go:runExtensionConnectWait
   - npm/kaboom-agentic-browser/lib/install.js:executeInstall
+  - npm/kaboom-agentic-browser/lib/cli.js:watchExtensionConnect
   - pypi/kaboom-agentic-browser/kaboom_agentic_browser/platform.py:run_install
 code_paths:
   - Makefile
@@ -19,16 +21,27 @@ code_paths:
   - scripts/install.ps1
   - server/scripts/install.js
   - cmd/browser-agent/native_install.go
+  - cmd/browser-agent/native_install_connect.go
   - npm/kaboom-agentic-browser/lib/config.js
   - npm/kaboom-agentic-browser/lib/install.js
+  - npm/kaboom-agentic-browser/lib/cli.js
+  - npm/kaboom-agentic-browser/lib/health.js
+  - npm/kaboom-agentic-browser/lib/daemon.js
+  - npm/kaboom-agentic-browser/lib/browser.js
+  - npm/kaboom-agentic-browser/lib/doctor.js
   - npm/kaboom-agentic-browser/lib/uninstall.js
   - pypi/kaboom-agentic-browser/kaboom_agentic_browser/install.py
   - pypi/kaboom-agentic-browser/kaboom_agentic_browser/platform.py
   - docs/mcp-install-guide.md
 test_paths:
   - cmd/browser-agent/native_install_test.go
+  - cmd/browser-agent/native_install_connect_test.go
   - npm/kaboom-agentic-browser/lib/config.test.js
   - npm/kaboom-agentic-browser/lib/install.test.js
+  - npm/kaboom-agentic-browser/lib/health.test.js
+  - npm/kaboom-agentic-browser/lib/daemon.test.js
+  - npm/kaboom-agentic-browser/lib/browser.test.js
+  - npm/kaboom-agentic-browser/lib/doctor.test.js
   - npm/kaboom-agentic-browser/lib/uninstall.test.js
   - pypi/kaboom-agentic-browser/tests/test_install.py
   - tests/extension/release-extension-zip.test.js
@@ -73,6 +86,9 @@ Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper t
    - pin extension
    - click Track This Tab
 10. Installer surfaces a branded panel-style summary at completion with the resolved binary path.
+11. Installer reveals the exact extension folder (`openExtensionFolder` / `openExtensionDir`) and opens the detected Chromium-family browser straight to its extensions page (`detectExtensionsTarget` → `openExtensionsPage`, browser-internal schemes `chrome://`/`brave://`/`edge://`).
+12. Installer ensures a daemon is running so the extension has something to connect to: the native installer starts it via `startDaemonSilently`; npm `--install` starts it via `ensureDaemon`/`startDaemon` (reusing an already-healthy daemon on the port instead of double-binding).
+13. Installer polls `/health` (`capture.extension_connected`) and shows a live connect loop (`waitForExtensionConnected` / `watchExtensionConnect`), printing a success line on connect or a phase-specific hint (`connectHintLine` / `connectHint`) on timeout. The wait is skipped — daemon still started — when opted out (`KABOOM_NO_WAIT`/`KABOOM_NO_DAEMON`) or when the output is non-interactive (piped/CI). `--connect` re-runs this loop on demand; `--doctor` reports the same daemon/extension/Node status non-blocking.
 
 ## Error and Recovery Paths
 
@@ -94,6 +110,9 @@ Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper t
 6. In strict mode, checksum verification is mandatory for release binary downloads.
 7. Existing-daemon reuse on port checks requires service identity and version parity.
 8. Extension unpacked path defaults to `~/KaboomAgenticDevtoolExtension` (overridable with `KABOOM_EXTENSION_DIR`).
+9. The connect loop reads only existing `/health` fields (`version`, `capture.extension_connected`); it is a consumer and adds no new wire fields.
+10. Install-time opt-outs share one accepted-value grammar (`isEnvFlagSet` in JS, `envFlagEnabled` in Go): unset/empty/`0`/`false`/`no` are off. Auto-open uses `KABOOM_NO_OPEN`/`KABOOM_INSTALL_NO_OPEN`; connect-wait uses `KABOOM_NO_WAIT`/`KABOOM_INSTALL_NO_WAIT`; daemon-start uses `KABOOM_NO_DAEMON`.
+11. The connect loop's clock, `/health` fetch, and output sink are injectable so the loop is deterministic under test (no real timers or daemon).
 
 ## Code Paths
 
@@ -103,8 +122,14 @@ Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper t
 - `scripts/install.ps1`
 - `server/scripts/install.js`
 - `cmd/browser-agent/native_install.go`
+- `cmd/browser-agent/native_install_connect.go`
 - `npm/kaboom-agentic-browser/lib/config.js`
 - `npm/kaboom-agentic-browser/lib/install.js`
+- `npm/kaboom-agentic-browser/lib/cli.js`
+- `npm/kaboom-agentic-browser/lib/health.js`
+- `npm/kaboom-agentic-browser/lib/daemon.js`
+- `npm/kaboom-agentic-browser/lib/browser.js`
+- `npm/kaboom-agentic-browser/lib/doctor.js`
 - `npm/kaboom-agentic-browser/lib/uninstall.js`
 - `pypi/kaboom-agentic-browser/kaboom_agentic_browser/install.py`
 - `pypi/kaboom-agentic-browser/kaboom_agentic_browser/platform.py`
@@ -113,8 +138,13 @@ Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper t
 ## Test Paths
 
 - `cmd/browser-agent/native_install_test.go`
+- `cmd/browser-agent/native_install_connect_test.go`
 - `npm/kaboom-agentic-browser/lib/config.test.js`
 - `npm/kaboom-agentic-browser/lib/install.test.js`
+- `npm/kaboom-agentic-browser/lib/health.test.js`
+- `npm/kaboom-agentic-browser/lib/daemon.test.js`
+- `npm/kaboom-agentic-browser/lib/browser.test.js`
+- `npm/kaboom-agentic-browser/lib/doctor.test.js`
 - `npm/kaboom-agentic-browser/lib/uninstall.test.js`
 - `pypi/kaboom-agentic-browser/tests/test_install.py`
 - `tests/extension/release-extension-zip.test.js`
@@ -131,3 +161,7 @@ Covers installer behavior for shell, PowerShell, npm wrapper, and PyPI wrapper t
 2. Do not regress to `npx`-only config entries for managed installs.
 3. Do not reintroduce allowlist-based packaging in extension zip or CRX fallback flows.
 4. Preserve manual-extension wording in installer output to avoid user confusion.
+5. The connect loop must stay a `/health` consumer — never add wire fields here; changes to the health payload belong to the health flow map and its `wire_*` types.
+6. Keep the connect loop's clock/fetch/sink injectable; do not call real timers or `http` directly inside the loop body.
+7. The blocking connect-wait must remain skippable and auto-skip for non-interactive installs so CI/piped installs never hang.
+8. Keep install-time opt-out grammar centralized (`isEnvFlagSet`/`envFlagEnabled`); do not hand-roll new env parsing.

--- a/docs/features/feature/enhanced-cli-config/flow-map.md
+++ b/docs/features/feature/enhanced-cli-config/flow-map.md
@@ -1,7 +1,7 @@
 ---
 doc_type: flow_map_pointer
 status: active
-last_reviewed: 2026-07-05
+last_reviewed: 2026-07-24
 canonical_flow_map: ../../../architecture/flow-maps/installer-binary-path-and-manual-extension-handoff.md
 ---
 
@@ -24,3 +24,7 @@ Notable coverage:
 - CRX fallback packaging in `scripts/build-crx.js` archives the full `extension/` directory to prevent missing MV3 module imports.
 - Startup integrity regression checks assert manifest file paths and service worker import graph resolve before release.
 - One-liner uninstallers (`scripts/uninstall.sh`, `scripts/uninstall.ps1`) reverse every install artifact: binaries/state, extension dir, autostart registrations, `# kaboom` PATH lines, MCP client entries (canonical + legacy keys, in-place JSON edits with backups), and marker-managed agent skills. Behavioral coverage in `tests/cli/uninstall-script.test.cjs`.
+- Post-install connect confirmation: both channels start the daemon (native via `startDaemonSilently`; npm `--install` via `ensureDaemon`/`startDaemon`, reusing a healthy daemon rather than double-binding) and poll `/health` (`capture.extension_connected`) in a live loop (`waitForExtensionConnected` in Go, `watchExtensionConnect` in `lib/cli.js`), printing a success line or a phase-specific hint on timeout. Skippable and auto-skipped for non-interactive installs.
+- Browser-aware extension handoff: `lib/browser.js` detects the first installed Chromium-family browser (Chrome/Brave/Edge/Arc/Chromium) and opens its extensions page directly (`chrome://`/`brave://`/`edge://extensions`), alongside revealing the exact unpacked-extension folder.
+- `--connect` re-runs the connect loop on demand; `--doctor` now performs live diagnosis (Node floor, daemon reachability, extension connectivity via `/health`) in addition to config checks — see `lib/health.js`, `lib/daemon.js`, `lib/doctor.js`.
+- Install-time opt-outs share one grammar (`isEnvFlagSet`/`envFlagEnabled`): `KABOOM_NO_OPEN`/`KABOOM_INSTALL_NO_OPEN` (auto-open), `KABOOM_NO_WAIT`/`KABOOM_INSTALL_NO_WAIT` (connect-wait), `KABOOM_NO_DAEMON` (daemon-start).

--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -9,7 +9,11 @@ code_paths:
   - Makefile
   - scripts/build-crx.js
   - cmd/browser-agent/native_install.go
+  - cmd/browser-agent/native_install_connect.go
   - npm/kaboom-agentic-browser/lib/extension.js
+  - npm/kaboom-agentic-browser/lib/browser.js
+  - npm/kaboom-agentic-browser/lib/health.js
+  - npm/kaboom-agentic-browser/lib/daemon.js
   - npm/kaboom-agentic-browser/lib/output.js
   - scripts/install.sh
   - scripts/install.ps1
@@ -26,8 +30,13 @@ code_paths:
 test_paths:
   - cmd/browser-agent/native_install_test.go
   - cmd/browser-agent/native_install_open_test.go
+  - cmd/browser-agent/native_install_connect_test.go
   - npm/kaboom-agentic-browser/lib/config.test.js
   - npm/kaboom-agentic-browser/lib/extension.test.js
+  - npm/kaboom-agentic-browser/lib/browser.test.js
+  - npm/kaboom-agentic-browser/lib/health.test.js
+  - npm/kaboom-agentic-browser/lib/daemon.test.js
+  - npm/kaboom-agentic-browser/lib/doctor.test.js
   - npm/kaboom-agentic-browser/lib/install.test.js
   - npm/kaboom-agentic-browser/lib/uninstall.test.js
   - tests/packaging/kaboom-packaging-branding.test.js

--- a/npm/kaboom-agentic-browser/bin/kaboom-agentic-browser
+++ b/npm/kaboom-agentic-browser/bin/kaboom-agentic-browser
@@ -72,7 +72,7 @@ function findBinary(info) {
 // --- CLI flag detection ---
 
 function isCliCommand(args) {
-  const cliFlags = new Set(['--config', '-c', '--install', '-i', '--update', '--doctor', '--uninstall', '--help', '-h', '--version', '-v'])
+  const cliFlags = new Set(['--config', '-c', '--install', '-i', '--update', '--doctor', '--connect', '--uninstall', '--help', '-h', '--version', '-v'])
   return args.some(arg => cliFlags.has(arg))
 }
 

--- a/npm/kaboom-agentic-browser/lib/browser.js
+++ b/npm/kaboom-agentic-browser/lib/browser.js
@@ -1,0 +1,167 @@
+// Purpose: Detect an installed Chromium-family browser and open its extensions
+// page, so the last install step ("Load unpacked") is one click away.
+// Why: The extensions page uses a browser-internal scheme (chrome://, edge://…)
+// that the OS file opener cannot handle — only the browser binary can open it.
+// Detecting which browser is present lets us launch the right page directly.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+'use strict';
+
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+const { autoOpenDisabled } = require('./extension');
+const { commandExistsOnPath } = require('./config');
+
+// Ordered by preference. `scheme` is the browser-internal URL scheme for its
+// extensions page. darwinApp is the .app bundle name; linuxBins are PATH names;
+// winPaths are segment arrays joined onto each base dir (kept as segments so
+// path.join builds a valid path on any host, e.g. for tests).
+const KNOWN_BROWSERS = [
+  {
+    id: 'chrome', name: 'Google Chrome', scheme: 'chrome',
+    darwinApp: 'Google Chrome',
+    linuxBins: ['google-chrome', 'google-chrome-stable'],
+    winPaths: [['Google', 'Chrome', 'Application', 'chrome.exe']],
+  },
+  {
+    id: 'brave', name: 'Brave', scheme: 'brave',
+    darwinApp: 'Brave Browser',
+    linuxBins: ['brave-browser', 'brave'],
+    winPaths: [['BraveSoftware', 'Brave-Browser', 'Application', 'brave.exe']],
+  },
+  {
+    id: 'edge', name: 'Microsoft Edge', scheme: 'edge',
+    darwinApp: 'Microsoft Edge',
+    linuxBins: ['microsoft-edge', 'microsoft-edge-stable'],
+    winPaths: [['Microsoft', 'Edge', 'Application', 'msedge.exe']],
+  },
+  {
+    id: 'arc', name: 'Arc', scheme: 'chrome',
+    darwinApp: 'Arc',
+    linuxBins: [],
+    winPaths: [],
+  },
+  {
+    id: 'chromium', name: 'Chromium', scheme: 'chrome',
+    darwinApp: 'Chromium',
+    linuxBins: ['chromium', 'chromium-browser'],
+    winPaths: [['Chromium', 'Application', 'chrome.exe']],
+  },
+];
+
+/** The extensions-page URL for a browser scheme. */
+function extensionsUrl(scheme) {
+  return `${scheme}://extensions/`;
+}
+
+/** macOS: is `${appName}.app` present in a standard Applications folder? */
+function defaultHasApp(appName) {
+  for (const base of ['/Applications', path.join(os.homedir(), 'Applications')]) {
+    try {
+      if (fs.existsSync(path.join(base, `${appName}.app`))) return true;
+    } catch {
+      // Unreadable base dir — treat as absent.
+    }
+  }
+  return false;
+}
+
+function defaultFileExists(p) {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/** Windows base dirs where browsers install, in priority order. */
+function winBaseDirs(env) {
+  const dirs = [];
+  for (const key of ['ProgramFiles', 'ProgramFiles(x86)', 'LOCALAPPDATA']) {
+    const value = env[key];
+    if (value && String(value).trim()) dirs.push(String(value));
+  }
+  return dirs;
+}
+
+function firstWinExe(browser, env, fileExists) {
+  for (const base of winBaseDirs(env)) {
+    for (const segments of browser.winPaths || []) {
+      const full = path.join(base, ...segments);
+      if (fileExists(full)) return full;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the first installed Chromium-family browser and how to open its
+ * extensions page. Pure given its injected detectors.
+ *
+ * @param {Object} [deps]
+ * @param {string} [deps.platform]  process.platform
+ * @param {Object} [deps.env]       process.env (Windows path lookup)
+ * @param {(appName: string) => boolean} [deps.hasApp]      macOS
+ * @param {(cmd: string) => boolean} [deps.onPath]          Linux
+ * @param {(absPath: string) => boolean} [deps.fileExists]  Windows
+ * @returns {{id: string, name: string, url: string,
+ *   launch: {command: string, args: string[]}}|null}
+ */
+function detectExtensionsTarget(deps = {}) {
+  const platform = deps.platform || process.platform;
+  const env = deps.env || process.env;
+  const hasApp = deps.hasApp || defaultHasApp;
+  const onPath = deps.onPath || commandExistsOnPath;
+  const fileExists = deps.fileExists || defaultFileExists;
+
+  for (const browser of KNOWN_BROWSERS) {
+    const url = extensionsUrl(browser.scheme);
+
+    if (platform === 'darwin') {
+      if (browser.darwinApp && hasApp(browser.darwinApp)) {
+        return { id: browser.id, name: browser.name, url, launch: { command: 'open', args: ['-a', browser.darwinApp, url] } };
+      }
+    } else if (platform === 'linux') {
+      for (const bin of browser.linuxBins) {
+        if (onPath(bin)) {
+          return { id: browser.id, name: browser.name, url, launch: { command: bin, args: [url] } };
+        }
+      }
+    } else if (platform === 'win32') {
+      const exe = firstWinExe(browser, env, fileExists);
+      if (exe) {
+        return { id: browser.id, name: browser.name, url, launch: { command: exe, args: [url] } };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Best-effort: open the detected browser's extensions page. Never throws; shares
+ * the folder auto-open opt-out. Returns whether a launch was attempted.
+ * @param {ReturnType<typeof detectExtensionsTarget>} target
+ * @param {{env?: Object, spawnFn?: Function}} [opts]
+ */
+function openExtensionsPage(target, opts = {}) {
+  const env = opts.env || process.env;
+  const spawnFn = opts.spawnFn || spawn;
+  if (!target || !target.launch || autoOpenDisabled(env)) return false;
+  try {
+    const child = spawnFn(target.launch.command, target.launch.args, { stdio: 'ignore', detached: true });
+    if (child && typeof child.on === 'function') child.on('error', () => {});
+    if (child && typeof child.unref === 'function') child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  KNOWN_BROWSERS,
+  extensionsUrl,
+  detectExtensionsTarget,
+  openExtensionsPage,
+};

--- a/npm/kaboom-agentic-browser/lib/browser.test.js
+++ b/npm/kaboom-agentic-browser/lib/browser.test.js
@@ -1,0 +1,87 @@
+// Tests for lib/browser.js — detecting an installed Chromium-family browser and
+// opening its extensions page so "Load unpacked" is one click away.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  KNOWN_BROWSERS,
+  extensionsUrl,
+  detectExtensionsTarget,
+  openExtensionsPage,
+} = require('./browser');
+
+test('extensionsUrl uses each brand internal scheme', () => {
+  assert.equal(extensionsUrl('chrome'), 'chrome://extensions/');
+  assert.equal(extensionsUrl('brave'), 'brave://extensions/');
+  assert.equal(extensionsUrl('edge'), 'edge://extensions/');
+});
+
+test('KNOWN_BROWSERS covers the browsers we advertise', () => {
+  const ids = KNOWN_BROWSERS.map((b) => b.id);
+  for (const id of ['chrome', 'brave', 'edge', 'arc', 'chromium']) {
+    assert.ok(ids.includes(id), `expected ${id} in KNOWN_BROWSERS`);
+  }
+});
+
+test('darwin: detects an installed app and builds an `open -a` launch', () => {
+  const hasApp = (name) => name === 'Brave Browser';
+  const target = detectExtensionsTarget({ platform: 'darwin', hasApp });
+  assert.equal(target.id, 'brave');
+  assert.equal(target.url, 'brave://extensions/');
+  assert.deepEqual(target.launch, { command: 'open', args: ['-a', 'Brave Browser', 'brave://extensions/'] });
+});
+
+test('darwin: Chrome wins when several are installed (declaration order)', () => {
+  const hasApp = () => true; // everything present
+  const target = detectExtensionsTarget({ platform: 'darwin', hasApp });
+  assert.equal(target.id, 'chrome');
+  assert.equal(target.url, 'chrome://extensions/');
+});
+
+test('linux: detects a browser on PATH and launches it with the URL', () => {
+  const onPath = (cmd) => cmd === 'google-chrome';
+  const target = detectExtensionsTarget({ platform: 'linux', onPath });
+  assert.equal(target.id, 'chrome');
+  assert.deepEqual(target.launch, { command: 'google-chrome', args: ['chrome://extensions/'] });
+});
+
+test('win32: finds an exe under a base dir and returns its absolute path', () => {
+  const env = { ProgramFiles: 'C:/PF' };
+  const edgeExe = path.join('C:/PF', 'Microsoft', 'Edge', 'Application', 'msedge.exe');
+  const fileExists = (p) => p === edgeExe;
+  const target = detectExtensionsTarget({ platform: 'win32', env, fileExists });
+  assert.equal(target.id, 'edge');
+  assert.equal(target.url, 'edge://extensions/');
+  assert.equal(target.launch.command, edgeExe);
+  assert.deepEqual(target.launch.args, ['edge://extensions/']);
+});
+
+test('returns null when no supported browser is found', () => {
+  assert.equal(detectExtensionsTarget({ platform: 'darwin', hasApp: () => false }), null);
+  assert.equal(detectExtensionsTarget({ platform: 'linux', onPath: () => false }), null);
+  assert.equal(detectExtensionsTarget({ platform: 'win32', env: {}, fileExists: () => false }), null);
+  assert.equal(detectExtensionsTarget({ platform: 'sunos' }), null);
+});
+
+test('openExtensionsPage launches the target, respects opt-out, and tolerates a null target', () => {
+  const calls = [];
+  const spawnFn = (command, args) => {
+    calls.push({ command, args });
+    return { on() {}, unref() {} };
+  };
+  const target = { id: 'chrome', name: 'Google Chrome', url: 'chrome://extensions/', launch: { command: 'open', args: ['-a', 'Google Chrome', 'chrome://extensions/'] } };
+
+  assert.equal(openExtensionsPage(target, { env: {}, spawnFn }), true);
+  assert.deepEqual(calls[0], { command: 'open', args: ['-a', 'Google Chrome', 'chrome://extensions/'] });
+
+  // Opt-out env shared with the folder auto-open.
+  assert.equal(openExtensionsPage(target, { env: { KABOOM_NO_OPEN: '1' }, spawnFn }), false);
+  // Nothing detected → nothing launched.
+  assert.equal(openExtensionsPage(null, { env: {}, spawnFn }), false);
+
+  assert.equal(calls.length, 1, 'only the happy path should have spawned');
+});

--- a/npm/kaboom-agentic-browser/lib/cli.js
+++ b/npm/kaboom-agentic-browser/lib/cli.js
@@ -9,9 +9,60 @@ const config = require('./config');
 const output = require('./output');
 const install = require('./install');
 const extension = require('./extension');
+const browser = require('./browser');
+const health = require('./health');
+const daemon = require('./daemon');
 const skills = require('./skills');
 const doctor = require('./doctor');
 const uninstall = require('./uninstall');
+
+// How long the post-install / --connect loop waits for the extension to appear.
+const CONNECT_WAIT_MS = 30000;
+
+// Interactive install = a human is watching (a TTY). The daemon-start, connect
+// wait, and browser-page open only make sense — and are only safe to trigger —
+// for an interactive install; scripted/CI installs must stay side-effect-free
+// (no lingering daemon, no windows popping open, no blocking wait).
+function isInteractiveInstall() {
+  return !!process.stdout.isTTY;
+}
+
+// Watch the loop only for an interactive install the user hasn't opted out of.
+function shouldWatchConnect() {
+  return isInteractiveInstall() && !health.connectWaitDisabled(process.env);
+}
+
+/**
+ * Ensure the daemon is up, then wait for the browser extension to connect,
+ * printing live progress and a targeted next step. Shared by post-install and
+ * the standalone --connect command.
+ */
+async function watchExtensionConnect({ port = health.DEFAULT_PORT, extensionDir, timeoutMs = CONNECT_WAIT_MS } = {}) {
+  await daemon.ensureDaemon({ port });
+
+  console.log(`\n⏳ Waiting for the browser extension to connect on port ${port} (Ctrl-C to skip)…`);
+  let lastPhase = null;
+  const result = await health.waitForExtension({
+    port,
+    timeoutMs,
+    onState: ({ phase }) => {
+      if (phase === lastPhase) return;
+      lastPhase = phase;
+      if (phase === 'daemon_unreachable') {
+        console.log('   … waiting for the Kaboom server to come up');
+      } else if (phase === 'waiting_extension') {
+        console.log('   … server is up — load the extension in your browser to finish');
+      }
+    },
+  });
+
+  if (result.connected) {
+    console.log('✅ Browser extension connected — Kaboom is fully wired up!');
+  } else {
+    console.log(`⚠️  ${health.connectHint(result.lastPhase, { port, extensionDir })}`);
+  }
+  return result;
+}
 
 // Write a JSON-RPC error to stdout so MCP clients get a clean protocol-level error
 function writeMcpError(message) {
@@ -71,6 +122,15 @@ async function installCommand(options) {
       if (!options.dryRun && extension.openExtensionDir(result.extensionDir)) {
         console.log('📂 Opened the extension folder for you — just select it in "Load unpacked".');
       }
+      // Also open the browser straight to its extensions page (the folder opener
+      // can't do that — it's a browser-internal URL). Interactive installs only,
+      // so scripted/CI runs never pop a browser window; same KABOOM_NO_OPEN opt-out.
+      if (!options.dryRun && isInteractiveInstall()) {
+        const target = browser.detectExtensionsTarget();
+        if (browser.openExtensionsPage(target)) {
+          console.log(`🌐 Opened ${target.name} at ${target.url} — click "Load unpacked" there.`);
+        }
+      }
       if (!options.dryRun) {
         const skillInstall = await skills.installBundledSkills({
           verbose: options.verbose,
@@ -91,6 +151,17 @@ async function installCommand(options) {
           for (const warning of skillInstall.warnings || []) {
             console.warn(`⚠️  ${warning}`);
           }
+        }
+        // Start the daemon so the extension has something to connect to — parity
+        // with the curl|sh installer's startDaemonSilently. ensureDaemon reuses a
+        // healthy daemon instead of double-binding; opt out with KABOOM_NO_DAEMON.
+        // The blocking connect confirmation is interactive-only so scripted/CI
+        // installs never hang; they get guidance to run --connect/--doctor.
+        if (shouldWatchConnect()) {
+          await watchExtensionConnect({ extensionDir: result.extensionDir });
+        } else {
+          await daemon.ensureDaemon();
+          console.log('👉 After loading the extension, run "kaboom-agentic-browser --connect" (or --doctor) to confirm it connected.');
         }
         console.log('✨ Kaboom Agentic Browser is ready to use!');
       }
@@ -136,11 +207,22 @@ async function updateCommand(options) {
   }
 }
 
-function doctorCommand(verbose) {
+async function doctorCommand(verbose) {
   try {
-    const report = doctor.runDiagnostics(verbose);
+    const report = await doctor.runDiagnostics(verbose);
     console.log(output.diagnosticReport(report));
     process.exit(0);
+  } catch (err) {
+    console.error(err.format ? err.format() : `Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+async function connectCommand() {
+  try {
+    const ext = extension.resolveExtensionDir();
+    const result = await watchExtensionConnect({ extensionDir: ext.dir });
+    process.exit(result.connected ? 0 : 1);
   } catch (err) {
     console.error(err.format ? err.format() : `Error: ${err.message}`);
     process.exit(1);
@@ -169,7 +251,8 @@ function showHelp() {
   console.log('  --config, -c          Show MCP configuration and detected clients');
   console.log('  --install, -i [tool]  Auto-install to detected clients, or a specific tool');
   console.log('  --update [tool]       Clean reinstall Kaboom for detected clients or one specific tool');
-  console.log('  --doctor              Run diagnostics on installed configs');
+  console.log('  --doctor              Run diagnostics (configs + live daemon/extension/Node)');
+  console.log('  --connect             Wait for the browser extension to connect, with live status');
   console.log('  --uninstall           Remove Kaboom from all clients');
   console.log('  --help, -h            Show this help message\n');
   console.log('Supported clients:');
@@ -207,7 +290,8 @@ function showHelp() {
   console.log('  kaboom-agentic-browser --install --skills-repo brennhill/kaboom-skills');
   console.log('  kaboom-agentic-browser --update                 # Clean reinstall Kaboom');
   console.log('  kaboom-agentic-browser --config                 # Show config and detected clients');
-  console.log('  kaboom-agentic-browser --doctor                 # Check config health');
+  console.log('  kaboom-agentic-browser --doctor                 # Check config + live daemon/extension health');
+  console.log('  kaboom-agentic-browser --connect                # Wait for the extension to connect');
   console.log('  kaboom-agentic-browser --uninstall              # Remove from all clients\n');
   process.exit(0);
 }
@@ -294,7 +378,13 @@ async function main() {
 
   // Doctor command
   if (args.includes('--doctor')) {
-    doctorCommand(verbose);
+    await doctorCommand(verbose);
+    return;
+  }
+
+  // Connect command — wait for the browser extension to connect.
+  if (args.includes('--connect')) {
+    await connectCommand();
     return;
   }
 

--- a/npm/kaboom-agentic-browser/lib/config.js
+++ b/npm/kaboom-agentic-browser/lib/config.js
@@ -593,6 +593,23 @@ function parseEnvVar(envStr) {
   return { key, value };
 }
 
+/**
+ * True when any of the given env keys is set to a truthy opt-in value.
+ * Unset/empty/"0"/"false"/"no" all count as off. Shared source of truth for the
+ * install-time opt-outs (auto-open, daemon-start, connect-wait) so their
+ * accepted values never drift apart.
+ * @param {object} env
+ * @param {string[]} keys
+ * @returns {boolean}
+ */
+function isEnvFlagSet(env, keys) {
+  for (const key of keys) {
+    const value = String((env && env[key]) || '').trim().toLowerCase();
+    if (value && value !== '0' && value !== 'false' && value !== 'no') return true;
+  }
+  return false;
+}
+
 module.exports = {
   CLIENT_DEFINITIONS,
   CLIENT_ALIASES,
@@ -617,4 +634,5 @@ module.exports = {
   mergeKaboomConfig,
   parseEnvVar,
   resolveManagedBinaryPath,
+  isEnvFlagSet,
 };

--- a/npm/kaboom-agentic-browser/lib/daemon.js
+++ b/npm/kaboom-agentic-browser/lib/daemon.js
@@ -1,0 +1,74 @@
+// Purpose: Start the Kaboom Go daemon during npm --install so the browser
+// extension has a server to connect to (parity with the curl|sh installer,
+// which already starts it via startDaemonSilently).
+// Why: Without a running daemon, "load the extension" has nothing to connect to
+// and the post-install connect check can never succeed.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+'use strict';
+
+const { spawn } = require('node:child_process');
+const { resolveManagedBinaryPath, isEnvFlagSet } = require('./config');
+const { fetchHealth, DEFAULT_PORT } = require('./health');
+
+/** The daemon flags — must match the Go installer's startDaemonSilently. */
+function daemonSpawnArgs(port) {
+  return ['--daemon', '--port', String(port)];
+}
+
+/** True when the user opted out of the install-time daemon start. */
+function daemonStartDisabled(env = process.env) {
+  return isEnvFlagSet(env, ['KABOOM_NO_DAEMON']);
+}
+
+/**
+ * Best-effort: launch the Kaboom binary in daemon mode, detached, on `port`.
+ * Never throws. Returns whether a launch was attempted and the resolved binary.
+ * @param {{binaryPath?: string, port?: number, spawnFn?: Function, env?: object}} [opts]
+ * @returns {{started: boolean, binaryPath: string}}
+ */
+function startDaemon(opts = {}) {
+  const env = opts.env || process.env;
+  const port = opts.port || DEFAULT_PORT;
+  const binaryPath = opts.binaryPath || resolveManagedBinaryPath();
+  const spawnFn = opts.spawnFn || spawn;
+
+  if (daemonStartDisabled(env)) return { started: false, binaryPath };
+
+  try {
+    const child = spawnFn(binaryPath, daemonSpawnArgs(port), { stdio: 'ignore', detached: true });
+    if (child && typeof child.on === 'function') child.on('error', () => {});
+    if (child && typeof child.unref === 'function') child.unref();
+    return { started: true, binaryPath };
+  } catch {
+    return { started: false, binaryPath };
+  }
+}
+
+/**
+ * Ensure a daemon is answering on `port`: reuse an existing healthy one, or
+ * start a new one. Reusing avoids two instances contending for the port.
+ * @param {{port?: number, env?: object, fetchHealthFn?: Function, startFn?: Function}} [opts]
+ * @returns {Promise<{alreadyRunning: boolean, started: boolean, binaryPath: string|null}>}
+ */
+async function ensureDaemon(opts = {}) {
+  const port = opts.port || DEFAULT_PORT;
+  const env = opts.env || process.env;
+  const fetchHealthFn = opts.fetchHealthFn || ((p) => fetchHealth(p, { timeoutMs: 600 }));
+  const startFn = opts.startFn || (() => startDaemon({ port, env }));
+
+  const snapshot = await fetchHealthFn(port);
+  if (snapshot && snapshot.reachable) {
+    return { alreadyRunning: true, started: false, binaryPath: null };
+  }
+  const result = startFn();
+  return { alreadyRunning: false, started: !!(result && result.started), binaryPath: (result && result.binaryPath) || null };
+}
+
+module.exports = {
+  DEFAULT_PORT,
+  daemonSpawnArgs,
+  daemonStartDisabled,
+  startDaemon,
+  ensureDaemon,
+};

--- a/npm/kaboom-agentic-browser/lib/daemon.test.js
+++ b/npm/kaboom-agentic-browser/lib/daemon.test.js
@@ -1,0 +1,80 @@
+// Tests for lib/daemon.js — starting the Kaboom daemon during npm --install so
+// the browser extension has something to connect to.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_PORT,
+  daemonSpawnArgs,
+  daemonStartDisabled,
+  startDaemon,
+  ensureDaemon,
+} = require('./daemon');
+
+test('daemonSpawnArgs matches the flags the Go installer uses', () => {
+  assert.deepEqual(daemonSpawnArgs(7890), ['--daemon', '--port', '7890']);
+  assert.deepEqual(daemonSpawnArgs(7999), ['--daemon', '--port', '7999']);
+});
+
+test('daemonStartDisabled honors KABOOM_NO_DAEMON', () => {
+  assert.equal(daemonStartDisabled({}), false);
+  assert.equal(daemonStartDisabled({ KABOOM_NO_DAEMON: '1' }), true);
+  assert.equal(daemonStartDisabled({ KABOOM_NO_DAEMON: '0' }), false);
+});
+
+test('startDaemon spawns the binary detached and unrefs it', () => {
+  const calls = [];
+  let unrefd = false;
+  const spawnFn = (command, args, options) => {
+    calls.push({ command, args, options });
+    return { on() {}, unref() { unrefd = true; } };
+  };
+  const res = startDaemon({ binaryPath: '/opt/kaboom', port: 7890, spawnFn, env: {} });
+  assert.equal(res.started, true);
+  assert.equal(res.binaryPath, '/opt/kaboom');
+  assert.deepEqual(calls[0].command, '/opt/kaboom');
+  assert.deepEqual(calls[0].args, ['--daemon', '--port', '7890']);
+  assert.equal(calls[0].options.detached, true);
+  assert.equal(unrefd, true);
+});
+
+test('startDaemon respects the opt-out and never spawns', () => {
+  let spawned = false;
+  const spawnFn = () => { spawned = true; return { on() {}, unref() {} }; };
+  const res = startDaemon({ binaryPath: '/opt/kaboom', spawnFn, env: { KABOOM_NO_DAEMON: '1' } });
+  assert.equal(res.started, false);
+  assert.equal(spawned, false);
+});
+
+test('startDaemon reports started=false when spawn throws', () => {
+  const spawnFn = () => { throw new Error('ENOENT'); };
+  const res = startDaemon({ binaryPath: '/opt/kaboom', spawnFn, env: {} });
+  assert.equal(res.started, false);
+});
+
+test('ensureDaemon reuses a daemon that is already answering', async () => {
+  let started = false;
+  const res = await ensureDaemon({
+    port: 7890,
+    fetchHealthFn: async () => ({ reachable: true }),
+    startFn: () => { started = true; return { started: true }; },
+  });
+  assert.equal(res.alreadyRunning, true);
+  assert.equal(res.started, false);
+  assert.equal(started, false, 'must not start a duplicate daemon');
+});
+
+test('ensureDaemon starts the daemon when nothing is answering', async () => {
+  let started = false;
+  const res = await ensureDaemon({
+    port: 7890,
+    fetchHealthFn: async () => ({ reachable: false }),
+    startFn: () => { started = true; return { started: true, binaryPath: '/opt/kaboom' }; },
+  });
+  assert.equal(res.alreadyRunning, false);
+  assert.equal(res.started, true);
+  assert.equal(started, true);
+});

--- a/npm/kaboom-agentic-browser/lib/doctor.js
+++ b/npm/kaboom-agentic-browser/lib/doctor.js
@@ -21,6 +21,12 @@ const {
   readConfigFile,
   expandPath,
 } = require('./config');
+const { fetchHealth, DEFAULT_PORT } = require('./health');
+
+// Node floor: the launcher and lib/*.js rely on modern Node built-ins
+// (node: specifiers, structuredClone, fetch-free http usage). 18 is the oldest
+// still-maintained line that clears that bar.
+const MIN_NODE_MAJOR = 18;
 
 function knownServerNames() {
   return [MCP_SERVER_NAME, ...LEGACY_MCP_SERVER_NAMES.filter((name) => name !== MCP_SERVER_NAME)];
@@ -160,6 +166,47 @@ function testBinary() {
       error: `Error testing binary: ${err.message}`,
     };
   }
+}
+
+/**
+ * Evaluate a Node version string against the supported floor. Pure.
+ * @param {string} versionString e.g. process.version ("v20.11.0")
+ * @returns {{ok: boolean, version: string, major: number|null, minMajor: number}}
+ */
+function evaluateNodeVersion(versionString) {
+  const match = /^v?(\d+)\./.exec(String(versionString || ''));
+  const major = match ? Number(match[1]) : null;
+  return {
+    ok: major != null && major >= MIN_NODE_MAJOR,
+    version: String(versionString || 'unknown'),
+    major,
+    minMajor: MIN_NODE_MAJOR,
+  };
+}
+
+/** Diagnose the Node runtime the CLI itself is running under. */
+function nodeCheck() {
+  return evaluateNodeVersion(process.version);
+}
+
+/**
+ * Live daemon/extension check via /health. Never throws.
+ * @param {{port?: number, fetchHealthFn?: Function}} [opts]
+ * @returns {Promise<{port: number, reachable: boolean, ok: boolean,
+ *   version: string|null, extensionConnected: boolean, extensionLastSeen: any}>}
+ */
+async function checkDaemon(opts = {}) {
+  const port = opts.port || DEFAULT_PORT;
+  const fetchHealthFn = opts.fetchHealthFn || ((p) => fetchHealth(p, { timeoutMs: 800 }));
+  const snap = await fetchHealthFn(port);
+  return {
+    port,
+    reachable: !!(snap && snap.reachable),
+    ok: !!(snap && snap.ok),
+    version: (snap && snap.version) || null,
+    extensionConnected: !!(snap && snap.extensionConnected),
+    extensionLastSeen: (snap && snap.extensionLastSeen) || null,
+  };
 }
 
 /**
@@ -328,14 +375,19 @@ function checkLegacyPaths() {
 }
 
 /**
- * Run full diagnostics on all client locations
+ * Run full diagnostics on all client locations, plus live runtime checks
+ * (Node version, daemon reachability, extension connectivity).
  * @param {boolean} verbose If true, log debug info
- * @returns {Object} Diagnostic report with tools array and summary
+ * @param {{fetchHealthFn?: Function, clients?: Array}} [opts]
+ *   Injectable /health and client list for hermetic tests (defaults hit the
+ *   real client scan + daemon).
+ * @returns {Promise<Object>} Diagnostic report with tools array and summary
  */
-function runDiagnostics(verbose = false) {
+async function runDiagnostics(verbose = false, opts = {}) {
   const tools = [];
+  const clients = opts.clients || CLIENT_DEFINITIONS;
 
-  for (const def of CLIENT_DEFINITIONS) {
+  for (const def of clients) {
     if (def.type === 'cli') {
       tools.push(diagnoseCliClient(def, verbose));
     } else {
@@ -347,8 +399,13 @@ function runDiagnostics(verbose = false) {
   const binary = testBinary();
 
   // Check default port availability (7890)
-  const defaultPort = 7890;
+  const defaultPort = DEFAULT_PORT;
   const port = checkPortSync(defaultPort);
+
+  // Live runtime checks: Node version + whether the daemon/extension are up.
+  const node = nodeCheck();
+  const daemon = await checkDaemon({ port: defaultPort, fetchHealthFn: opts.fetchHealthFn });
+  const extension = { connected: daemon.extensionConnected, lastSeen: daemon.extensionLastSeen };
 
   // Check for legacy paths
   const legacyWarnings = checkLegacyPaths();
@@ -370,12 +427,19 @@ function runDiagnostics(verbose = false) {
     tools,
     binary,
     port: { port: defaultPort, ...port },
+    node,
+    daemon,
+    extension,
     legacyWarnings,
     summary,
   };
 }
 
 module.exports = {
+  MIN_NODE_MAJOR,
+  evaluateNodeVersion,
+  nodeCheck,
+  checkDaemon,
   testBinary,
   runDiagnostics,
 };

--- a/npm/kaboom-agentic-browser/lib/doctor.test.js
+++ b/npm/kaboom-agentic-browser/lib/doctor.test.js
@@ -1,0 +1,64 @@
+// Tests for lib/doctor.js — the live diagnosis added on top of config checks:
+// Node version, daemon reachability, and extension connectivity.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MIN_NODE_MAJOR,
+  evaluateNodeVersion,
+  nodeCheck,
+  checkDaemon,
+  runDiagnostics,
+} = require('./doctor');
+
+test('evaluateNodeVersion flags versions below the floor', () => {
+  assert.equal(evaluateNodeVersion('v20.11.0').ok, true);
+  assert.equal(evaluateNodeVersion('v18.0.0').ok, true);
+  const old = evaluateNodeVersion('v16.20.0');
+  assert.equal(old.ok, false);
+  assert.equal(old.major, 16);
+  assert.equal(old.minMajor, MIN_NODE_MAJOR);
+  // Unparseable input must not crash — treat as unknown, not ok.
+  assert.equal(evaluateNodeVersion('not-a-version').ok, false);
+});
+
+test('nodeCheck describes the running Node', () => {
+  const res = nodeCheck();
+  assert.match(res.version, /^v\d+\./);
+  assert.equal(typeof res.ok, 'boolean');
+});
+
+test('checkDaemon reports a reachable daemon with a connected extension', async () => {
+  const fetchHealthFn = async (port) => {
+    assert.equal(port, 7890);
+    return { reachable: true, ok: true, version: '0.8.6', extensionConnected: true, extensionLastSeen: 'now' };
+  };
+  const res = await checkDaemon({ port: 7890, fetchHealthFn });
+  assert.equal(res.reachable, true);
+  assert.equal(res.version, '0.8.6');
+  assert.equal(res.extensionConnected, true);
+  assert.equal(res.port, 7890);
+});
+
+test('checkDaemon reports an unreachable daemon without throwing', async () => {
+  const res = await checkDaemon({ port: 7890, fetchHealthFn: async () => ({ reachable: false }) });
+  assert.equal(res.reachable, false);
+  assert.equal(res.extensionConnected, false);
+});
+
+test('runDiagnostics is async and includes node, daemon, and extension sections', async () => {
+  const report = await runDiagnostics(false, {
+    // Empty client list keeps the test hermetic — no real `claude mcp get`
+    // subprocess scan. We only assert the new runtime-check wiring here.
+    clients: [],
+    fetchHealthFn: async () => ({ reachable: true, ok: true, version: '0.8.6', extensionConnected: false }),
+  });
+  assert.ok(Array.isArray(report.tools));
+  assert.ok(report.node && typeof report.node.ok === 'boolean');
+  assert.equal(report.daemon.reachable, true);
+  assert.equal(report.extension.connected, false);
+  assert.ok(typeof report.summary === 'string');
+});

--- a/npm/kaboom-agentic-browser/lib/extension.js
+++ b/npm/kaboom-agentic-browser/lib/extension.js
@@ -10,6 +10,7 @@ const os = require('node:os');
 const path = require('node:path');
 const fs = require('node:fs');
 const { spawn } = require('node:child_process');
+const { isEnvFlagSet } = require('./config');
 
 // The folder the curl|sh / PowerShell installers stage the extension into.
 const STAGED_DIR_NAME = 'KaboomAgenticDevtoolExtension';
@@ -57,11 +58,7 @@ function resolveExtensionDir(env = process.env, homeDir = os.homedir()) {
 
 /** True when the user opted out of the install-time auto-open. */
 function autoOpenDisabled(env = process.env) {
-  for (const key of ['KABOOM_NO_OPEN', 'KABOOM_INSTALL_NO_OPEN']) {
-    const value = String(env[key] || '').trim().toLowerCase();
-    if (value && value !== '0' && value !== 'false' && value !== 'no') return true;
-  }
-  return false;
+  return isEnvFlagSet(env, ['KABOOM_NO_OPEN', 'KABOOM_INSTALL_NO_OPEN']);
 }
 
 /**

--- a/npm/kaboom-agentic-browser/lib/health.js
+++ b/npm/kaboom-agentic-browser/lib/health.js
@@ -1,0 +1,235 @@
+// Purpose: Query the running Kaboom daemon's /health endpoint and wait for the
+// browser extension to connect.
+// Why: After install the one remaining manual step is loading the unpacked
+// extension. Polling /health lets us confirm it actually connected — or tell the
+// user exactly what is still missing — instead of leaving them guessing.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+//
+// NOTE: kill-daemon.js has its own narrow /health reader (readHealthIdentity)
+// that only inspects service identity and must stay conservative for the
+// process-killing path. This module is the canonical health client for
+// user-facing install/doctor/connect flows; keep the two intentionally separate.
+
+'use strict';
+
+const http = require('node:http');
+const { isEnvFlagSet } = require('./config');
+
+const DEFAULT_PORT = 7890;
+// One /health read should be quick on localhost; cap it so a hung socket can
+// never wedge the connect loop.
+const DEFAULT_REQUEST_TIMEOUT_MS = 800;
+
+/**
+ * @typedef {Object} HealthSnapshot
+ * @property {boolean} reachable          Daemon answered on the port at all.
+ * @property {boolean} ok                 HTTP 200 with a parseable JSON object.
+ * @property {boolean} extensionConnected capture.extension_connected === true.
+ * @property {string|number|null} extensionLastSeen
+ * @property {string|null} version
+ * @property {string|null} serviceName
+ * @property {object|null} raw            The parsed body (when ok).
+ */
+
+function emptySnapshot(reachable) {
+  return {
+    reachable,
+    ok: false,
+    extensionConnected: false,
+    extensionLastSeen: null,
+    version: null,
+    serviceName: null,
+    raw: null,
+  };
+}
+
+/**
+ * Normalize a raw /health response into a HealthSnapshot. Pure.
+ * @param {number|null} statusCode  null means the daemon never answered.
+ * @param {string|null} body
+ * @returns {HealthSnapshot}
+ */
+function summarizeHealth(statusCode, body) {
+  if (statusCode == null) return emptySnapshot(false);
+  const snap = emptySnapshot(true);
+  if (statusCode !== 200) return snap;
+
+  let data;
+  try {
+    data = JSON.parse(body);
+  } catch {
+    return snap;
+  }
+  if (!data || typeof data !== 'object') return snap;
+
+  snap.ok = true;
+  snap.raw = data;
+  snap.version = typeof data.version === 'string' ? data.version : null;
+  for (const key of ['service-name', 'service_name', 'name']) {
+    if (typeof data[key] === 'string' && data[key].trim()) {
+      snap.serviceName = data[key].trim();
+      break;
+    }
+  }
+  const cap = data.capture && typeof data.capture === 'object' ? data.capture : null;
+  if (cap) {
+    snap.extensionConnected = cap.extension_connected === true;
+    snap.extensionLastSeen = cap.extension_last_seen == null ? null : cap.extension_last_seen;
+  }
+  return snap;
+}
+
+/**
+ * Real /health request. Resolves { statusCode, body } or null on any error or
+ * timeout — never rejects, so a down daemon is just "unreachable".
+ * @param {number} port
+ * @param {number} timeoutMs
+ * @returns {Promise<{statusCode: number, body: string}|null>}
+ */
+function defaultRequest(port, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let req;
+    try {
+      req = http.get({ hostname: '127.0.0.1', port, path: '/health', timeout: timeoutMs }, (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+          // Guard against an unbounded body from a misbehaving server.
+          if (body.length > 256 * 1024) {
+            try { req.destroy(); } catch { /* already gone */ }
+          }
+        });
+        res.on('end', () => finish({ statusCode: res.statusCode, body }));
+        res.on('error', () => finish(null));
+      });
+    } catch {
+      finish(null);
+      return;
+    }
+    req.on('timeout', () => {
+      try { req.destroy(); } catch { /* already gone */ }
+      finish(null);
+    });
+    req.on('error', () => finish(null));
+  });
+}
+
+/**
+ * Fetch and normalize the daemon /health snapshot. Never rejects.
+ * @param {number} [port]
+ * @param {{timeoutMs?: number, request?: Function}} [opts]
+ *   request(port, timeoutMs) is injectable for tests.
+ * @returns {Promise<HealthSnapshot>}
+ */
+async function fetchHealth(port = DEFAULT_PORT, opts = {}) {
+  const request = opts.request || defaultRequest;
+  const timeoutMs = opts.timeoutMs || DEFAULT_REQUEST_TIMEOUT_MS;
+  let res;
+  try {
+    res = await request(port, timeoutMs);
+  } catch {
+    res = null;
+  }
+  if (!res) return summarizeHealth(null, null);
+  return summarizeHealth(res.statusCode, res.body);
+}
+
+/** Classify a snapshot into a connect phase. */
+function phaseOf(snapshot) {
+  if (snapshot.extensionConnected) return 'connected';
+  if (snapshot.reachable) return 'waiting_extension';
+  return 'daemon_unreachable';
+}
+
+/**
+ * Poll /health until the extension connects or the deadline passes. Reports each
+ * poll via onState so a caller can render live progress. Deterministic under an
+ * injected clock (now/sleep) — no real timers required for tests.
+ *
+ * @param {Object} opts
+ * @param {number} [opts.port]
+ * @param {number} [opts.timeoutMs]  Overall budget (default 30s).
+ * @param {number} [opts.pollMs]     Delay between polls (default 750ms).
+ * @param {number} [opts.perPollTimeoutMs]
+ * @param {Function} [opts.request]  Injected /health request.
+ * @param {Function} [opts.now]      () => ms.
+ * @param {Function} [opts.sleep]    (ms) => Promise.
+ * @param {Function} [opts.onState]  ({phase, snapshot, elapsedMs}) => void.
+ * @returns {Promise<{connected: boolean, reason: 'connected'|'timeout',
+ *   lastPhase: string, snapshot: HealthSnapshot, elapsedMs: number}>}
+ */
+async function waitForExtension(opts = {}) {
+  const port = opts.port || DEFAULT_PORT;
+  const timeoutMs = opts.timeoutMs != null ? opts.timeoutMs : 30000;
+  const pollMs = opts.pollMs || 750;
+  const perPollTimeoutMs = opts.perPollTimeoutMs || DEFAULT_REQUEST_TIMEOUT_MS;
+  const request = opts.request;
+  const now = opts.now || (() => Date.now());
+  const sleep = opts.sleep || ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const onState = typeof opts.onState === 'function' ? opts.onState : () => {};
+
+  const start = now();
+  let snapshot = emptySnapshot(false);
+  let lastPhase = 'daemon_unreachable';
+
+  for (;;) {
+    snapshot = await fetchHealth(port, { request, timeoutMs: perPollTimeoutMs });
+    lastPhase = phaseOf(snapshot);
+    const elapsedMs = now() - start;
+    onState({ phase: lastPhase, snapshot, elapsedMs });
+
+    if (lastPhase === 'connected') {
+      return { connected: true, reason: 'connected', lastPhase, snapshot, elapsedMs };
+    }
+    if (elapsedMs >= timeoutMs) {
+      return { connected: false, reason: 'timeout', lastPhase, snapshot, elapsedMs };
+    }
+    await sleep(pollMs);
+  }
+}
+
+/**
+ * Targeted next-step message for a connect loop that did not finish. Pure.
+ * @param {string} lastPhase 'daemon_unreachable' | 'waiting_extension'
+ * @param {{port?: number, extensionDir?: string}} [ctx]
+ * @returns {string}
+ */
+function connectHint(lastPhase, ctx = {}) {
+  const port = ctx.port || DEFAULT_PORT;
+  if (lastPhase === 'waiting_extension') {
+    const where = ctx.extensionDir ? `\n     Folder to load: ${ctx.extensionDir}` : '';
+    return (
+      `The Kaboom server is running on port ${port}, but the browser extension has not connected yet.\n` +
+      `   → Open chrome://extensions, enable "Developer mode", click "Load unpacked", and select the\n` +
+      `     extension folder — then make sure the toggle is on.${where}`
+    );
+  }
+  // daemon_unreachable (or anything unexpected)
+  return (
+    `The Kaboom server is not answering on port ${port} yet.\n` +
+    `   → Start your AI client (Claude, Cursor, …) so it launches Kaboom, or run\n` +
+    `     "kaboom-agentic-browser --install", then re-run "kaboom-agentic-browser --connect".`
+  );
+}
+
+/** True when the user opted out of the install-time connect wait. */
+function connectWaitDisabled(env = process.env) {
+  return isEnvFlagSet(env, ['KABOOM_NO_WAIT', 'KABOOM_INSTALL_NO_WAIT']);
+}
+
+module.exports = {
+  DEFAULT_PORT,
+  summarizeHealth,
+  fetchHealth,
+  waitForExtension,
+  connectHint,
+  connectWaitDisabled,
+  phaseOf,
+};

--- a/npm/kaboom-agentic-browser/lib/health.test.js
+++ b/npm/kaboom-agentic-browser/lib/health.test.js
@@ -1,0 +1,174 @@
+// Tests for lib/health.js — reading the daemon /health snapshot and waiting for
+// the browser extension to connect.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_PORT,
+  summarizeHealth,
+  fetchHealth,
+  waitForExtension,
+  connectHint,
+  connectWaitDisabled,
+} = require('./health');
+
+test('DEFAULT_PORT matches the daemon default', () => {
+  assert.equal(DEFAULT_PORT, 7890);
+});
+
+test('summarizeHealth reports a connected extension from a 200 body', () => {
+  const body = JSON.stringify({
+    version: '0.8.6',
+    'service-name': 'kaboom-agentic-browser',
+    capture: { extension_connected: true, extension_last_seen: '2026-07-24T00:00:00Z' },
+  });
+  const snap = summarizeHealth(200, body);
+  assert.equal(snap.reachable, true);
+  assert.equal(snap.ok, true);
+  assert.equal(snap.extensionConnected, true);
+  assert.equal(snap.extensionLastSeen, '2026-07-24T00:00:00Z');
+  assert.equal(snap.version, '0.8.6');
+  assert.equal(snap.serviceName, 'kaboom-agentic-browser');
+});
+
+test('summarizeHealth: daemon up but extension not connected', () => {
+  const body = JSON.stringify({ version: '0.8.6', capture: { extension_connected: false } });
+  const snap = summarizeHealth(200, body);
+  assert.equal(snap.reachable, true);
+  assert.equal(snap.ok, true);
+  assert.equal(snap.extensionConnected, false);
+  assert.equal(snap.extensionLastSeen, null);
+});
+
+test('summarizeHealth: no capture block means daemon up, extension unknown/false', () => {
+  const snap = summarizeHealth(200, JSON.stringify({ version: '0.8.6' }));
+  assert.equal(snap.reachable, true);
+  assert.equal(snap.ok, true);
+  assert.equal(snap.extensionConnected, false);
+});
+
+test('summarizeHealth: null status means the daemon never answered', () => {
+  const snap = summarizeHealth(null, null);
+  assert.equal(snap.reachable, false);
+  assert.equal(snap.ok, false);
+  assert.equal(snap.extensionConnected, false);
+  assert.equal(snap.version, null);
+  assert.equal(snap.raw, null);
+});
+
+test('summarizeHealth: non-200 counts as reachable but not ok', () => {
+  const snap = summarizeHealth(503, 'Service Unavailable');
+  assert.equal(snap.reachable, true);
+  assert.equal(snap.ok, false);
+  assert.equal(snap.extensionConnected, false);
+});
+
+test('summarizeHealth: invalid JSON body is reachable but not ok', () => {
+  const snap = summarizeHealth(200, '{ not json');
+  assert.equal(snap.reachable, true);
+  assert.equal(snap.ok, false);
+});
+
+test('fetchHealth uses the injected request and summarizes the result', async () => {
+  const request = async (port, timeoutMs) => {
+    assert.equal(port, 7890);
+    assert.ok(timeoutMs > 0);
+    return { statusCode: 200, body: JSON.stringify({ capture: { extension_connected: true } }) };
+  };
+  const snap = await fetchHealth(7890, { request });
+  assert.equal(snap.extensionConnected, true);
+});
+
+test('fetchHealth treats a thrown/absent request as unreachable', async () => {
+  const throwing = async () => { throw new Error('ECONNREFUSED'); };
+  assert.equal((await fetchHealth(7890, { request: throwing })).reachable, false);
+
+  const nullish = async () => null;
+  assert.equal((await fetchHealth(7890, { request: nullish })).reachable, false);
+});
+
+// A deterministic fake clock: sleep() advances virtual time so waitForExtension
+// terminates without real timers.
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: (ms) => { t += ms; return Promise.resolve(); },
+  };
+}
+
+test('waitForExtension resolves connected once the extension appears', async () => {
+  const clock = fakeClock();
+  // Poll 1: unreachable. Poll 2: up, no extension. Poll 3: connected.
+  const queue = [
+    null,
+    { statusCode: 200, body: JSON.stringify({ capture: { extension_connected: false } }) },
+    { statusCode: 200, body: JSON.stringify({ capture: { extension_connected: true } }) },
+  ];
+  const request = async () => queue.shift();
+  const phases = [];
+  const result = await waitForExtension({
+    port: 7890,
+    timeoutMs: 30000,
+    pollMs: 500,
+    request,
+    now: clock.now,
+    sleep: clock.sleep,
+    onState: (s) => phases.push(s.phase),
+  });
+  assert.equal(result.connected, true);
+  assert.equal(result.reason, 'connected');
+  assert.equal(result.lastPhase, 'connected');
+  assert.deepEqual(phases, ['daemon_unreachable', 'waiting_extension', 'connected']);
+});
+
+test('waitForExtension times out and reports the last phase (extension never loaded)', async () => {
+  const clock = fakeClock();
+  const request = async () => ({ statusCode: 200, body: JSON.stringify({ capture: { extension_connected: false } }) });
+  const result = await waitForExtension({
+    timeoutMs: 2000,
+    pollMs: 750,
+    request,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+  assert.equal(result.connected, false);
+  assert.equal(result.reason, 'timeout');
+  assert.equal(result.lastPhase, 'waiting_extension');
+});
+
+test('waitForExtension times out reporting daemon_unreachable when nothing answers', async () => {
+  const clock = fakeClock();
+  const request = async () => null;
+  const result = await waitForExtension({
+    timeoutMs: 1500,
+    pollMs: 750,
+    request,
+    now: clock.now,
+    sleep: clock.sleep,
+  });
+  assert.equal(result.connected, false);
+  assert.equal(result.lastPhase, 'daemon_unreachable');
+});
+
+test('connectWaitDisabled honors the opt-out env vars', () => {
+  assert.equal(connectWaitDisabled({}), false);
+  assert.equal(connectWaitDisabled({ KABOOM_NO_WAIT: '1' }), true);
+  assert.equal(connectWaitDisabled({ KABOOM_INSTALL_NO_WAIT: 'true' }), true);
+  assert.equal(connectWaitDisabled({ KABOOM_NO_WAIT: '0' }), false);
+  assert.equal(connectWaitDisabled({ KABOOM_NO_WAIT: 'false' }), false);
+});
+
+test('connectHint gives a distinct, actionable message per stuck phase', () => {
+  const unreachable = connectHint('daemon_unreachable', { port: 7890, extensionDir: '/x/ext' });
+  const waiting = connectHint('waiting_extension', { port: 7890, extensionDir: '/x/ext' });
+  assert.notEqual(unreachable, waiting);
+  // Unreachable → tell them the server isn't running.
+  assert.match(unreachable, /server|running|start/i);
+  // Waiting → tell them to load the extension, and name the exact folder.
+  assert.match(waiting, /extension/i);
+  assert.match(waiting, /\/x\/ext/);
+});

--- a/npm/kaboom-agentic-browser/lib/output.js
+++ b/npm/kaboom-agentic-browser/lib/output.js
@@ -193,6 +193,41 @@ function diagnosticReport(report) {
     }
   }
 
+  // Node runtime the launcher/CLI runs under.
+  if (report.node) {
+    if (report.node.ok) {
+      output += `✅ Node.js ${report.node.version}\n`;
+    } else {
+      output += `⚠️  Node.js ${report.node.version}\n`;
+      output += `   Kaboom needs Node ${report.node.minMajor}+; upgrade Node to run the CLI reliably.\n`;
+    }
+  }
+
+  // Live daemon + browser-extension status (the actual data path).
+  if (report.daemon) {
+    if (report.daemon.reachable) {
+      const ver = report.daemon.version ? ` (v${report.daemon.version})` : '';
+      output += `✅ Kaboom daemon${ver}\n`;
+      output += `   Responding on port ${report.daemon.port}\n`;
+    } else {
+      output += `⚪ Kaboom daemon\n`;
+      output += `   Not running — it starts when your AI client launches Kaboom (or run --install).\n`;
+    }
+  }
+
+  if (report.extension) {
+    if (report.extension.connected) {
+      output += `✅ Browser extension\n`;
+      output += `   Connected and streaming to the daemon\n`;
+    } else if (report.daemon && report.daemon.reachable) {
+      output += `⚠️  Browser extension\n`;
+      output += `   Not connected — open chrome://extensions, "Load unpacked", select the Kaboom folder, and enable it.\n`;
+    } else {
+      output += `⚪ Browser extension\n`;
+      output += `   Can't check until the daemon is running.\n`;
+    }
+  }
+
   // Legacy path warnings
   if (report.legacyWarnings && report.legacyWarnings.length > 0) {
     output += '\n⚠️  Legacy Configs Found:\n';

--- a/tests/cli/cli-integration.test.cjs
+++ b/tests/cli/cli-integration.test.cjs
@@ -11,11 +11,20 @@ const fs = require('fs')
 const _path = require('path')
 const _os = require('os')
 
-// Helper to run kaboom-agentic-browser command
+// Helper to run kaboom-agentic-browser command.
+// Real (non-dry-run) --install would otherwise start the daemon, open the
+// extension folder/browser, and block on the connect wait. Disable all three so
+// the parser/routing tests stay hermetic and never leave a daemon running.
+const HERMETIC_ENV = {
+  ...process.env,
+  KABOOM_NO_DAEMON: '1',
+  KABOOM_NO_OPEN: '1',
+  KABOOM_NO_WAIT: '1',
+}
 function runCommand(args) {
   try {
     const cmd = `npm/kaboom-agentic-browser/bin/kaboom-agentic-browser ${args}`.trim()
-    const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+    const output = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], env: HERMETIC_ENV })
     return { success: true, output, exitCode: 0 }
   } catch (e) {
     return { success: false, output: e.stdout || '', error: e.stderr || '', exitCode: e.status || 1 }

--- a/tests/cli/doctor.test.cjs
+++ b/tests/cli/doctor.test.cjs
@@ -11,7 +11,12 @@ const os = require('os')
 const doctor = require('../../npm/kaboom-agentic-browser/lib/doctor')
 const config = require('../../npm/kaboom-agentic-browser/lib/config')
 
-test('doctor.testBinary returns object with expected structure', () => {
+// runDiagnostics is async and now performs a live /health probe. Stub it to an
+// unreachable daemon so these config-focused tests stay hermetic and fast
+// regardless of whether a real Kaboom daemon happens to be running.
+const NO_DAEMON = { fetchHealthFn: async () => ({ reachable: false }) }
+
+test('doctor.testBinary returns object with expected structure', async () => {
   const result = doctor.testBinary()
 
   assert.ok(typeof result === 'object', 'Should return object')
@@ -25,15 +30,15 @@ test('doctor.testBinary returns object with expected structure', () => {
   }
 })
 
-test('doctor.testBinary handles unsupported platform gracefully', () => {
+test('doctor.testBinary handles unsupported platform gracefully', async () => {
   // This test just verifies the function doesn't crash
   // The actual result depends on the platform
   const result = doctor.testBinary()
   assert.ok(result, 'Should return result')
 })
 
-test('doctor.runDiagnostics returns complete report structure', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics returns complete report structure', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   assert.ok(report.tools, 'Should have tools array')
   assert.ok(Array.isArray(report.tools), 'tools should be array')
@@ -43,8 +48,8 @@ test('doctor.runDiagnostics returns complete report structure', () => {
   assert.strictEqual(report.tools.length, config.CLIENT_DEFINITIONS.length, 'Should check all configured clients')
 })
 
-test('doctor.runDiagnostics tools have correct structure', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics tools have correct structure', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   for (const tool of report.tools) {
     assert.ok(tool.name, 'Tool should have name')
@@ -60,8 +65,8 @@ test('doctor.runDiagnostics tools have correct structure', () => {
   }
 })
 
-test('doctor.runDiagnostics identifies tool names correctly', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics identifies tool names correctly', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
   const names = report.tools.map((t) => t.name)
 
   assert.ok(names.includes('Claude Code'), 'Should identify Claude Code')
@@ -71,15 +76,15 @@ test('doctor.runDiagnostics identifies tool names correctly', () => {
   assert.ok(names.includes('Windsurf'), 'Should identify Windsurf')
 })
 
-test('doctor.runDiagnostics with verbose=true does not crash', () => {
+test('doctor.runDiagnostics with verbose=true does not crash', async () => {
   // Verbose mode should produce debug output but not crash
-  const report = doctor.runDiagnostics(true)
+  const report = await doctor.runDiagnostics(true, NO_DAEMON)
 
   assert.ok(report.tools, 'Should still return valid report with verbose=true')
 })
 
-test('doctor.runDiagnostics provides suggestions for unconfigured tools', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics provides suggestions for unconfigured tools', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   // Error tools (misconfigured) should provide a remediation.
   const errorTools = report.tools.filter((t) => t.status === 'error')
@@ -88,8 +93,8 @@ test('doctor.runDiagnostics provides suggestions for unconfigured tools', () => 
   }
 })
 
-test('doctor.runDiagnostics binary result has correct structure', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics binary result has correct structure', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
   const binary = report.binary
 
   assert.ok(typeof binary.ok === 'boolean', 'Binary should have ok boolean')
@@ -102,8 +107,8 @@ test('doctor.runDiagnostics binary result has correct structure', () => {
   }
 })
 
-test('doctor.runDiagnostics summary mentions count information', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor.runDiagnostics summary mentions count information', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   assert.ok(typeof report.summary === 'string', 'Summary should be string')
   assert.ok(report.summary.length > 0, 'Summary should not be empty')
@@ -111,7 +116,7 @@ test('doctor.runDiagnostics summary mentions count information', () => {
   assert.ok(report.summary.includes('Summary') || report.summary.includes('tool'), 'Summary should describe tools')
 })
 
-test('doctor.runDiagnostics identifies existing valid configs', () => {
+test('doctor.runDiagnostics identifies existing valid configs', async () => {
   // Create a temporary valid config
   const testDir = path.join(os.tmpdir(), 'doctor-test')
   if (!fs.existsSync(testDir)) {
@@ -129,7 +134,7 @@ test('doctor.runDiagnostics identifies existing valid configs', () => {
 
     // Note: runDiagnostics checks specific hardcoded paths, not our test path
     // So this test mainly verifies the diagnostic logic works with valid configs
-    const report = doctor.runDiagnostics(false)
+    const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
     assert.ok(report.tools.length > 0, 'Should return tools even if not configured')
   } finally {
@@ -140,9 +145,9 @@ test('doctor.runDiagnostics identifies existing valid configs', () => {
   }
 })
 
-test('doctor.runDiagnostics handles invalid JSON gracefully', () => {
+test('doctor.runDiagnostics handles invalid JSON gracefully', async () => {
   // The diagnostic should handle invalid configs without crashing
-  const report = doctor.runDiagnostics(false)
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   // Should always return a complete report
   assert.ok(report.tools, 'Should return tools')
@@ -150,8 +155,8 @@ test('doctor.runDiagnostics handles invalid JSON gracefully', () => {
   assert.ok(report.summary, 'Should return summary')
 })
 
-test('doctor tool statuses are consistent with structure', () => {
-  const report = doctor.runDiagnostics(false)
+test('doctor tool statuses are consistent with structure', async () => {
+  const report = await doctor.runDiagnostics(false, NO_DAEMON)
 
   for (const tool of report.tools) {
     // If status is 'ok', should have no issues
@@ -169,7 +174,7 @@ test('doctor tool statuses are consistent with structure', () => {
   }
 })
 
-test('doctor.runDiagnostics does not modify config files', () => {
+test('doctor.runDiagnostics does not modify config files', async () => {
   const candidates = config.getConfigCandidates()
 
   // Get checksums of existing files
@@ -182,7 +187,7 @@ test('doctor.runDiagnostics does not modify config files', () => {
   }
 
   // Run diagnostics
-  doctor.runDiagnostics(false)
+  await doctor.runDiagnostics(false, NO_DAEMON)
 
   // Verify files haven't changed
   for (const candidate in checksums) {


### PR DESCRIPTION
## Summary

Finishes installer improvements #1–#3 on top of #606. The one step the installer can't click for the user — loading the unpacked extension — is now **confirmed**: after install we start the daemon and poll `/health` (`capture.extension_connected`) with live status and a targeted timeout hint.

### #1 Connect confirmation loop (both channels)
- `lib/health.js`: `fetchHealth`/`summarizeHealth` (pure), `waitForExtension` (deterministic under an injected clock), `connectHint`, `connectWaitDisabled`.
- `lib/daemon.js`: `startDaemon`/`ensureDaemon` — **npm `--install` now starts the daemon** (parity with the curl|sh installer's `startDaemonSilently`); `ensureDaemon` reuses a healthy daemon instead of double-binding. Opt out with `KABOOM_NO_DAEMON`.
- `native_install_connect.go`: post-`startDaemonSilently` connect loop for the curl|sh channel; injectable clock/fetch/sink → unit-tested with no real daemon/timers.
- New `--connect` command re-runs the loop on demand.

### #2 Browser-aware page open
- `lib/browser.js`: detects Chrome/Brave/Edge/Arc/Chromium and opens its extensions page (`chrome://`/`brave://`/`edge://extensions`) — the folder opener can't, since those are browser-internal URLs.

### #3 `--doctor` real diagnosis
- `lib/doctor.js` (now async): live Node-floor, daemon reachability, and extension connectivity checks; `output.js` renders them.

### Cross-cutting
- One shared opt-out grammar: `isEnvFlagSet` (JS) / `envFlagEnabled` (Go); refactored existing `autoOpenDisabled` onto it. Opt-outs: `KABOOM_NO_DAEMON`, `KABOOM_NO_WAIT`, `KABOOM_NO_OPEN`.
- **Interactive (TTY) gating**: blocking wait + browser-open fire only on a TTY, so scripted/CI installs never hang or pop windows. `/health` is *consumed*, not modified → zero wire drift.
- Docs cross-ref contract satisfied (canonical flow map + feature pointer + index code/test paths).

## Tests
New: health 14, browser 8, daemon 7, doctor 5, Go connect 7. Converted `tests/cli/doctor.test.cjs` to async; made `cli-integration` harness hermetic.
Green locally: npm wrapper **136/136**, `go test ./cmd/browser-agent` full package + `go vet`, doctor integration **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)