### PR TITLE
fix(daemon): stop the crash-loop — SIGPIPE death, install-epoch tiebreaker, respawn + restart throttles

### DIFF
--- a/cmd/browser-agent/daemon_install_epoch_test.go
+++ b/cmd/browser-agent/daemon_install_epoch_test.go
@@ -1,0 +1,173 @@
+// Tests for the install-epoch "latest install always wins" takeover tiebreaker.
+// At the SAME version, a strictly newer install epoch supersedes an older one, so
+// two same-version installs (e.g. ~/.kaboom/bin vs an npm-global copy) resolve a
+// deterministic winner instead of thrashing.
+// Docs: docs/features/feature/mcp-persistent-server/index.md
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// --- computeInstallEpoch ------------------------------------------------------
+
+func TestComputeInstallEpoch_StampFileWins(t *testing.T) {
+	exe := func() (string, error) { return "/opt/app/bin/kaboom", nil }
+	stat := func(string) (os.FileInfo, error) {
+		t.Fatal("stat should not be reached when stamp is valid")
+		return nil, nil
+	}
+	readFile := func(p string) ([]byte, error) {
+		if p != filepath.Join("/opt/app/bin", installEpochStampName) {
+			t.Fatalf("read wrong path: %s", p)
+		}
+		return []byte("  1730000000123456789\n"), nil
+	}
+	if got := computeInstallEpoch(exe, stat, readFile); got != 1730000000123456789 {
+		t.Fatalf("want stamp value, got %d", got)
+	}
+}
+
+func TestComputeInstallEpoch_FallsBackToBinaryMtime(t *testing.T) {
+	mtime := time.Date(2026, 7, 26, 1, 2, 3, 456, time.UTC)
+	exe := func() (string, error) { return "/x/kaboom", nil }
+	stat := func(string) (os.FileInfo, error) { return fakeFileInfo{mod: mtime}, nil }
+	readFile := func(string) ([]byte, error) { return nil, os.ErrNotExist }
+	if got := computeInstallEpoch(exe, stat, readFile); got != mtime.UnixNano() {
+		t.Fatalf("want mtime nanos %d, got %d", mtime.UnixNano(), got)
+	}
+}
+
+func TestComputeInstallEpoch_InvalidStampFallsBackToMtime(t *testing.T) {
+	mtime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	exe := func() (string, error) { return "/x/kaboom", nil }
+	stat := func(string) (os.FileInfo, error) { return fakeFileInfo{mod: mtime}, nil }
+	readFile := func(string) ([]byte, error) { return []byte("not-a-number"), nil }
+	if got := computeInstallEpoch(exe, stat, readFile); got != mtime.UnixNano() {
+		t.Fatalf("invalid stamp should fall back to mtime; got %d", got)
+	}
+}
+
+func TestComputeInstallEpoch_NoExecutable_ReturnsZero(t *testing.T) {
+	exe := func() (string, error) { return "", os.ErrNotExist }
+	stat := func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	readFile := func(string) ([]byte, error) { return nil, os.ErrNotExist }
+	if got := computeInstallEpoch(exe, stat, readFile); got != 0 {
+		t.Fatalf("want 0 when executable unknown, got %d", got)
+	}
+}
+
+// --- sameNonEmptyVersion ------------------------------------------------------
+
+func TestSameNonEmptyVersion(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.8.8", "0.8.8", true},
+		{"v0.8.8", "0.8.8", true},
+		{"0.8.8", "0.9.0", false},
+		{"0.9.0", "0.8.8", false},
+		{"", "0.8.8", false},
+		{"0.8.8", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		if got := sameNonEmptyVersion(c.a, c.b); got != c.want {
+			t.Errorf("sameNonEmptyVersion(%q,%q)=%v want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// --- classifyExistingDaemon epoch tiebreaker ----------------------------------
+
+func TestClassifyExistingDaemon_InstallEpoch(t *testing.T) {
+	server, err := NewServer(filepath.Join(t.TempDir(), "epoch.log"), 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	oldNow, oldProbe, oldSleep, oldVer, oldEpoch := daemonNow, daemonProbeHealth, daemonSleep, version, daemonInstallEpoch
+	defer func() {
+		daemonNow, daemonProbeHealth, daemonSleep, version, daemonInstallEpoch = oldNow, oldProbe, oldSleep, oldVer, oldEpoch
+	}()
+	daemonNow = func() time.Time { return base }
+	daemonSleep = func(time.Duration) {}
+	version = "0.8.8"
+
+	// A record written a minute ago (outside grace) at the same version, with a
+	// given install epoch.
+	lock := func(epoch int64) *daemonLockRecord {
+		return &daemonLockRecord{
+			PID: 1, Port: 7890, Version: "0.8.8", InstallEpoch: epoch,
+			UpdatedAt: base.Add(-time.Minute).Format(time.RFC3339),
+		}
+	}
+	// A record written just now (inside the 5s grace window).
+	youngLock := func(epoch int64) *daemonLockRecord {
+		return &daemonLockRecord{
+			PID: 1, Port: 7890, Version: "0.8.8", InstallEpoch: epoch,
+			UpdatedAt: base.Add(-time.Second).Format(time.RFC3339),
+		}
+	}
+
+	t.Run("same version, NEWER install epoch -> take over (latest install wins)", func(t *testing.T) {
+		daemonInstallEpoch = func() int64 { return 2000 }
+		daemonProbeHealth = func(int) (bool, string, bool) { return true, "0.8.8", false } // incumbent is healthy
+		if err := classifyExistingDaemon(server, 7890, lock(1000)); err != nil {
+			t.Fatalf("newer install should take over a healthy same-version incumbent, got %v", err)
+		}
+	})
+
+	t.Run("same version, OLDER install epoch, healthy -> defer", func(t *testing.T) {
+		daemonInstallEpoch = func() int64 { return 1000 }
+		daemonProbeHealth = func(int) (bool, string, bool) { return true, "0.8.8", false }
+		if err := classifyExistingDaemon(server, 7890, lock(2000)); !errors.Is(err, errDeferToHealthyDaemon) {
+			t.Fatalf("older install must defer to a healthy newer install, got %v", err)
+		}
+	})
+
+	t.Run("same version, EQUAL install epoch, healthy -> defer (no thrash)", func(t *testing.T) {
+		daemonInstallEpoch = func() int64 { return 1000 }
+		daemonProbeHealth = func(int) (bool, string, bool) { return true, "0.8.8", false }
+		if err := classifyExistingDaemon(server, 7890, lock(1000)); !errors.Is(err, errDeferToHealthyDaemon) {
+			t.Fatalf("equal epoch must defer (never ping-pong same install), got %v", err)
+		}
+	})
+
+	t.Run("newer install epoch fires even inside the startup grace window", func(t *testing.T) {
+		daemonInstallEpoch = func() int64 { return 2000 }
+		// No health probe needed — epoch takeover uses the registered record.
+		daemonProbeHealth = func(int) (bool, string, bool) {
+			t.Fatal("should not probe: epoch decides first")
+			return false, "", false
+		}
+		if err := classifyExistingDaemon(server, 7890, youngLock(1000)); err != nil {
+			t.Fatalf("newer install should supersede even a just-started older one, got %v", err)
+		}
+	})
+
+	t.Run("our epoch 0 (unknown) never takes over on epoch alone", func(t *testing.T) {
+		daemonInstallEpoch = func() int64 { return 0 }
+		daemonProbeHealth = func(int) (bool, string, bool) { return true, "0.8.8", false }
+		if err := classifyExistingDaemon(server, 7890, lock(0)); !errors.Is(err, errDeferToHealthyDaemon) {
+			t.Fatalf("unknown epoch must not trigger takeover; got %v", err)
+		}
+	})
+}
+
+// fakeFileInfo is a minimal os.FileInfo for mtime-based tests.
+type fakeFileInfo struct{ mod time.Time }
+
+func (f fakeFileInfo) Name() string       { return "kaboom" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0o755 }
+func (f fakeFileInfo) ModTime() time.Time { return f.mod }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }

--- a/cmd/browser-agent/daemon_lifecycle.go
+++ b/cmd/browser-agent/daemon_lifecycle.go
@@ -24,6 +24,9 @@ type daemonLockRecord struct {
 	StateDir  string `json:"state_dir"`
 	Version   string `json:"version,omitempty"`
 	UpdatedAt string `json:"updated_at"`
+	// InstallEpoch is the writer's install epoch (see install_epoch.go). At the same
+	// version it is the takeover tiebreaker: a strictly newer epoch supersedes.
+	InstallEpoch int64 `json:"install_epoch,omitempty"`
 }
 
 var (
@@ -35,6 +38,9 @@ var (
 	daemonNow                = time.Now
 	daemonFindProcessOnPort  = findProcessOnPort
 	daemonSleep              = time.Sleep
+	// daemonInstallEpoch reports THIS daemon's install epoch (the takeover
+	// tiebreaker at equal versions). Injectable for tests.
+	daemonInstallEpoch = resolveInstallEpoch
 
 	// daemonProbeHealth reports whether the daemon on port answers /health, its
 	// reported version, and whether the failure was connection-refused (nothing
@@ -96,6 +102,25 @@ func classifyExistingDaemon(server *Server, port int, rec *daemonLockRecord) err
 			"our_version":      version,
 		})
 		return nil
+	}
+
+	// Same version, but a strictly NEWER install supersedes an older one — the
+	// "latest install always wins" tiebreaker (install_epoch.go). Without it, two
+	// same-version installs (e.g. ~/.kaboom/bin vs an npm-global copy) have no way to
+	// pick a winner and thrash. Uses the registered epoch (no /health round-trip),
+	// and fires before the startup-grace defer so a fresh install takes over at once.
+	// An equal-or-older epoch never reaches the takeover here, so this cannot
+	// ping-pong: the older install always defers to the newer one.
+	if sameNonEmptyVersion(version, rec.Version) {
+		if ourEpoch := daemonInstallEpoch(); ourEpoch > 0 && ourEpoch > rec.InstallEpoch {
+			server.logLifecycle("daemon_takeover_newer_install", port, map[string]any{
+				"existing_pid":           rec.PID,
+				"existing_install_epoch": rec.InstallEpoch,
+				"our_install_epoch":      ourEpoch,
+				"version":                version,
+			})
+			return nil
+		}
 	}
 
 	// Not a known upgrade. Never kill a daemon that only just registered — it may

--- a/cmd/browser-agent/daemon_lifecycle.go
+++ b/cmd/browser-agent/daemon_lifecycle.go
@@ -141,10 +141,16 @@ func classifyExistingDaemon(server *Server, port int, rec *daemonLockRecord) err
 	}
 
 	// Probe liveness, retried across the window so a momentarily busy-but-healthy
-	// daemon answers before we ever conclude it is stalled. But a connection-refused
-	// probe means nothing is listening — the daemon is definitively gone, not busy —
-	// so break immediately instead of burning the retry budget's sleeps on a
-	// certainty (finding L). Only a timeout/ambiguous failure warrants a retry.
+	// daemon answers before we ever conclude it is stalled. A connection-refused
+	// probe means nothing is accepting on the port right now — but that is only
+	// DEFINITIVE ("gone") when the incumbent PID is ALSO dead, in which case we break
+	// immediately instead of burning the retry budget's sleeps on a certainty
+	// (finding L's fast path). A refused probe while the PID is still ALIVE is NOT
+	// proof of death: a healthy daemon can transiently refuse (listen backlog full)
+	// or be mid graceful-shutdown, so we retry rather than SIGTERM a live, healthy
+	// peer on a single stray refusal (which would feed the takeover war). A
+	// persistently-wedged live daemon is still reclaimed once the retry budget is
+	// exhausted below.
 	reachable := false
 	liveVersion := ""
 	for attempt := 0; attempt < daemonHealthProbeRetries; attempt++ {
@@ -152,7 +158,7 @@ func classifyExistingDaemon(server *Server, port int, rec *daemonLockRecord) err
 		if reachable, liveVersion, refused = daemonProbeHealth(rec.Port); reachable {
 			break
 		}
-		if refused {
+		if refused && !daemonIsProcessAlive(rec.PID) {
 			break
 		}
 		if attempt < daemonHealthProbeRetries-1 {

--- a/cmd/browser-agent/daemon_lifecycle_takeover_test.go
+++ b/cmd/browser-agent/daemon_lifecycle_takeover_test.go
@@ -18,20 +18,26 @@ func TestClassifyExistingDaemon(t *testing.T) {
 	}
 
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	oldNow, oldProbe, oldSleep, oldVer := daemonNow, daemonProbeHealth, daemonSleep, version
+	oldNow, oldProbe, oldSleep, oldVer, oldEpoch := daemonNow, daemonProbeHealth, daemonSleep, version, daemonInstallEpoch
 	defer func() {
 		daemonNow = oldNow
 		daemonProbeHealth = oldProbe
 		daemonSleep = oldSleep
 		version = oldVer
+		daemonInstallEpoch = oldEpoch
 	}()
 	daemonNow = func() time.Time { return base }
 	daemonSleep = func(time.Duration) {} // never really sleep in tests
 	version = "0.8.7"
+	// Neutralize the install-epoch tiebreaker for these version/grace/health cases:
+	// our epoch equals every lock's epoch, so same-version behavior is decided by the
+	// existing rules (not "latest install wins", which has its own test).
+	daemonInstallEpoch = func() int64 { return 1000 }
 
-	// Lock written a minute ago => outside the startup grace window.
+	// Lock written a minute ago => outside the startup grace window. Epoch matches
+	// ours (neutral tiebreaker).
 	oldLock := func(v string) *daemonLockRecord {
-		return &daemonLockRecord{PID: 1, Port: 7890, Version: v, UpdatedAt: base.Add(-time.Minute).Format(time.RFC3339)}
+		return &daemonLockRecord{PID: 1, Port: 7890, Version: v, InstallEpoch: 1000, UpdatedAt: base.Add(-time.Minute).Format(time.RFC3339)}
 	}
 
 	t.Run("healthy same version -> defer (never kill a healthy daemon)", func(t *testing.T) {
@@ -73,7 +79,7 @@ func TestClassifyExistingDaemon(t *testing.T) {
 	t.Run("young same-version daemon -> defer via grace, without probing", func(t *testing.T) {
 		probed := false
 		daemonProbeHealth = func(int) (bool, string, bool) { probed = true; return true, "0.8.7", false }
-		young := &daemonLockRecord{PID: 1, Port: 7890, Version: "0.8.7", UpdatedAt: base.Add(-time.Second).Format(time.RFC3339)}
+		young := &daemonLockRecord{PID: 1, Port: 7890, Version: "0.8.7", InstallEpoch: 1000, UpdatedAt: base.Add(-time.Second).Format(time.RFC3339)}
 		if err := classifyExistingDaemon(server, 7890, young); !errors.Is(err, errDeferToHealthyDaemon) {
 			t.Fatalf("young lock should defer (grace), got %v", err)
 		}
@@ -87,7 +93,7 @@ func TestClassifyExistingDaemon(t *testing.T) {
 		daemonProbeHealth = func(int) (bool, string, bool) { probed = true; return false, "", false }
 		// Lock timestamped 2s in the FUTURE (backward clock step): age is negative,
 		// which must still be treated as "brand new" and deferred, not taken over.
-		future := &daemonLockRecord{PID: 1, Port: 7890, Version: "0.8.7", UpdatedAt: base.Add(2 * time.Second).Format(time.RFC3339)}
+		future := &daemonLockRecord{PID: 1, Port: 7890, Version: "0.8.7", InstallEpoch: 1000, UpdatedAt: base.Add(2 * time.Second).Format(time.RFC3339)}
 		if err := classifyExistingDaemon(server, 7890, future); !errors.Is(err, errDeferToHealthyDaemon) {
 			t.Fatalf("future-dated (negative-age) lock should defer via grace, got %v", err)
 		}

--- a/cmd/browser-agent/daemon_lifecycle_takeover_test.go
+++ b/cmd/browser-agent/daemon_lifecycle_takeover_test.go
@@ -18,17 +18,22 @@ func TestClassifyExistingDaemon(t *testing.T) {
 	}
 
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	oldNow, oldProbe, oldSleep, oldVer, oldEpoch := daemonNow, daemonProbeHealth, daemonSleep, version, daemonInstallEpoch
+	oldNow, oldProbe, oldSleep, oldVer, oldEpoch, oldAlive := daemonNow, daemonProbeHealth, daemonSleep, version, daemonInstallEpoch, daemonIsProcessAlive
 	defer func() {
 		daemonNow = oldNow
 		daemonProbeHealth = oldProbe
 		daemonSleep = oldSleep
 		version = oldVer
 		daemonInstallEpoch = oldEpoch
+		daemonIsProcessAlive = oldAlive
 	}()
 	daemonNow = func() time.Time { return base }
 	daemonSleep = func(time.Duration) {} // never really sleep in tests
 	version = "0.8.7"
+	// Default: the incumbent PID is alive. classifyExistingDaemon only consults this
+	// seam on the connection-refused path (a refused probe while the PID is alive is
+	// not proof of death, so it is retried). Refused-path subtests override it.
+	daemonIsProcessAlive = func(int) bool { return true }
 	// Neutralize the install-epoch tiebreaker for these version/grace/health cases:
 	// our epoch equals every lock's epoch, so same-version behavior is decided by the
 	// existing rules (not "latest install wins", which has its own test).
@@ -110,17 +115,60 @@ func TestClassifyExistingDaemon(t *testing.T) {
 		}
 	})
 
-	// finding L: a connection-refused probe is definitive (nothing is listening), so
-	// takeover must NOT burn the retry budget's sleeps on it. Only an ambiguous
-	// timeout warrants retrying.
-	t.Run("connection-refused probe takes over WITHOUT retrying (L)", func(t *testing.T) {
+	// finding L (refined): a connection-refused probe is only DEFINITIVE ("gone")
+	// when the incumbent PID is also dead — then takeover must NOT burn the retry
+	// budget's sleeps. But a refused probe while the PID is still ALIVE is not proof
+	// of death (a healthy daemon can transiently refuse: listen backlog full, or a
+	// graceful-shutdown drain), so it is retried to avoid falsely SIGTERM'ing a live
+	// peer and feeding the takeover war.
+	t.Run("refused + DEAD pid takes over WITHOUT retrying (L)", func(t *testing.T) {
+		daemonIsProcessAlive = func(int) bool { return false } // genuinely gone
+		defer func() { daemonIsProcessAlive = func(int) bool { return true } }()
 		probeCalls := 0
-		daemonProbeHealth = func(int) (bool, string, bool) { probeCalls++; return false, "", true } // refused = gone
+		daemonProbeHealth = func(int) (bool, string, bool) { probeCalls++; return false, "", true } // refused
 		if err := classifyExistingDaemon(server, 7890, oldLock("0.8.7")); err != nil {
-			t.Fatalf("a refused (gone) daemon should take over, got %v", err)
+			t.Fatalf("a refused daemon whose PID is dead should take over, got %v", err)
 		}
 		if probeCalls != 1 {
-			t.Fatalf("connection-refused is definitive — want exactly 1 probe, got %d", probeCalls)
+			t.Fatalf("refused + dead PID is definitive — want exactly 1 probe, got %d", probeCalls)
+		}
+	})
+
+	// Regression for the false-takeover risk in finding L: a healthy daemon that
+	// transiently refuses ONE probe (PID alive) must be retried, see health on the
+	// retry, and be DEFERRED to — never taken over on a single stray refusal.
+	t.Run("refused-then-healthy + ALIVE pid -> defer (no false takeover)", func(t *testing.T) {
+		daemonIsProcessAlive = func(int) bool { return true } // incumbent is alive
+		defer func() { daemonIsProcessAlive = func(int) bool { return true } }()
+		call := 0
+		daemonProbeHealth = func(int) (bool, string, bool) {
+			call++
+			if call == 1 {
+				return false, "", true // transient connection-refused
+			}
+			return true, "0.8.7", false // healthy on retry
+		}
+		if err := classifyExistingDaemon(server, 7890, oldLock("0.8.7")); !errors.Is(err, errDeferToHealthyDaemon) {
+			t.Fatalf("a transiently-refusing but healthy live daemon must be deferred to, got %v", err)
+		}
+		if call < 2 {
+			t.Fatalf("want a retry after the first refused probe (PID alive), got %d probes", call)
+		}
+	})
+
+	// A live daemon whose listener stays wedged (refused across the whole window) is
+	// still reclaimed after the retry budget — the alive-PID retry must not protect a
+	// genuinely stalled daemon forever.
+	t.Run("refused-persistently + ALIVE pid -> takeover after full retry budget (L)", func(t *testing.T) {
+		daemonIsProcessAlive = func(int) bool { return true }
+		defer func() { daemonIsProcessAlive = func(int) bool { return true } }()
+		probeCalls := 0
+		daemonProbeHealth = func(int) (bool, string, bool) { probeCalls++; return false, "", true } // always refused
+		if err := classifyExistingDaemon(server, 7890, oldLock("0.8.7")); err != nil {
+			t.Fatalf("a persistently-wedged live daemon should take over after retries, got %v", err)
+		}
+		if probeCalls != daemonHealthProbeRetries {
+			t.Fatalf("refused + alive PID must retry the full budget, want %d probes, got %d", daemonHealthProbeRetries, probeCalls)
 		}
 	})
 

--- a/cmd/browser-agent/daemon_lock_file.go
+++ b/cmd/browser-agent/daemon_lock_file.go
@@ -89,10 +89,11 @@ func persistCurrentDaemonLock(port int) error {
 		return err
 	}
 	return writeDaemonLockFile(daemonLockRecord{
-		PID:       os.Getpid(),
-		Port:      port,
-		StateDir:  stateDir,
-		Version:   version,
-		UpdatedAt: daemonNow().UTC().Format(time.RFC3339),
+		PID:          os.Getpid(),
+		Port:         port,
+		StateDir:     stateDir,
+		Version:      version,
+		UpdatedAt:    daemonNow().UTC().Format(time.RFC3339),
+		InstallEpoch: resolveInstallEpoch(),
 	})
 }

--- a/cmd/browser-agent/install_epoch.go
+++ b/cmd/browser-agent/install_epoch.go
@@ -1,0 +1,65 @@
+// install_epoch.go — resolves a monotonic "which install is newer" stamp so that,
+// at the SAME version, the LATEST install always wins the single-instance takeover.
+// Two same-version daemons (e.g. a ~/.kaboom/bin install and an npm-global copy)
+// otherwise have no tiebreaker and thrash — each defers to or kills the other. The
+// epoch gives a deterministic total order: newer install epoch supersedes.
+//
+// Resolution order (per install, so two installs get distinct values):
+//  1. an installer-written stamp file next to the binary (authoritative), else
+//  2. the binary's own mtime (a manually-copied/run binary still gets a sane,
+//     comparable value), else
+//  3. 0 (unknown — treated as "oldest", so a stamped install always wins).
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// installEpochStampName is the per-install stamp file the installer writes next to
+// the binary. Kept next to the binary (not in the shared state dir) so each install
+// reports its OWN install time — a shared stamp would collapse to one value and
+// defeat the tiebreaker.
+const installEpochStampName = ".kaboom-install-epoch"
+
+var (
+	installEpochOnce sync.Once
+	installEpoch     int64
+)
+
+// resolveInstallEpoch returns this binary's install epoch, computing it once.
+func resolveInstallEpoch() int64 {
+	installEpochOnce.Do(func() {
+		installEpoch = computeInstallEpoch(os.Executable, os.Stat, os.ReadFile)
+	})
+	return installEpoch
+}
+
+// computeInstallEpoch is the pure, injectable core. Returns a unix-nanosecond stamp.
+func computeInstallEpoch(
+	execPath func() (string, error),
+	stat func(string) (os.FileInfo, error),
+	readFile func(string) ([]byte, error),
+) int64 {
+	exe, err := execPath()
+	if err != nil || exe == "" {
+		return 0
+	}
+	// 1. Installer stamp next to the binary wins — it records the actual install
+	//    moment, which mtime can't when a copy preserves timestamps.
+	stamp := filepath.Join(filepath.Dir(exe), installEpochStampName)
+	if b, e := readFile(stamp); e == nil {
+		if v, e2 := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); e2 == nil && v > 0 {
+			return v
+		}
+	}
+	// 2. Fall back to the binary's mtime.
+	if fi, e := stat(exe); e == nil {
+		return fi.ModTime().UnixNano()
+	}
+	return 0
+}

--- a/cmd/browser-agent/internal/bridge/bridge.go
+++ b/cmd/browser-agent/internal/bridge/bridge.go
@@ -63,8 +63,17 @@ func (s *daemonState) buildDaemonCmd() (*exec.Cmd, error) {
 	}
 	cmd := exec.Command(exe, args...) // #nosec G702 -- exe is our own binary path from os.Executable with fixed flags // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command, go_subproc_rule-subproc -- bridge spawns own daemon
 	cmd.Args[0] = deps.DaemonProcessArgv0(exe)
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
+	// Detach the daemon's standard streams. nil => os/exec connects the fd to
+	// os.DevNull (/dev/null). We must NOT use io.Discard here: os/exec routes any
+	// non-*os.File writer through an OS pipe whose read-end lives in THIS bridge
+	// process. Setsid detaches the daemon's session/process group but NOT the
+	// inherited pipe fds. When the bridge exits on stdin_eof, those pipe read-ends
+	// close, and the daemon's next stderr write dies with SIGPIPE on fd 2 (Go
+	// terminates on a broken pipe to fd 1/2). /dev/null never breaks, so the
+	// spawned daemon stays persistent across the bridge's exit. This mirrors the
+	// installer's startDaemonSilently (native_install.go), which already uses nil.
+	cmd.Stdout = nil
+	cmd.Stderr = nil
 	cmd.Stdin = nil
 	util.SetDetachedProcess(cmd)
 	return cmd, nil

--- a/cmd/browser-agent/internal/bridge/bridge_deps_isolation_test.go
+++ b/cmd/browser-agent/internal/bridge/bridge_deps_isolation_test.go
@@ -1,0 +1,36 @@
+// bridge_deps_isolation_test.go -- Guards against the shared-global `deps` clobber.
+// initTestDeps replaces the package-global deps installed by TestMain; if it does not
+// restore the prior value, it leaks the minimal stub into every test that runs after
+// it (this is exactly what broke the FastPath tests once and hung the framed-init test).
+package bridge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestInitTestDepsRestoresGlobalDeps asserts initTestDeps restores the caller's prior
+// package-global deps after the test completes, so its stub cannot leak to later tests.
+func TestInitTestDepsRestoresGlobalDeps(t *testing.T) {
+	// Install a recognizable sentinel so the assertion is independent of whatever
+	// earlier tests happened to leave in the package-global deps.
+	prev := deps
+	sentinel := deps
+	sentinel.NegotiateProtocolVersion = func(json.RawMessage) string { return "SENTINEL-VERSION" }
+	deps = sentinel
+	defer func() { deps = prev }()
+
+	t.Run("inner clobbers deps via initTestDeps", func(t *testing.T) {
+		initTestDeps(t)
+		if deps.NegotiateProtocolVersion(nil) == "SENTINEL-VERSION" {
+			t.Fatal("initTestDeps should have replaced the sentinel deps inside the subtest")
+		}
+	})
+
+	// t.Run returns only after the subtest's cleanups have run. If initTestDeps
+	// registered a restoring t.Cleanup, deps is back to the sentinel; otherwise the
+	// stub leaked.
+	if deps.NegotiateProtocolVersion(nil) != "SENTINEL-VERSION" {
+		t.Fatalf("initTestDeps leaked: it must restore the package-global deps to the caller's prior value")
+	}
+}

--- a/cmd/browser-agent/internal/bridge/bridge_detach_stdio_test.go
+++ b/cmd/browser-agent/internal/bridge/bridge_detach_stdio_test.go
@@ -1,0 +1,61 @@
+// bridge_detach_stdio_test.go -- Regression test for the bridge->daemon SIGPIPE crash-loop.
+// A bridge-spawned daemon must be genuinely persistent: its standard streams must be
+// detached from the bridge, not routed through bridge-owned OS pipes.
+package bridge
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// TestBuildDaemonCmdDetachesStdio guards against the crash-loop where a
+// bridge-spawned daemon died ~4s after the bridge's stdin_eof.
+//
+// Mechanism it prevents: os/exec routes Stdout/Stderr through an OS pipe whenever
+// the assigned writer is NOT an *os.File (io.Discard is such a writer). The pipe's
+// read-end lives in the BRIDGE process. Setsid detaches the daemon's session/process
+// group but NOT the inherited pipe fds. When the bridge exits on stdin_eof, the
+// pipe read-ends close; the daemon's next stderr write hits a broken pipe on fd 2,
+// and Go's default disposition terminates the process with SIGPIPE.
+//
+// A genuinely detached daemon must have nil (=> os/exec connects fd to /dev/null,
+// which never breaks) or an *os.File for both streams.
+func TestBuildDaemonCmdDetachesStdio(t *testing.T) {
+	// NB: do NOT call initTestDeps here — it replaces the package-global deps
+	// installed by TestMain (and never restores it), which would clobber deps for
+	// every test that runs after this one (the FastPath tests break with the stub's
+	// 2024-11-05 protocol / broken Content-Length writer). TestMain already provides
+	// DaemonProcessArgv0, which is all buildDaemonCmd needs.
+	s := &daemonState{port: 7890}
+	cmd, err := s.buildDaemonCmd()
+	if err != nil {
+		t.Fatalf("buildDaemonCmd: %v", err)
+	}
+
+	assertDetachedStream(t, "stdout", cmd.Stdout)
+	assertDetachedStream(t, "stderr", cmd.Stderr)
+
+	// stdin must likewise never be tied to the bridge.
+	if cmd.Stdin != nil {
+		if _, ok := cmd.Stdin.(*os.File); !ok {
+			t.Errorf("stdin = %T: must be nil (=> /dev/null) or *os.File so the daemon is detached", cmd.Stdin)
+		}
+	}
+}
+
+// assertDetachedStream fails if w would make os/exec create a bridge-owned pipe.
+func assertDetachedStream(t *testing.T, name string, w io.Writer) {
+	t.Helper()
+	if w == nil {
+		return // nil => os/exec connects the fd to /dev/null: fully detached.
+	}
+	if w == io.Discard {
+		t.Fatalf("%s = io.Discard: os/exec routes it through a bridge-owned pipe, so the "+
+			"spawned daemon dies with SIGPIPE on fd 2 when the bridge exits. Use nil (=> /dev/null) or an *os.File.", name)
+	}
+	if _, ok := w.(*os.File); !ok {
+		t.Fatalf("%s = %T: any non-*os.File writer makes os/exec create a bridge-owned pipe; "+
+			"use nil (=> /dev/null) or an *os.File so the daemon survives the bridge's exit.", name, w)
+	}
+}

--- a/cmd/browser-agent/internal/bridge/bridge_respawn_backoff_test.go
+++ b/cmd/browser-agent/internal/bridge/bridge_respawn_backoff_test.go
@@ -1,0 +1,111 @@
+// bridge_respawn_backoff_test.go -- Regression tests for bounded respawn backoff.
+// A repeatedly-dying daemon must not become a spawn storm: respawnIfNeeded throttles
+// the real cmd.Start() to at most one per (escalating, capped) interval.
+package bridge
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// closedLoopbackPort returns a loopback port with nothing listening, so
+// isServerRunning(port) is deterministically false (connection refused).
+func closedLoopbackPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen(:0) error = %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// TestRespawnIfNeeded_ThrottlesRapidSpawns asserts N rapid respawnIfNeeded calls
+// produce at most ONE real spawn within the throttle interval, and that a spawn is
+// permitted again once the interval elapses (fake clock advanced).
+func TestRespawnIfNeeded_ThrottlesRapidSpawns(t *testing.T) {
+	oldNow, oldSpawn := bridgeNow, respawnSpawnFn
+	defer func() { bridgeNow = oldNow; respawnSpawnFn = oldSpawn }()
+
+	fakeNow := time.Unix(1_700_000_000, 0)
+	bridgeNow = func() time.Time { return fakeNow }
+
+	spawns := 0
+	respawnSpawnFn = func(s *daemonState) bool {
+		spawns++
+		// Simulate a daemon that never comes up, so the state stays "failed" and
+		// every subsequent respawnIfNeeded re-enters the spawn section (and is
+		// therefore subject to the throttle gate rather than short-circuiting ready).
+		s.markFailed("simulated: respawned daemon never became healthy")
+		return false
+	}
+
+	port := closedLoopbackPort(t)
+	s := &daemonState{
+		port:     port,
+		readyCh:  make(chan struct{}),
+		failedCh: make(chan struct{}),
+	}
+	// Put the state into "failed" so planRespawnAttempt takes the spawn path
+	// immediately (rather than waiting on peer signals).
+	s.markFailed("initial: force spawn path")
+
+	// N rapid calls at the same instant: only the first should actually spawn.
+	const rapid = 6
+	for i := 0; i < rapid; i++ {
+		s.respawnIfNeeded()
+		s.markFailed("keep failed for next iteration") // ensure spawn path re-entry
+	}
+	if spawns != 1 {
+		t.Fatalf("rapid respawns within the interval: want exactly 1 actual spawn, got %d", spawns)
+	}
+
+	// Advance past the throttle interval: the next respawn is permitted.
+	fakeNow = fakeNow.Add(respawnMinInterval + time.Millisecond)
+	s.respawnIfNeeded()
+	if spawns != 2 {
+		t.Fatalf("after the interval elapsed: want a 2nd real spawn, got %d", spawns)
+	}
+
+	// Immediately after, still within the (now escalated) interval: throttled again.
+	s.markFailed("keep failed")
+	s.respawnIfNeeded()
+	if spawns != 2 {
+		t.Fatalf("second rapid burst must be throttled: want spawns still 2, got %d", spawns)
+	}
+}
+
+// TestReserveRespawnSlot_BackoffEscalatesAndCools unit-tests the throttle gate:
+// escalating (capped) interval under a storm, reset after a cool-down gap.
+func TestReserveRespawnSlot_BackoffEscalatesAndCools(t *testing.T) {
+	s := &daemonState{}
+	base := time.Unix(1_700_000_000, 0)
+
+	// First reservation always granted (immediate respawn after a death).
+	if !s.reserveRespawnSlot(base) {
+		t.Fatal("first reserveRespawnSlot must be granted")
+	}
+	// Same instant -> throttled.
+	if s.reserveRespawnSlot(base) {
+		t.Fatal("second reservation at the same instant must be throttled")
+	}
+	// Exactly at the min interval -> granted, and the interval doubles.
+	if !s.reserveRespawnSlot(base.Add(respawnMinInterval)) {
+		t.Fatal("reservation at the min interval must be granted")
+	}
+	// The interval has now escalated beyond min: a gap of min is no longer enough.
+	if s.reserveRespawnSlot(base.Add(respawnMinInterval + respawnMinInterval)) {
+		t.Fatal("after escalation, a min-sized gap must still be throttled")
+	}
+	// A cool-down gap >= respawnMaxBackoff resets the escalation and is granted.
+	coolStart := base.Add(respawnMinInterval + respawnMaxBackoff + time.Second)
+	if !s.reserveRespawnSlot(coolStart) {
+		t.Fatal("a respawn after a full cool-down must be granted")
+	}
+	// And escalation is reset: the very next min-interval gap is granted again.
+	if !s.reserveRespawnSlot(coolStart.Add(respawnMinInterval)) {
+		t.Fatal("after cool-down reset, a min-interval gap must be granted again")
+	}
+}

--- a/cmd/browser-agent/internal/bridge/bridge_startup_state.go
+++ b/cmd/browser-agent/internal/bridge/bridge_startup_state.go
@@ -28,6 +28,87 @@ type daemonState struct {
 	port       int
 	logFile    string
 	maxEntries int
+
+	// Respawn throttle state. Bounds how often the real spawn (cmd.Start) can fire
+	// so a repeatedly-dying daemon cannot become a launchd-throttling spawn storm.
+	// Guarded by respawnMu (independent of mu, which markReady/markFailed take).
+	respawnMu       sync.Mutex
+	lastRespawnAt   time.Time
+	respawnInterval time.Duration
+}
+
+// bridgeNow is the injectable clock for respawn throttling (mirrors daemonNow in
+// the main package). Overridden in tests for deterministic backoff assertions.
+var bridgeNow = time.Now
+
+const (
+	// respawnMinInterval is the minimum gap between real daemon spawns. The first
+	// respawn after a death is immediate; only rapid repeats are throttled.
+	respawnMinInterval = 1 * time.Second
+	// respawnMaxBackoff caps the exponential backoff between rapid respawns and
+	// also marks when a storm has "cooled" (a respawn this long after the last is
+	// treated as isolated and resets the escalation).
+	respawnMaxBackoff = 8 * time.Second
+)
+
+// respawnSpawnFn performs the actual daemon (re)spawn: build the command, start it
+// detached, and wait for readiness. Injectable so tests can count/stub real spawns
+// without launching processes.
+var respawnSpawnFn = performDaemonRespawn
+
+// reserveRespawnSlot reports whether a real daemon spawn is permitted at `now`, and
+// if so records the attempt and advances the (capped, exponential) backoff. It never
+// blocks: a throttled caller is told "no" and backs off instead of hammering
+// cmd.Start(). The first respawn after a death is always granted; only rapid repeats
+// are throttled. A respawn arriving after a full cool-down (>= respawnMaxBackoff since
+// the last) is treated as isolated and resets the escalation, so a lone respawn is
+// never penalized.
+func (s *daemonState) reserveRespawnSlot(now time.Time) bool {
+	s.respawnMu.Lock()
+	defer s.respawnMu.Unlock()
+
+	if s.lastRespawnAt.IsZero() {
+		s.lastRespawnAt = now
+		s.respawnInterval = respawnMinInterval
+		return true
+	}
+	elapsed := now.Sub(s.lastRespawnAt)
+	if elapsed >= respawnMaxBackoff {
+		// Storm has cooled — treat as a fresh, isolated respawn.
+		s.lastRespawnAt = now
+		s.respawnInterval = respawnMinInterval
+		return true
+	}
+	if elapsed < s.respawnInterval {
+		return false // too soon; throttle
+	}
+	// Interval satisfied but still inside the storm window: permit and escalate.
+	s.lastRespawnAt = now
+	s.respawnInterval *= 2
+	if s.respawnInterval > respawnMaxBackoff {
+		s.respawnInterval = respawnMaxBackoff
+	}
+	return true
+}
+
+// performDaemonRespawn is the default (real) spawn implementation behind respawnSpawnFn.
+func performDaemonRespawn(s *daemonState) bool {
+	cmd, err := s.buildDaemonCmd()
+	if err != nil {
+		s.markFailed(err.Error())
+		return false
+	}
+	if err := cmd.Start(); err != nil {
+		s.markFailed("Failed to start daemon: " + err.Error())
+		return false
+	}
+	if waitForServer(s.port, daemonStartupReadyTimeout) {
+		s.markReady()
+		deps.Stderrf("[Kaboom] daemon respawned successfully on port %d\n", s.port)
+		return true
+	}
+	s.markFailed(fmt.Sprintf("Daemon respawned but not responding on port %d after %s", s.port, daemonStartupReadyTimeout))
+	return false
 }
 
 type respawnPlan struct {
@@ -191,26 +272,22 @@ func (s *daemonState) respawnIfNeeded() bool {
 		return false
 	}
 
+	// Bounded respawn backoff: never fire cmd.Start() faster than the (capped,
+	// exponential) throttle interval, so a repeatedly-dying daemon cannot become a
+	// spawn storm that launchd throttles into oblivion. Fail loud when throttled —
+	// never silently drop the request. If a prior spawn actually did come up while
+	// we were being throttled, adopt it as ready instead of reporting failure.
+	if !s.reserveRespawnSlot(bridgeNow()) {
+		if isServerRunning(s.port) {
+			s.markReady()
+			return true
+		}
+		s.markFailed(fmt.Sprintf("daemon respawn throttled on port %d; backing off to avoid a restart storm", s.port))
+		return false
+	}
+
 	deps.Stderrf("[Kaboom] daemon not responding, respawning on port %d\n", s.port)
-
-	cmd, err := s.buildDaemonCmd()
-	if err != nil {
-		s.markFailed(err.Error())
-		return false
-	}
-	if err := cmd.Start(); err != nil {
-		s.markFailed("Failed to start daemon: " + err.Error())
-		return false
-	}
-
-	if waitForServer(s.port, daemonStartupReadyTimeout) {
-		s.markReady()
-		deps.Stderrf("[Kaboom] daemon respawned successfully on port %d\n", s.port)
-		return true
-	}
-
-	s.markFailed(fmt.Sprintf("Daemon respawned but not responding on port %d after %s", s.port, daemonStartupReadyTimeout))
-	return false
+	return respawnSpawnFn(s)
 }
 
 func spawnDaemonAsync(state *daemonState) {

--- a/cmd/browser-agent/internal/bridge/bridge_test_support_test.go
+++ b/cmd/browser-agent/internal/bridge/bridge_test_support_test.go
@@ -16,8 +16,16 @@ import (
 
 
 // initTestDeps sets up minimal bridge deps for testing.
+//
+// It restores the previous package-global deps (installed by TestMain, or by an
+// enclosing test) via t.Cleanup so this stub cannot leak into tests that run after
+// this one. Without the restore, the minimal stub below (protocol 2024-11-05, no real
+// resources, a spaces-only Content-Length writer) leaks and breaks every later test
+// that relies on the real deps — the FastPath failures + framed-init hang we hit once.
 func initTestDeps(t *testing.T) {
 	t.Helper()
+	prev := deps
+	t.Cleanup(func() { deps = prev })
 	Init(Deps{
 		Version:              "0.0.0-test",
 		MaxPostBodySize:      10 * 1024 * 1024,

--- a/cmd/browser-agent/main_connection_mcp.go
+++ b/cmd/browser-agent/main_connection_mcp.go
@@ -57,6 +57,13 @@ func runMCPMode(server *Server, port int, apiKey string, opts daemonLaunchOption
 		}
 	}
 
+	// Crash-loop self-defense: if this SAME install (version + epoch) has restarted
+	// too many times too fast, log loudly and back off a bounded amount before binding
+	// so a pathological loop degrades gracefully instead of hammering launchd (which
+	// would throttle/disable the LaunchAgent and take the terminal server on port+1
+	// dark too). Never refuses to start; an upgrade/epoch takeover resets the counter.
+	applyStartupRestartThrottle(server, port)
+
 	srv, httpDone, err := startHTTPServer(server, port, apiKey, mux)
 	if err != nil {
 		return err

--- a/cmd/browser-agent/main_connection_mcp_shutdown.go
+++ b/cmd/browser-agent/main_connection_mcp_shutdown.go
@@ -54,6 +54,14 @@ func awaitShutdownSignal(server *Server, srv *http.Server, port int, httpDone <-
 		"shutdown_source": shutdownSource,
 		"uptime_seconds":  time.Since(startTime).Seconds(),
 	})
+
+	// Reset the crash-loop restart counter on a clean, signal-initiated shutdown: a
+	// controlled stop is not a crash, so legitimate stop/start cycles never accumulate
+	// toward the startup throttle. An unexpected listener death (http_listener_died) is
+	// crash-like and must NOT clear — it should count toward the storm threshold.
+	if shutdownSource != "http_listener_died" {
+		clearRestartHistoryOnCleanShutdown(server, port)
+	}
 	if diagPath := appendExitDiagnostic("daemon_shutdown", map[string]any{
 		"port":            port,
 		"signal":          s.String(),

--- a/cmd/browser-agent/startup_throttle.go
+++ b/cmd/browser-agent/startup_throttle.go
@@ -1,13 +1,13 @@
 // startup_throttle.go — self-defense against crash-loop restart storms.
-// If the SAME install (version + install epoch) restarts too many times within a
-// short window, the daemon logs LOUDLY and waits a bounded delay before binding, so
+// If the SAME daemon instance (version + install epoch + port) restarts too many
+// times within a short window, the daemon logs LOUDLY and waits a bounded delay before binding, so
 // a pathological loop degrades gracefully instead of hammering launchd (which throttles
 // or disables the LaunchAgent, taking the whole service — including the terminal
 // server on port+1 — dark). It NEVER refuses to start: it only warns and delays.
 //
 // A legitimate upgrade or install-epoch takeover is NOT a crash-restart: those change
-// the (version, epoch) identity, which resets the counter so a real deploy is never
-// penalized.
+// the identity, which resets the counter so a real deploy is never penalized. Port is
+// part of that identity too — see restartHistory.
 
 package main
 
@@ -36,25 +36,34 @@ const (
 )
 
 // restartHistory is the persisted record of this install's recent restarts. It is
-// keyed by (Version, InstallEpoch) so a different install (upgrade / epoch takeover)
-// starts from a clean slate rather than inheriting the previous install's restarts.
+// keyed by (Version, InstallEpoch, Port) so a different install (upgrade / epoch
+// takeover) — or a different daemon instance — starts from a clean slate rather than
+// inheriting unrelated restarts.
+//
+// Port is part of the identity because a restart storm is about ONE endpoint being
+// restarted repeatedly, which is what launchd throttles. Without it, every daemon
+// sharing a state dir was counted together: the Go test suite spawns many short-lived
+// daemons on distinct random ports in one state dir, crossed the threshold, and then
+// throttled every subsequent start into "Server failed to start". Production always
+// binds the same port, so a genuine crash loop still accumulates.
 type restartHistory struct {
 	Version      string  `json:"version"`
 	InstallEpoch int64   `json:"install_epoch"`
+	Port         int     `json:"port"`
 	Timestamps   []int64 `json:"restart_unixnano"`
 }
 
 // daemonThrottleSleep is the injectable sleep used by the startup restart throttle.
 var daemonThrottleSleep = time.Sleep
 
-// recordRestartAndComputeDelay appends `now` to the restart history for (ver, epoch)
-// and returns the updated history plus the bounded startup delay to apply. It never
-// signals refusal — only a delay (0 when under the threshold). A history whose
-// identity differs from (ver, epoch) is reset first: an upgrade or epoch takeover is
-// not a crash-restart. Timestamps older than the window are pruned.
-func recordRestartAndComputeDelay(prev restartHistory, now time.Time, ver string, epoch int64) (restartHistory, time.Duration) {
-	if prev.Version != ver || prev.InstallEpoch != epoch {
-		prev = restartHistory{Version: ver, InstallEpoch: epoch}
+// recordRestartAndComputeDelay appends `now` to the restart history for
+// (ver, epoch, port) and returns the updated history plus the bounded startup delay
+// to apply. It never signals refusal — only a delay (0 when under the threshold). A
+// history whose identity differs is reset first: an upgrade, an epoch takeover, or a
+// different port is not a restart of this instance. Older timestamps are pruned.
+func recordRestartAndComputeDelay(prev restartHistory, now time.Time, ver string, epoch int64, port int) (restartHistory, time.Duration) {
+	if prev.Version != ver || prev.InstallEpoch != epoch || prev.Port != port {
+		prev = restartHistory{Version: ver, InstallEpoch: epoch, Port: port}
 	}
 	cutoff := now.Add(-restartThrottleWindow)
 	kept := make([]int64, 0, len(prev.Timestamps)+1)
@@ -64,7 +73,7 @@ func recordRestartAndComputeDelay(prev restartHistory, now time.Time, ver string
 		}
 	}
 	kept = append(kept, now.UnixNano())
-	next := restartHistory{Version: ver, InstallEpoch: epoch, Timestamps: kept}
+	next := restartHistory{Version: ver, InstallEpoch: epoch, Port: port, Timestamps: kept}
 
 	// Under the threshold: no delay. Only the (max+1)-th and beyond within the window
 	// back off, escalating one step per excess restart, capped so startup never stalls.
@@ -140,7 +149,7 @@ func applyStartupRestartThrottle(server *Server, port int) time.Duration {
 	}
 	path := restartHistoryPath(stateDir)
 	prev := loadRestartHistory(path)
-	next, delay := recordRestartAndComputeDelay(prev, daemonNow(), version, daemonInstallEpoch())
+	next, delay := recordRestartAndComputeDelay(prev, daemonNow(), version, daemonInstallEpoch(), port)
 	if err := saveRestartHistory(path, next); err != nil {
 		server.logLifecycle("restart_history_write_failed", port, map[string]any{"error": err.Error()})
 	}

--- a/cmd/browser-agent/startup_throttle.go
+++ b/cmd/browser-agent/startup_throttle.go
@@ -110,6 +110,24 @@ func saveRestartHistory(path string, h restartHistory) error {
 	return os.WriteFile(path, b, 0o600)
 }
 
+// clearRestartHistoryOnCleanShutdown removes the restart history after a graceful,
+// signal-initiated shutdown. A clean shutdown means we are NOT crash-looping, so the
+// restart counter resets — this is what keeps legitimate stop/start cycles (a user
+// restart, or a test suite's rapid --stop/spawn) from ever engaging the backoff. A
+// crash (uncaught SIGPIPE, panic, or an unexpected http_listener_died) never runs this
+// path, so its restart still counts toward the storm threshold. Best effort: a failure
+// to remove the file is logged, never fatal.
+func clearRestartHistoryOnCleanShutdown(server *Server, port int) {
+	stateDir, err := state.RootDir()
+	if err != nil {
+		return
+	}
+	path := restartHistoryPath(stateDir)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		server.logLifecycle("restart_history_clear_failed", port, map[string]any{"error": err.Error()})
+	}
+}
+
 // applyStartupRestartThrottle records this daemon start and, if the same install has
 // restarted too many times too fast, logs loudly and waits a bounded delay before
 // returning. It NEVER refuses to start. Returns the delay applied (0 if none). Any

--- a/cmd/browser-agent/startup_throttle.go
+++ b/cmd/browser-agent/startup_throttle.go
@@ -1,0 +1,144 @@
+// startup_throttle.go — self-defense against crash-loop restart storms.
+// If the SAME install (version + install epoch) restarts too many times within a
+// short window, the daemon logs LOUDLY and waits a bounded delay before binding, so
+// a pathological loop degrades gracefully instead of hammering launchd (which throttles
+// or disables the LaunchAgent, taking the whole service — including the terminal
+// server on port+1 — dark). It NEVER refuses to start: it only warns and delays.
+//
+// A legitimate upgrade or install-epoch takeover is NOT a crash-restart: those change
+// the (version, epoch) identity, which resets the counter so a real deploy is never
+// penalized.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/internal/state"
+)
+
+const (
+	// restartThrottleWindow is the sliding window over which restarts are counted.
+	restartThrottleWindow = 30 * time.Second
+	// restartThrottleMax is the number of restarts allowed in the window before the
+	// backoff engages. More than this many (i.e. the N+1-th) starts delaying.
+	restartThrottleMax = 5
+	// restartThrottleStep is the per-excess-restart delay increment.
+	restartThrottleStep = 500 * time.Millisecond
+	// restartThrottleCap bounds the delay so we never stall startup for long.
+	restartThrottleCap = 3 * time.Second
+
+	// restartHistoryFileName is the state-dir file tracking recent restart times.
+	restartHistoryFileName = "restart-history.json"
+)
+
+// restartHistory is the persisted record of this install's recent restarts. It is
+// keyed by (Version, InstallEpoch) so a different install (upgrade / epoch takeover)
+// starts from a clean slate rather than inheriting the previous install's restarts.
+type restartHistory struct {
+	Version      string  `json:"version"`
+	InstallEpoch int64   `json:"install_epoch"`
+	Timestamps   []int64 `json:"restart_unixnano"`
+}
+
+// daemonThrottleSleep is the injectable sleep used by the startup restart throttle.
+var daemonThrottleSleep = time.Sleep
+
+// recordRestartAndComputeDelay appends `now` to the restart history for (ver, epoch)
+// and returns the updated history plus the bounded startup delay to apply. It never
+// signals refusal — only a delay (0 when under the threshold). A history whose
+// identity differs from (ver, epoch) is reset first: an upgrade or epoch takeover is
+// not a crash-restart. Timestamps older than the window are pruned.
+func recordRestartAndComputeDelay(prev restartHistory, now time.Time, ver string, epoch int64) (restartHistory, time.Duration) {
+	if prev.Version != ver || prev.InstallEpoch != epoch {
+		prev = restartHistory{Version: ver, InstallEpoch: epoch}
+	}
+	cutoff := now.Add(-restartThrottleWindow)
+	kept := make([]int64, 0, len(prev.Timestamps)+1)
+	for _, ts := range prev.Timestamps {
+		if time.Unix(0, ts).After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	kept = append(kept, now.UnixNano())
+	next := restartHistory{Version: ver, InstallEpoch: epoch, Timestamps: kept}
+
+	// Under the threshold: no delay. Only the (max+1)-th and beyond within the window
+	// back off, escalating one step per excess restart, capped so startup never stalls.
+	if len(kept) <= restartThrottleMax {
+		return next, 0
+	}
+	over := len(kept) - restartThrottleMax // 1, 2, 3, ...
+	delay := time.Duration(over) * restartThrottleStep
+	if delay > restartThrottleCap {
+		delay = restartThrottleCap
+	}
+	return next, delay
+}
+
+// restartHistoryPath returns the restart-history file path under the given state dir.
+func restartHistoryPath(stateDir string) string {
+	return filepath.Join(stateDir, restartHistoryFileName)
+}
+
+// loadRestartHistory reads the restart history; a missing or corrupt file yields an
+// empty history (treated as a fresh install), never an error.
+func loadRestartHistory(path string) restartHistory {
+	b, err := os.ReadFile(path) // #nosec G304 -- path derived from our own state dir
+	if err != nil {
+		return restartHistory{}
+	}
+	var h restartHistory
+	if err := json.Unmarshal(b, &h); err != nil {
+		return restartHistory{}
+	}
+	return h
+}
+
+// saveRestartHistory persists the restart history, creating the state dir if needed.
+func saveRestartHistory(path string, h restartHistory) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	b, err := json.Marshal(h)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// applyStartupRestartThrottle records this daemon start and, if the same install has
+// restarted too many times too fast, logs loudly and waits a bounded delay before
+// returning. It NEVER refuses to start. Returns the delay applied (0 if none). Any
+// state-dir / IO problem is non-fatal (best effort: startup proceeds without a delay).
+func applyStartupRestartThrottle(server *Server, port int) time.Duration {
+	stateDir, err := state.RootDir()
+	if err != nil {
+		server.logLifecycle("restart_history_statedir_failed", port, map[string]any{"error": err.Error()})
+		return 0
+	}
+	path := restartHistoryPath(stateDir)
+	prev := loadRestartHistory(path)
+	next, delay := recordRestartAndComputeDelay(prev, daemonNow(), version, daemonInstallEpoch())
+	if err := saveRestartHistory(path, next); err != nil {
+		server.logLifecycle("restart_history_write_failed", port, map[string]any{"error": err.Error()})
+	}
+	if delay <= 0 {
+		return 0
+	}
+	server.logLifecycle("restart_storm_throttle", port, map[string]any{
+		"restarts_in_window": len(next.Timestamps),
+		"window_seconds":     int(restartThrottleWindow.Seconds()),
+		"delay_ms":           delay.Milliseconds(),
+		"version":            version,
+		"install_epoch":      next.InstallEpoch,
+	})
+	stderrf("[Kaboom] WARNING: this install restarted %d times within %s — possible crash loop. "+
+		"Backing off %s before binding to avoid launchd throttling.\n",
+		len(next.Timestamps), restartThrottleWindow, delay)
+	daemonThrottleSleep(delay)
+	return delay
+}

--- a/cmd/browser-agent/startup_throttle_test.go
+++ b/cmd/browser-agent/startup_throttle_test.go
@@ -1,0 +1,173 @@
+// startup_throttle_test.go -- Tests for crash-loop restart-storm self-defense.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRecordRestartAndComputeDelay_ThrottlesRapidRestarts asserts the backoff engages
+// only once the same install restarts MORE than restartThrottleMax times within the
+// window, and that the delay escalates and is capped.
+func TestRecordRestartAndComputeDelay_ThrottlesRapidRestarts(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	h := restartHistory{}
+
+	// The first restartThrottleMax restarts, all inside the window, are free.
+	for i := 0; i < restartThrottleMax; i++ {
+		var delay time.Duration
+		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100)
+		if delay != 0 {
+			t.Fatalf("restart %d within threshold: want delay 0, got %s", i+1, delay)
+		}
+	}
+
+	// The (max+1)-th rapid restart engages the backoff: one step.
+	var delay time.Duration
+	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax)*time.Second), "1.0.0", 100)
+	if delay != restartThrottleStep {
+		t.Fatalf("first over-threshold restart: want delay %s, got %s", restartThrottleStep, delay)
+	}
+
+	// The next one escalates by another step.
+	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+1)*time.Second), "1.0.0", 100)
+	if delay != 2*restartThrottleStep {
+		t.Fatalf("second over-threshold restart: want delay %s, got %s", 2*restartThrottleStep, delay)
+	}
+
+	// Escalation is capped.
+	for i := 0; i < 20; i++ {
+		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+2+i)*time.Second), "1.0.0", 100)
+	}
+	if delay != restartThrottleCap {
+		t.Fatalf("escalating delay must be capped at %s, got %s", restartThrottleCap, delay)
+	}
+}
+
+// TestRecordRestartAndComputeDelay_SpacedOutNeverThrottles asserts restarts spread
+// further apart than the window never engage the backoff (old restarts are pruned).
+func TestRecordRestartAndComputeDelay_SpacedOutNeverThrottles(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	h := restartHistory{}
+	for i := 0; i < 50; i++ {
+		var delay time.Duration
+		// Each restart is a full window + 1s after the previous, so pruning keeps
+		// the count at 1 every time.
+		now := base.Add(time.Duration(i) * (restartThrottleWindow + time.Second))
+		h, delay = recordRestartAndComputeDelay(h, now, "1.0.0", 100)
+		if delay != 0 {
+			t.Fatalf("spaced-out restart %d must not throttle, got delay %s", i+1, delay)
+		}
+	}
+}
+
+// TestRecordRestartAndComputeDelay_UpgradeResetsCounter asserts an upgrade (new
+// version) or install-epoch takeover (new epoch) is NOT counted as a crash-restart:
+// the counter resets so a real deploy is never penalized.
+func TestRecordRestartAndComputeDelay_UpgradeResetsCounter(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+
+	// Build a history that is deep in throttle territory for install (1.0.0, epoch 100).
+	h := restartHistory{}
+	for i := 0; i < restartThrottleMax+5; i++ {
+		h, _ = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100)
+	}
+
+	// An upgrade to a new VERSION at the same instant must reset -> no throttle.
+	next, delay := recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+5)*time.Second), "1.1.0", 100)
+	if delay != 0 {
+		t.Fatalf("upgrade (new version) must not be throttled, got delay %s", delay)
+	}
+	if len(next.Timestamps) != 1 || next.Version != "1.1.0" {
+		t.Fatalf("upgrade must reset history, got version=%s timestamps=%d", next.Version, len(next.Timestamps))
+	}
+
+	// A same-version but new-EPOCH takeover must likewise reset.
+	_, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+6)*time.Second), "1.0.0", 200)
+	if delay != 0 {
+		t.Fatalf("epoch takeover (new epoch) must not be throttled, got delay %s", delay)
+	}
+}
+
+// TestRestartHistoryPersistenceRoundTrip asserts save/load preserves the history and
+// that a missing/corrupt file yields an empty (fresh) history, never an error.
+func TestRestartHistoryPersistenceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := restartHistoryPath(dir)
+
+	// Missing file -> empty.
+	if got := loadRestartHistory(path); got.Version != "" || len(got.Timestamps) != 0 {
+		t.Fatalf("missing file must load empty, got %+v", got)
+	}
+
+	want := restartHistory{Version: "2.0.0", InstallEpoch: 42, Timestamps: []int64{111, 222, 333}}
+	if err := saveRestartHistory(path, want); err != nil {
+		t.Fatalf("saveRestartHistory error = %v", err)
+	}
+	got := loadRestartHistory(path)
+	if got.Version != want.Version || got.InstallEpoch != want.InstallEpoch || len(got.Timestamps) != len(want.Timestamps) {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", got, want)
+	}
+
+	// Corrupt file -> empty, no error.
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadRestartHistory(path); got.Version != "" {
+		t.Fatalf("corrupt file must load empty, got %+v", got)
+	}
+}
+
+// TestApplyStartupRestartThrottle_EngagesPastThreshold drives the wired entrypoint
+// with an injected clock + sleep + temp state dir: the delay engages only after the
+// threshold and the injected sleep receives it (no real sleeping).
+func TestApplyStartupRestartThrottle_EngagesPastThreshold(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KABOOM_STATE_DIR", dir)
+
+	oldNow, oldEpoch, oldSleep, oldVer := daemonNow, daemonInstallEpoch, daemonThrottleSleep, version
+	defer func() {
+		daemonNow = oldNow
+		daemonInstallEpoch = oldEpoch
+		daemonThrottleSleep = oldSleep
+		version = oldVer
+	}()
+	version = "9.9.9"
+	daemonInstallEpoch = func() int64 { return 777 }
+
+	base := time.Unix(1_700_000_000, 0)
+	fakeNow := base
+	daemonNow = func() time.Time { return fakeNow }
+
+	var slept time.Duration
+	daemonThrottleSleep = func(d time.Duration) { slept += d }
+
+	server, err := NewServer(filepath.Join(dir, "throttle.log"), 100)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+	defer server.logs.shutdownAsyncLogger(2 * time.Second)
+
+	// The first restartThrottleMax rapid starts do not throttle.
+	for i := 0; i < restartThrottleMax; i++ {
+		fakeNow = base.Add(time.Duration(i) * time.Second)
+		if d := applyStartupRestartThrottle(server, 7890); d != 0 {
+			t.Fatalf("start %d within threshold: want no delay, got %s", i+1, d)
+		}
+	}
+	if slept != 0 {
+		t.Fatalf("no delay should have been slept yet, got %s", slept)
+	}
+
+	// The next rapid start engages the backoff, and the injected sleep receives it.
+	fakeNow = base.Add(time.Duration(restartThrottleMax) * time.Second)
+	d := applyStartupRestartThrottle(server, 7890)
+	if d != restartThrottleStep {
+		t.Fatalf("over-threshold start: want delay %s, got %s", restartThrottleStep, d)
+	}
+	if slept != restartThrottleStep {
+		t.Fatalf("injected sleep must receive the delay, got %s", slept)
+	}
+}

--- a/cmd/browser-agent/startup_throttle_test.go
+++ b/cmd/browser-agent/startup_throttle_test.go
@@ -171,3 +171,75 @@ func TestApplyStartupRestartThrottle_EngagesPastThreshold(t *testing.T) {
 		t.Fatalf("injected sleep must receive the delay, got %s", slept)
 	}
 }
+
+// TestCleanShutdownResetsRestartThrottle is the regression for the release-gate break:
+// legitimate rapid stop/start cycles (which the test suite and real users perform) must
+// NOT accumulate toward the throttle. A clean shutdown clears the history, so a rapid
+// restart right after a clean stop is never throttled — only an uncleared (crash) run is.
+func TestCleanShutdownResetsRestartThrottle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KABOOM_STATE_DIR", dir)
+
+	oldNow, oldEpoch, oldSleep, oldVer := daemonNow, daemonInstallEpoch, daemonThrottleSleep, version
+	defer func() {
+		daemonNow = oldNow
+		daemonInstallEpoch = oldEpoch
+		daemonThrottleSleep = oldSleep
+		version = oldVer
+	}()
+	version = "9.9.9"
+	daemonInstallEpoch = func() int64 { return 777 }
+	base := time.Unix(1_700_000_000, 0)
+	fakeNow := base
+	daemonNow = func() time.Time { return fakeNow }
+	daemonThrottleSleep = func(time.Duration) {}
+
+	server, err := NewServer(filepath.Join(dir, "throttle-reset.log"), 100)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+	defer server.logs.shutdownAsyncLogger(2 * time.Second)
+
+	// Drive rapid starts past the threshold so the backoff is engaged.
+	for i := 0; i <= restartThrottleMax; i++ {
+		fakeNow = base.Add(time.Duration(i) * time.Second)
+		_ = applyStartupRestartThrottle(server, 7890)
+	}
+	fakeNow = base.Add(time.Duration(restartThrottleMax+1) * time.Second)
+	if d := applyStartupRestartThrottle(server, 7890); d <= 0 {
+		t.Fatalf("precondition: throttle should be engaged before the clean shutdown, got %s", d)
+	}
+
+	// A clean shutdown clears the history...
+	clearRestartHistoryOnCleanShutdown(server, 7890)
+
+	// ...so the very next rapid start is NOT throttled (counter reset).
+	fakeNow = base.Add(time.Duration(restartThrottleMax+2) * time.Second)
+	if d := applyStartupRestartThrottle(server, 7890); d != 0 {
+		t.Fatalf("after a clean shutdown, a rapid restart must not be throttled, got %s", d)
+	}
+}
+
+// TestClearRestartHistoryOnCleanShutdown asserts the clear removes the history file and
+// is a no-op (no error/log) when the file is already absent.
+func TestClearRestartHistoryOnCleanShutdown(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KABOOM_STATE_DIR", dir)
+
+	server, err := NewServer(filepath.Join(dir, "clear.log"), 100)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+	defer server.logs.shutdownAsyncLogger(2 * time.Second)
+
+	path := restartHistoryPath(dir)
+	if err := saveRestartHistory(path, restartHistory{Version: "1.0.0", Timestamps: []int64{1, 2, 3}}); err != nil {
+		t.Fatalf("saveRestartHistory error = %v", err)
+	}
+	clearRestartHistoryOnCleanShutdown(server, 7890)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("clear must remove the history file, stat err = %v", err)
+	}
+	// Idempotent: clearing an already-absent history is a no-op.
+	clearRestartHistoryOnCleanShutdown(server, 7890)
+}

--- a/cmd/browser-agent/startup_throttle_test.go
+++ b/cmd/browser-agent/startup_throttle_test.go
@@ -18,7 +18,7 @@ func TestRecordRestartAndComputeDelay_ThrottlesRapidRestarts(t *testing.T) {
 	// The first restartThrottleMax restarts, all inside the window, are free.
 	for i := 0; i < restartThrottleMax; i++ {
 		var delay time.Duration
-		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100)
+		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100, throttleTestPort)
 		if delay != 0 {
 			t.Fatalf("restart %d within threshold: want delay 0, got %s", i+1, delay)
 		}
@@ -26,20 +26,20 @@ func TestRecordRestartAndComputeDelay_ThrottlesRapidRestarts(t *testing.T) {
 
 	// The (max+1)-th rapid restart engages the backoff: one step.
 	var delay time.Duration
-	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax)*time.Second), "1.0.0", 100)
+	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax)*time.Second), "1.0.0", 100, throttleTestPort)
 	if delay != restartThrottleStep {
 		t.Fatalf("first over-threshold restart: want delay %s, got %s", restartThrottleStep, delay)
 	}
 
 	// The next one escalates by another step.
-	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+1)*time.Second), "1.0.0", 100)
+	h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+1)*time.Second), "1.0.0", 100, throttleTestPort)
 	if delay != 2*restartThrottleStep {
 		t.Fatalf("second over-threshold restart: want delay %s, got %s", 2*restartThrottleStep, delay)
 	}
 
 	// Escalation is capped.
 	for i := 0; i < 20; i++ {
-		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+2+i)*time.Second), "1.0.0", 100)
+		h, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+2+i)*time.Second), "1.0.0", 100, throttleTestPort)
 	}
 	if delay != restartThrottleCap {
 		t.Fatalf("escalating delay must be capped at %s, got %s", restartThrottleCap, delay)
@@ -56,7 +56,7 @@ func TestRecordRestartAndComputeDelay_SpacedOutNeverThrottles(t *testing.T) {
 		// Each restart is a full window + 1s after the previous, so pruning keeps
 		// the count at 1 every time.
 		now := base.Add(time.Duration(i) * (restartThrottleWindow + time.Second))
-		h, delay = recordRestartAndComputeDelay(h, now, "1.0.0", 100)
+		h, delay = recordRestartAndComputeDelay(h, now, "1.0.0", 100, throttleTestPort)
 		if delay != 0 {
 			t.Fatalf("spaced-out restart %d must not throttle, got delay %s", i+1, delay)
 		}
@@ -72,11 +72,11 @@ func TestRecordRestartAndComputeDelay_UpgradeResetsCounter(t *testing.T) {
 	// Build a history that is deep in throttle territory for install (1.0.0, epoch 100).
 	h := restartHistory{}
 	for i := 0; i < restartThrottleMax+5; i++ {
-		h, _ = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100)
+		h, _ = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100, throttleTestPort)
 	}
 
 	// An upgrade to a new VERSION at the same instant must reset -> no throttle.
-	next, delay := recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+5)*time.Second), "1.1.0", 100)
+	next, delay := recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+5)*time.Second), "1.1.0", 100, throttleTestPort)
 	if delay != 0 {
 		t.Fatalf("upgrade (new version) must not be throttled, got delay %s", delay)
 	}
@@ -85,9 +85,53 @@ func TestRecordRestartAndComputeDelay_UpgradeResetsCounter(t *testing.T) {
 	}
 
 	// A same-version but new-EPOCH takeover must likewise reset.
-	_, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+6)*time.Second), "1.0.0", 200)
+	_, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+6)*time.Second), "1.0.0", 200, throttleTestPort)
 	if delay != 0 {
 		t.Fatalf("epoch takeover (new epoch) must not be throttled, got delay %s", delay)
+	}
+}
+
+// throttleTestPort is the port used by the pure-function tests. The throttle is
+// scoped per listening port, so tests that are not specifically about port scoping
+// must all use the same one.
+const throttleTestPort = 7890
+
+// TestRecordRestartAndComputeDelay_DifferentPortIsADifferentInstance is the
+// regression for the CI break this scoping fixes.
+//
+// A restart storm is about ONE endpoint being restarted over and over — that is
+// what launchd throttles. Counting every daemon that happens to share a state dir
+// conflated unrelated instances: the Go test suite spawns many short-lived daemons
+// on distinct random ports inside one state dir, crossed the threshold, and then
+// every subsequent start slept up to the 3s cap — so ~25 integration tests failed
+// with "Server failed to start" on CI while passing locally (the -race suite is
+// slow enough to spread restarts past the 30s window; the coverage run is not).
+//
+// Production is unaffected: the daemon always uses the same port, so a genuine
+// crash loop still accumulates and still backs off.
+func TestRecordRestartAndComputeDelay_DifferentPortIsADifferentInstance(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+
+	// Drive one port deep into throttle territory.
+	h := restartHistory{}
+	for i := 0; i < restartThrottleMax+5; i++ {
+		h, _ = recordRestartAndComputeDelay(h, base.Add(time.Duration(i)*time.Second), "1.0.0", 100, 7890)
+	}
+
+	// A start on a DIFFERENT port at the same instant is a different daemon
+	// instance, not a restart of the throttled one — it must not be penalized.
+	next, delay := recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+5)*time.Second), "1.0.0", 100, 45291)
+	if delay != 0 {
+		t.Fatalf("a different port is a different instance and must not be throttled, got delay %s", delay)
+	}
+	if next.Port != 45291 || len(next.Timestamps) != 1 {
+		t.Fatalf("a different port must start a fresh history, got port=%d timestamps=%d", next.Port, len(next.Timestamps))
+	}
+
+	// And the same port keeps accumulating — the guard must not disable the defense.
+	_, delay = recordRestartAndComputeDelay(h, base.Add(time.Duration(restartThrottleMax+6)*time.Second), "1.0.0", 100, 7890)
+	if delay == 0 {
+		t.Fatal("the same port must still accumulate toward the storm threshold")
 	}
 }
 

--- a/cmd/browser-agent/version_compare.go
+++ b/cmd/browser-agent/version_compare.go
@@ -30,6 +30,14 @@ func parseVersionParts(v string) []int {
 	return parts
 }
 
+// sameNonEmptyVersion reports whether a and b are both non-empty and parse to the
+// same semver (neither strictly newer). Used to gate the install-epoch takeover
+// tiebreaker to genuinely equal versions — a blank/unparseable version is never
+// treated as "same", so the epoch rule can't fire on unknown data.
+func sameNonEmptyVersion(a, b string) bool {
+	return a != "" && b != "" && !isNewerVersion(a, b) && !isNewerVersion(b, a)
+}
+
 // isNewerVersion returns true if candidate is strictly newer than current.
 // Both strings are parsed as semver (with optional "v" prefix).
 // Returns false for equal versions, malformed input, or empty strings.

--- a/docs/features/feature/bridge-restart/index.md
+++ b/docs/features/feature/bridge-restart/index.md
@@ -4,13 +4,13 @@ feature_id: feature-bridge-restart
 status: implemented
 feature_type: feature
 owners: []
-last_reviewed: 2026-07-05
+last_reviewed: 2026-07-26
 code_paths:
   - cmd/browser-agent/bridge.go
   - cmd/browser-agent/bridge_startup.go
   - cmd/browser-agent/bridge_startup_orchestration.go
   - cmd/browser-agent/bridge_startup_lock.go
-  - cmd/browser-agent/bridge_startup_state.go
+  - cmd/browser-agent/internal/bridge/bridge_startup_state.go
   - cmd/browser-agent/bridge_startup_status.go
   - cmd/browser-agent/tools_configure.go
   - cmd/browser-agent/tools_schema.go
@@ -21,6 +21,7 @@ test_paths:
   - cmd/browser-agent/bridge_startup_contention_test.go
   - cmd/browser-agent/bridge_faststart_extended_test.go
   - cmd/browser-agent/bridge_fastpath_unit_test.go
+  - cmd/browser-agent/internal/bridge/bridge_respawn_backoff_test.go
 last_verified_version: 0.7.12
 last_verified_date: 2026-03-05
 ---

--- a/docs/features/feature/mcp-persistent-server/index.md
+++ b/docs/features/feature/mcp-persistent-server/index.md
@@ -4,12 +4,16 @@ feature_id: feature-mcp-persistent-server
 status: shipped
 feature_type: feature
 owners: []
-last_reviewed: 2026-07-05
+last_reviewed: 2026-07-26
 code_paths:
   - cmd/browser-agent/mcp_identity.go
   - cmd/browser-agent/bridge_adapter.go
   - cmd/browser-agent/internal/bridge/bridge.go
   - cmd/browser-agent/internal/bridge/bridge_startup_orchestration.go
+  - cmd/browser-agent/daemon_lifecycle.go
+  - cmd/browser-agent/startup_throttle.go
+  - cmd/browser-agent/main_connection_mcp.go
+  - cmd/browser-agent/main_connection_mcp_shutdown.go
   - cmd/browser-agent/server_middleware.go
   - cmd/browser-agent/handler_http.go
   - cmd/browser-agent/connect_mode.go
@@ -27,6 +31,10 @@ test_paths:
   - cmd/browser-agent/server_routes_unit_test.go
   - cmd/browser-agent/main_connection_diag_test.go
   - cmd/browser-agent/internal/bridge/bridge_fastpath_unit_test.go
+  - cmd/browser-agent/internal/bridge/bridge_detach_stdio_test.go
+  - cmd/browser-agent/internal/bridge/bridge_deps_isolation_test.go
+  - cmd/browser-agent/daemon_lifecycle_takeover_test.go
+  - cmd/browser-agent/startup_throttle_test.go
   - tests/regression/08-fast-start/test-fast-start.sh
 last_verified_version: 0.8.1
 last_verified_date: 2026-03-29

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -566,6 +566,22 @@ fi
 if [ "$HOOKS_ONLY" != "1" ]; then
     BINARY_NAME="kaboom-agentic-browser-$PLATFORM-$E_ARCH$BINARY_EXT"
     download_and_verify "$BINARY_NAME" "$CANONICAL_KABOOM_BIN" "$MIN_BINARY_BYTES" "kaboom binary"
+
+    # Stamp this install's epoch next to the binary so the daemon's single-instance
+    # takeover has a deterministic tiebreaker at equal versions: the LATEST install
+    # wins (see install_epoch.go). Without it, two same-version installs (e.g. this
+    # one and an npm-global copy) thrash — a takeover war that crash-loops the daemon.
+    # Unit is UnixNano to match the binary-mtime fallback; GNU date gives it via %N,
+    # BSD/macOS date lacks %N so we fall back to whole seconds scaled to nanoseconds.
+    INSTALL_EPOCH_NS="$(date +%s%N 2>/dev/null)"
+    case "$INSTALL_EPOCH_NS" in
+        ''|*[!0-9]*) INSTALL_EPOCH_NS="$(date +%s)000000000" ;;
+    esac
+    if printf '%s\n' "$INSTALL_EPOCH_NS" > "$BIN_DIR/.kaboom-install-epoch" 2>/dev/null; then
+        echo -e "${GREEN}Install epoch stamped (latest install wins).${NC}"
+    else
+        echo -e "${YELLOW}  Could not write install epoch stamp; daemon will fall back to binary mtime.${NC}"
+    fi
 fi
 
 # --- Always install hooks binary ---

--- a/tests/cli/install.test.cjs
+++ b/tests/cli/install.test.cjs
@@ -147,3 +147,17 @@ test('install-bundled-skills.sh markers match the real bundled manifest versions
     fs.rmSync(tmp, { recursive: true, force: true })
   }
 })
+
+test('installer stamps the install epoch next to the binary (latest-install-wins tiebreaker)', () => {
+  const installSh = fs.readFileSync(path.join(REPO_ROOT, 'scripts/install.sh'), 'utf8')
+  // A per-install epoch stamp gives the daemon's single-instance takeover a
+  // deterministic tiebreaker at equal versions (see install_epoch.go): the latest
+  // install wins, so two same-version installs can't thrash into a takeover war.
+  assert.match(installSh, /\.kaboom-install-epoch/, 'install.sh must write the .kaboom-install-epoch stamp')
+  // Nanosecond units (to match the binary-mtime fallback), with a BSD/macOS
+  // whole-seconds fallback since their date lacks %N.
+  assert.match(installSh, /date \+%s%N/, 'stamp should prefer GNU date %N nanoseconds')
+  assert.match(installSh, /date \+%s\)000000000/, 'stamp needs a BSD/macOS seconds-scaled-to-nanos fallback')
+  // Next to the binary in BIN_DIR, where install_epoch.go looks for it.
+  assert.match(installSh, /"\$BIN_DIR\/\.kaboom-install-epoch"/, 'stamp must live next to the binary in BIN_DIR')
+})


### PR DESCRIPTION
## Why

The daemon was dying seconds after an MCP client disconnected, then fighting itself to come back. Root cause was **not** the takeover logic — it was SIGPIPE.

`buildDaemonCmd` set `cmd.Stdout/Stderr = io.Discard`. Because `io.Discard` is not an `*os.File`, `os/exec` routes it through an OS pipe **owned by the bridge**. When the bridge exits on stdin EOF those pipes close, and the daemon's next stderr write takes SIGPIPE and dies. `setsid` does not help — it does not detach inherited pipe fds.

## What

| Commit | Fix |
|---|---|
| `aa17c6e7` | **The killer.** Spawn detached to `/dev/null` (`nil`), not `io.Discard` |
| `2febe096` + `23bd9cf2` | Install-epoch tiebreaker — at equal versions the newest install wins, so "latest install wins" is deterministic instead of a race |
| `95406dd7` | Finding L — a single refused health probe no longer takes over a live daemon unless its PID is also dead |
| `a65ec5ad` | Bounded respawn backoff in the bridge (1s→8s capped) so a dying daemon can't become a spawn storm |
| `f8ba34cf` + `efa36c88` | launchd restart-storm self-defense: warns and delays (3s cap), **never refuses to start** |
| `f64094d2` | Test hygiene — `initTestDeps` restores the package-global `deps` via `t.Cleanup` |
| `1469f892` | Docs cross-ref (rule 9) |

## Notes for review

- The restart throttle is keyed by `(version, install_epoch)`, so a legitimate upgrade resets the counter and is never counted as a crash-restart. It is cleared on clean shutdown, so ordinary stop/start cycles never accumulate.
- `efa36c88` fixes a regression introduced by `f8ba34cf`: counting *every* start broke the `TestIntegration_ServerStartupUnder1Second` release gate (3.04s vs the 1s budget). Gating on `UnderSupervisor` was rejected — the macOS LaunchAgent plist sets no supervisor env marker and modern launchd doesn't export `LAUNCH_JOB_KEY`, so it would have disabled the throttle for the very daemon this defends. Distinguisher is graceful-vs-crash exit instead. Startup now measures 610ms.

## Gates

`go build` + `go vet` clean · **14/14 Go packages under `-race`** · `verify-llm` passed (0 errors) · no TS/`src/` files touched, so `compile-ts` not required.