### PR TITLE
fix(test): qualify window as globalThis.window in annotation regression test (green Security Scan + JS Checks)

### DIFF
--- a/tests/extension/tracked-hover-launcher.test.js
+++ b/tests/extension/tracked-hover-launcher.test.js
@@ -498,16 +498,16 @@ describe('tracked hover launcher', () => {
     // Net add/remove for the annotation event proves it is still installed. Old
     // code: added on mount, removed on unmount -> net 0. Fixed: added once at
     // enable, never removed on unmount -> net 1.
-    const added = window.addEventListener.mock.calls.filter(
+    const added = globalThis.window.addEventListener.mock.calls.filter(
       (c) => c.arguments[0] === 'kaboom-annotations-ready'
     ).length
-    const removed = window.removeEventListener.mock.calls.filter(
+    const removed = globalThis.window.removeEventListener.mock.calls.filter(
       (c) => c.arguments[0] === 'kaboom-annotations-ready'
     ).length
     assert.strictEqual(added - removed, 1, 'annotation listener must remain installed while the terminal panel is open')
 
     // Firing the submit event now writes a prompt into the open panel.
-    const handlerCall = window.addEventListener.mock.calls.find((c) => c.arguments[0] === 'kaboom-annotations-ready')
+    const handlerCall = globalThis.window.addEventListener.mock.calls.find((c) => c.arguments[0] === 'kaboom-annotations-ready')
     handlerCall.arguments[1]({
       detail: {
         annotations: [{ text: 'Make the header bigger', selector: 'h1', rect: { x: 1, y: 2, width: 3, height: 4 } }],


### PR DESCRIPTION
## Summary
The annotation→terminal regression test added in #609 referenced bare `window`, which the `tests/extension` ESLint config flags as `no-undef` (browser globals aren't declared there; the harness assigns `globalThis.window`). This turned the **Security Scan** and **JavaScript Checks** ESLint steps red on STABLE (both non-required, so #609/#610 auto-merged past them).

Fix: reference `globalThis.window.{add,remove}EventListener` to match the harness. No behavior change — the regression test still passes.

## Verified
- `npx eslint extension/ tests/extension/ --max-warnings=50` → clean (the exact Security Scan command)
- `npm run lint` (eslint .) → clean
- Regression test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)