### PR TITLE
ci(release): one-click manual release workflow + hardened sync-version

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,166 @@
+name: Cut Release
+
+# One-click, manually-triggered release. Does everything:
+#   bump VERSION -> sync all version files -> recompile bundle -> validate ->
+#   test (go + ext + wire drift) -> commit + push STABLE + tag -> build & publish.
+#
+# Publishing is delegated to the reusable release-publish.yml (same pipeline the
+# tag-triggered release.yml uses), invoked directly here — we do NOT rely on the
+# tag-push event, because a tag pushed with the default GITHUB_TOKEN does not
+# trigger other workflows. No PAT or extra secret is required.
+#
+# Prereq: STABLE is not branch-protected, so this workflow pushes the bump commit
+# and tag straight to STABLE with the built-in GITHUB_TOKEN.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target release version (no leading v), e.g. 0.8.7'
+        required: true
+        type: string
+      dry_run:
+        description: 'Prepare + validate + test only; do NOT commit, tag, or publish'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  prepare:
+    name: Bump, validate & test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - name: Guard — must run on STABLE
+        if: github.ref != 'refs/heads/STABLE'
+        run: |
+          echo "❌ cut-release must be run from the STABLE branch (got ${{ github.ref }})."
+          echo "   Re-run this workflow with 'Use workflow from: STABLE'."
+          exit 1
+
+      - name: Checkout STABLE
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: STABLE
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.24.13'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Validate target version
+        id: check
+        env:
+          TARGET: ${{ inputs.version }}
+        run: |
+          if ! [[ "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Not strict semver: '$TARGET' (expected X.Y.Z)"; exit 1
+          fi
+          CURRENT=$(tr -d '[:space:]' < VERSION)
+          echo "Current: $CURRENT  Target: $TARGET"
+          if [ "$TARGET" = "$CURRENT" ]; then
+            echo "❌ Target equals current version ($CURRENT). Nothing to release."; exit 1
+          fi
+          # Reject downgrades: highest of {current,target} must be target.
+          HIGHEST=$(printf '%s\n%s\n' "$CURRENT" "$TARGET" | sort -V | tail -1)
+          if [ "$HIGHEST" != "$TARGET" ]; then
+            echo "❌ Version regression: $CURRENT -> $TARGET"; exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/v$TARGET" | grep -q .; then
+            echo "❌ Tag v$TARGET already exists on origin. Pick a new version."; exit 1
+          fi
+
+      - name: Bump version everywhere
+        id: bump
+        env:
+          TARGET: ${{ inputs.version }}
+        run: |
+          printf '%s' "$TARGET" > VERSION
+          make sync-version
+          make compile-ts
+          echo "version=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version consistency (fail closed)
+        run: bash scripts/validate-versions.sh
+
+      - name: Wire drift gate (Go <-> TS payload contracts)
+        run: |
+          make check-wire-drift
+          node scripts/check-sync-wire-drift.js
+
+      - name: Go tests (short)
+        run: go test -short ./...
+
+      - name: JS tests
+        run: npm run test:ext
+
+      # --- Dry run: show the diff, stop before any mutation ------------------
+      - name: Upload prepared diff (dry-run artifact)
+        if: ${{ inputs.dry_run }}
+        run: |
+          git diff > /tmp/cut-release-${{ inputs.version }}.diff
+          echo "Dry run — prepared bump for v${{ inputs.version }}. Diff:"
+          git --no-pager diff --stat
+
+      - name: Store dry-run diff
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cut-release-${{ inputs.version }}-diff
+          path: /tmp/cut-release-${{ inputs.version }}.diff
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "## 🧪 Dry run for v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Bump prepared, validated, and tested. Nothing committed, tagged, or published." >> "$GITHUB_STEP_SUMMARY"
+          echo "Re-run with dry_run unchecked to cut the release." >> "$GITHUB_STEP_SUMMARY"
+
+      # --- Real run: commit, push STABLE, tag --------------------------------
+      - name: Commit, push STABLE, and tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          TARGET: ${{ inputs.version }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Stage tracked modifications only (a version bump never adds new files);
+          # this keeps any stray generated/untracked file out of the release commit.
+          git add -u
+          git commit -m "release: bump to $TARGET"
+          git push origin HEAD:STABLE
+          git tag "v$TARGET"
+          git push origin "v$TARGET"
+
+      - name: Release-cut summary
+        if: ${{ !inputs.dry_run }}
+        run: |
+          echo "## 🏷️ Cut v${{ inputs.version }} on STABLE" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Bumped, validated, tested, committed, pushed, and tagged. Publishing next…" >> "$GITHUB_STEP_SUMMARY"
+
+  # Delegates to the same pipeline the tag-triggered release.yml uses.
+  publish:
+    name: Publish
+    needs: prepare
+    if: ${{ !inputs.dry_run }}
+    uses: ./.github/workflows/release-publish.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,156 @@
+name: Release Publish (reusable)
+
+# Reusable build + publish pipeline. Called by:
+#   - release.yml         (tag push  v*.*.* on STABLE)
+#   - cut-release.yml     (manual one-click release)
+# Behavior is identical to the old inline release.yml build-and-release job; the
+# only additions are the `version` input and an explicit tag_name on the GitHub
+# Release (so it works when invoked from a branch dispatch, not just a tag ref).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version (no leading v), e.g. 0.8.7'
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-release:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the release tag
+        # Pin to the tag (not github.sha): when called from cut-release.yml the
+        # dispatch's github.sha is STABLE *before* the bump commit, so building
+        # that would produce the previous version. The tag always points at the
+        # bump commit for both callers.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.24.13'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build all platform binaries
+        run: make build
+        env:
+          VERSION: ${{ inputs.version }}
+
+      - name: Verify binary version
+        run: |
+          ./dist/kaboom-agentic-browser-linux-x64 --version
+          BINARY_VERSION=$(./dist/kaboom-agentic-browser-linux-x64 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          EXPECTED="${{ inputs.version }}"
+
+          if [ "$BINARY_VERSION" != "$EXPECTED" ]; then
+            echo "❌ Binary version mismatch: $BINARY_VERSION (expected $EXPECTED)"
+            exit 1
+          fi
+
+          echo "✅ Binary version verified: $BINARY_VERSION"
+
+      - name: Compile TypeScript
+        run: make compile-ts
+
+      # Stages kaboom-agentic-browser + kaboom-hooks binaries into npm/*/bin/
+      # using the names whitelisted by each platform package's "files" field.
+      - name: Stage package binaries
+        run: make npm-binaries
+
+      - name: Publish packages
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+
+          # Publish platform packages first
+          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
+            echo "Publishing platform package: $pkg"
+            cd npm/$pkg
+            set +e
+            OUTPUT=$(npm publish --access public 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ $STATUS -ne 0 ]; then
+              if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
+                echo "Platform package already published for $pkg; continuing."
+              else
+                exit $STATUS
+              fi
+            fi
+            cd ../..
+          done
+
+          # Publish main package last
+          echo "Publishing aggregate package"
+          cd npm/kaboom-agentic-browser
+          set +e
+          OUTPUT=$(npm publish --access public 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $STATUS -ne 0 ]; then
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
+              echo "Aggregate package already published; continuing."
+            else
+              exit $STATUS
+            fi
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build extension zip
+        run: make extension-zip
+
+      - name: Generate checksums manifest
+        run: make checksums
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        with:
+          tag_name: v${{ inputs.version }}
+          files: |
+            dist/kaboom-agentic-browser-darwin-arm64
+            dist/kaboom-agentic-browser-darwin-x64
+            dist/kaboom-agentic-browser-linux-arm64
+            dist/kaboom-agentic-browser-linux-x64
+            dist/kaboom-agentic-browser-win32-x64.exe
+            dist/kaboom-hooks-darwin-arm64
+            dist/kaboom-hooks-darwin-x64
+            dist/kaboom-hooks-linux-arm64
+            dist/kaboom-hooks-linux-x64
+            dist/kaboom-hooks-win32-x64.exe
+            dist/kaboom-extension-v*.zip
+            dist/checksums.txt
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          VERSION="${{ inputs.version }}"
+          echo "## 🚀 Release v$VERSION Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Package Publication" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Platform and aggregate packages published for v$VERSION." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,137 +115,17 @@ jobs:
       - name: JS tests
         run: npm run test:ext
 
-  # Step 4: Build and publish
+  # Step 4: Build and publish (delegated to the reusable pipeline shared with
+  # cut-release.yml so both entry points build & publish identically).
   build-and-release:
     name: Build & Publish
-    runs-on: ubuntu-latest
     needs: [verify-tag, test]
     if: needs.verify-tag.result == 'success' && needs.test.result == 'success'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: '1.24.13'
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
-      # CRX build removed (requires local Chrome signing key)
-      
-      - name: Install Node dependencies
-        run: npm ci
-
-      - name: Build all platform binaries
-        run: make build
-        env:
-          VERSION: ${{ needs.verify-tag.outputs.version }}
-
-      - name: Verify binary version
-        run: |
-          ./dist/kaboom-agentic-browser-linux-x64 --version
-          BINARY_VERSION=$(./dist/kaboom-agentic-browser-linux-x64 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          EXPECTED="${{ needs.verify-tag.outputs.version }}"
-
-          if [ "$BINARY_VERSION" != "$EXPECTED" ]; then
-            echo "❌ Binary version mismatch: $BINARY_VERSION (expected $EXPECTED)"
-            exit 1
-          fi
-
-          echo "✅ Binary version verified: $BINARY_VERSION"
-
-      - name: Compile TypeScript
-        run: make compile-ts
-
-      # CRX build removed (requires local Chrome signing key)
-
-      # Stages kaboom-agentic-browser + kaboom-hooks binaries into npm/*/bin/
-      # using the names whitelisted by each platform package's "files" field.
-      - name: Stage package binaries
-        run: make npm-binaries
-
-      - name: Publish packages
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-
-          # Publish platform packages first
-          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
-            echo "Publishing platform package: $pkg"
-            cd npm/$pkg
-            set +e
-            OUTPUT=$(npm publish --access public 2>&1)
-            STATUS=$?
-            set -e
-            echo "$OUTPUT"
-            if [ $STATUS -ne 0 ]; then
-              if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
-                echo "Platform package already published for $pkg; continuing."
-              else
-                exit $STATUS
-              fi
-            fi
-            cd ../..
-          done
-
-          # Publish main package last
-          echo "Publishing aggregate package"
-          cd npm/kaboom-agentic-browser
-          set +e
-          OUTPUT=$(npm publish --access public 2>&1)
-          STATUS=$?
-          set -e
-          echo "$OUTPUT"
-          if [ $STATUS -ne 0 ]; then
-            if echo "$OUTPUT" | grep -q "cannot publish over the previously published versions"; then
-              echo "Aggregate package already published; continuing."
-            else
-              exit $STATUS
-            fi
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Build extension zip
-        run: make extension-zip
-
-      - name: Generate checksums manifest
-        run: make checksums
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
-        with:
-          files: |
-            dist/kaboom-agentic-browser-darwin-arm64
-            dist/kaboom-agentic-browser-darwin-x64
-            dist/kaboom-agentic-browser-linux-arm64
-            dist/kaboom-agentic-browser-linux-x64
-            dist/kaboom-agentic-browser-win32-x64.exe
-            dist/kaboom-hooks-darwin-arm64
-            dist/kaboom-hooks-darwin-x64
-            dist/kaboom-hooks-linux-arm64
-            dist/kaboom-hooks-linux-x64
-            dist/kaboom-hooks-win32-x64.exe
-            dist/kaboom-extension-v*.zip
-            dist/checksums.txt
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Summary
-        run: |
-          VERSION="${{ needs.verify-tag.outputs.version }}"
-          echo "## 🚀 Release v$VERSION Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Package Publication" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- Platform and aggregate packages published for v$VERSION." >> $GITHUB_STEP_SUMMARY
+    uses: ./.github/workflows/release-publish.yml
+    with:
+      version: ${{ needs.verify-tag.outputs.version }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   skip-nonstable-tag:
     name: Skip Non-STABLE Tags

--- a/Makefile
+++ b/Makefile
@@ -468,22 +468,35 @@ release-gate: quality-gate test-upgrade-guards
 # Update all version references to match VERSION (single source of truth)
 sync-version:
 	@echo "Syncing version to $(VERSION)..."
-	@# JSON "version" fields
+	@# JSON "version" fields. These files hold exactly one "version" (their own),
+	@# so a blanket match is safe. package-lock.json is handled structurally below
+	@# because it also carries dependency "version" fields that must NOT change.
 	@perl -pi -e 's/"version": "[0-9]+\.[0-9]+\.[0-9]+"/"version": "$(VERSION)"/g' \
+			package.json \
 			extension/manifest.json extension/package.json server/package.json \
 			npm/kaboom-agentic-browser/package.json npm/darwin-x64/package.json \
 			npm/darwin-arm64/package.json npm/linux-x64/package.json \
 			npm/linux-arm64/package.json npm/win32-x64/package.json \
+			packages/kaboom-ci/package.json packages/kaboom-playwright/package.json \
 			$(CMD_DIR)/testdata/mcp-initialize.golden.json
-	@# NPM optionalDependencies versions
-	@perl -pi -e 's/("@brennhill\/kaboom-[^"]+": ")[0-9]+\.[0-9]+\.[0-9]+(")/$${1}$(VERSION)$$2/g' \
+	@# root package-lock.json: update ONLY the package's own version (top-level and
+	@# packages[""]) — never the nested dependency versions. Structural JSON edit
+	@# preserves npm's 2-space + trailing-newline formatting (zero-dep node built-ins).
+	@node -e 'const fs=require("fs"),f="package-lock.json",j=JSON.parse(fs.readFileSync(f,"utf8"));j.version="$(VERSION)";if(j.packages&&j.packages[""])j.packages[""].version="$(VERSION)";fs.writeFileSync(f,JSON.stringify(j,null,2)+"\n")'
+	@# NPM optionalDependencies versions. NOTE: the "@" MUST be escaped (\@) — an
+	@# unescaped @brennhill is parsed by perl as array interpolation and silently
+	@# empties the pattern, so the substitution no-ops. Same for \@anthropic below.
+	@perl -pi -e 's/("\@brennhill\/kaboom-[^"]+": ")[0-9]+\.[0-9]+\.[0-9]+(")/$${1}$(VERSION)$$2/g' \
 		npm/kaboom-agentic-browser/package.json
+	@# kaboom-playwright pins @anthropic/kaboom-ci to the release version.
+	@perl -pi -e 's/("\@anthropic\/kaboom-ci": ")[0-9]+\.[0-9]+\.[0-9]+(")/$${1}$(VERSION)$$2/g' \
+		packages/kaboom-playwright/package.json
 	@# PyPI sync removed: pypi/ packaging tree no longer exists in this repo.
-	@# JS version strings
+	@# JS version strings. (Legacy tests/extension/{popup,background}.test.js were
+	@# removed; the current extension version flows through esbuild's
+	@# __KABOOM_VERSION__ define at bundle time, so no test-file edit is needed.)
 	@perl -pi -e "s/version: '[0-9]+\.[0-9]+\.[0-9]+'/version: '$(VERSION)'/g" \
-		extension/inject.js tests/extension/popup.test.js
-	@perl -pi -e "s/(parsed\.version, )'[0-9]+\.[0-9]+\.[0-9]+'/\$$1'$(VERSION)'/g" \
-		tests/extension/background.test.js
+		extension/inject.js
 	@perl -pi -e "s/VERSION = '[0-9]+\.[0-9]+\.[0-9]+'/VERSION = '$(VERSION)'/g" \
 		server/scripts/install.js
 	@# Go version fallback (both binaries)

--- a/docs/core/release.md
+++ b/docs/core/release.md
@@ -175,6 +175,32 @@ make check-wire-drift
 node scripts/check-sync-wire-drift.js
 ```
 
+## One-Click Release (recommended)
+
+Once `STABLE` holds everything you want to ship, the entire release is a single
+manual CI trigger — the [`Cut Release`](../../.github/workflows/cut-release.yml)
+workflow (`workflow_dispatch`, run it **from the STABLE branch**):
+
+1. Actions → **Cut Release** → *Run workflow* → set **`version`** (e.g. `0.8.7`),
+   leave **`dry_run`** unchecked (or check it for a no-mutation preview).
+2. It does everything: bump `VERSION` → `make sync-version` → `make compile-ts` →
+   `validate-versions.sh` → wire-drift gate → `go test -short` → `npm run test:ext`
+   → commit + push `STABLE` + tag `v<version>` → build 5 platforms → publish npm
+   (platform + aggregate) → GitHub Release.
+
+Publishing is delegated to the reusable
+[`release-publish.yml`](../../.github/workflows/release-publish.yml) — the same
+pipeline the tag-triggered `release.yml` uses, so both paths build and publish
+identically. No PAT or extra secret is needed (it pushes to the unprotected
+`STABLE` with the built-in `GITHUB_TOKEN` and invokes the publish pipeline
+directly rather than via the tag event).
+
+**Dry run:** check `dry_run` to bump + validate + test and upload the prepared
+`git diff` as an artifact — nothing is committed, tagged, or published.
+
+The manual checklist below is the equivalent by-hand procedure (and how to reason
+about each gate); the one-click workflow performs exactly these steps.
+
 ## Release Checklist
 
 When `UNSTABLE` is stable and ready for release:
@@ -224,12 +250,11 @@ bash scripts/validate-versions.sh
 | `README.md` | version badge + prose |
 | `cmd/browser-agent/testdata/mcp-initialize.golden.json` | `"VERSION"` placeholder (stays literal) |
 
-> **⚠️ `optionalDependencies` gotcha:** the five `@brennhill/kaboom-agentic-browser-*`
+> **`optionalDependencies`:** the five `@brennhill/kaboom-agentic-browser-*`
 > entries in `npm/kaboom-agentic-browser/package.json` MUST equal the wrapper
-> version, or npx installs old binaries. `make sync-version` does not currently
-> cover the root `package.json`, `package-lock.json`, or `packages/kaboom-*` —
-> update those by hand until the target is hardened, then re-run
-> `validate-versions.sh`.
+> version, or npx installs old binaries. `make sync-version` now covers these plus
+> the root `package.json`, `package-lock.json` (own version only), and
+> `packages/kaboom-*` — so `validate-versions.sh` passes with no manual edits.
 
 Commit the bump to a `release/<version>` branch and merge it to `STABLE` via PR.
 


### PR DESCRIPTION
## Summary

Turns the whole release into a single manual CI trigger, per request. Also hardens `make sync-version` so the bump needs zero by-hand edits (the prerequisite that made 0.8.6 partly manual).

### New: `Cut Release` (`cut-release.yml`, workflow_dispatch)
Run from **STABLE** with a `version` input. It does everything:

`bump VERSION → make sync-version → make compile-ts → validate-versions.sh → wire-drift gate → go test -short → npm run test:ext → commit + push STABLE + tag → build 5 platforms → publish npm (platform + aggregate) → GitHub Release`

- **`dry_run`** input: prepare + validate + test, upload the `git diff` artifact, **no** commit/tag/publish.
- Guards: strict-semver, no downgrade/equal, tag-not-already-present, must run on STABLE.

### New: `release-publish.yml` (reusable, `workflow_call`)
The build+publish pipeline, extracted from `release.yml`'s old `build-and-release` job **verbatim** (behavior-preserving). Now called by **both** `release.yml` (tag push) and `cut-release.yml`, so both paths build & publish identically.

### Changed: `release.yml`
`build-and-release` is now a `uses:` call to `release-publish.yml` — same steps, one source of truth.

### Why no PAT / how publish is triggered
STABLE is **not** branch-protected, so `cut-release` pushes the bump commit + tag with the built-in `GITHUB_TOKEN`. A tag pushed by `GITHUB_TOKEN` does **not** trigger `release.yml`, so publishing is invoked **directly** via the reusable workflow instead of relying on the tag event. The reusable workflow checks out the **tag** (not `github.sha`) so a branch dispatch still builds the bump commit.

### Hardened `make sync-version`
Now covers everything `validate-versions.sh` checks, with **zero** manual edits:
- adds root `package.json`, `packages/kaboom-ci`, `packages/kaboom-playwright` (+ `@anthropic/kaboom-ci` pin)
- updates `package-lock.json`'s **own** version structurally (never dependency versions)
- **fixes a real bug:** the optionalDeps perl left `@brennhill`/`@anthropic` unescaped — perl parses the unescaped `@` as array interpolation and silently empties the pattern, so the substitution no-oped. This is exactly why 0.8.6's `optionalDependencies` had to be fixed by hand. Escaped as `\@`.
- drops the two removed test files it errored on

## Test plan
- ✅ Hardened `make sync-version` on a throwaway `0.8.7` bump → `validate-versions.sh` **all green, no manual edits**; `package-lock.json` diff is exactly its two own-version lines (no dep corruption). Reverted.
- ✅ All three workflow YAMLs parse; action SHAs match the repo's existing pins.
- ✅ `release.md` links resolve.
- ▶️ **After merge:** run `Cut Release` with **`dry_run` checked** first to exercise the full prepare path (bump/validate/test) with no side effects, then a real cut when ready.

## Notes
- No new secrets. Publishing still uses the existing `NPM_TOKEN` repo secret.
- The tag-triggered `release.yml` path is unchanged in behavior (just refactored to share the pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)