### PR TITLE
feat(cli): auto-approve Kaboom's MCP tools at install so users aren't prompted per call

### DIFF
--- a/docs/features/feature/enhanced-cli-config/index.md
+++ b/docs/features/feature/enhanced-cli-config/index.md
@@ -4,7 +4,7 @@ feature_id: feature-enhanced-cli-config
 status: proposed
 feature_type: feature
 owners: []
-last_reviewed: 2026-07-24
+last_reviewed: 2026-07-26
 code_paths:
   - Makefile
   - scripts/build-crx.js
@@ -26,12 +26,18 @@ code_paths:
   - npm/kaboom-agentic-browser/lib/install.js
   - npm/kaboom-agentic-browser/lib/uninstall.js
   - npm/kaboom-agentic-browser/lib/cli.js
+  - npm/kaboom-agentic-browser/lib/output.js
+  - npm/kaboom-agentic-browser/lib/auto-approve.js
+  - npm/kaboom-agentic-browser/lib/codex-config.js
   - docs/mcp-install-guide.md
 test_paths:
   - cmd/browser-agent/native_install_test.go
   - cmd/browser-agent/native_install_open_test.go
   - cmd/browser-agent/native_install_connect_test.go
   - npm/kaboom-agentic-browser/lib/config.test.js
+  - npm/kaboom-agentic-browser/lib/auto-approve.test.js
+  - npm/kaboom-agentic-browser/lib/codex-config.test.js
+  - npm/kaboom-agentic-browser/lib/output.test.js
   - npm/kaboom-agentic-browser/lib/extension.test.js
   - npm/kaboom-agentic-browser/lib/browser.test.js
   - npm/kaboom-agentic-browser/lib/health.test.js
@@ -84,3 +90,21 @@ last_verified_date: 2026-03-28
 - PyPI wrapper config helpers now converge on `merge_kaboom_config(...)`, and packaged `.egg-info` metadata now exposes only Kaboom package names, entry points, and repo URLs.
 - Platform npm packages now ship `kaboom-agentic-browser` and `kaboom-hooks` binaries while preserving legacy cleanup for customer machines.
 - Server postinstall now validates `kaboom-browser-devtools` on `/health` reuse checks and points manual extension loading at `KABOOM_EXTENSION_DIR` / `~/KaboomAgenticDevtoolExtension`.
+- Install now also fixes the Claude Code `claude mcp add-json` invocation (JSON passed as a positional arg, not stdin) and adds **Codex CLI** as a supported client (`~/.codex/config.toml`, TOML; honors `$CODEX_HOME`).
+
+## Tool Auto-Approve (default-ON)
+
+Install trusts **all** Kaboom MCP tools by default in every client that exposes a verified config-file mechanism, so the user is never prompted. It is merge-safe (preserves existing config, dedupes, creates keys/file when absent, fails loud on genuine write errors), and uninstall removes every entry it added.
+
+| Client | Config-file mechanism (verified) | Implemented |
+| --- | --- | --- |
+| Claude Code | `~/.claude/settings.json` → `permissions.allow += "mcp__kaboom-browser-devtools"` (bare rule = all tools) — [docs](https://code.claude.com/docs/en/permissions) | Yes |
+| Gemini CLI | `mcpServers.<name>.trust = true` — [docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md) | Yes |
+| OpenCode | `permission["kaboom-browser-devtools_*"] = "allow"` — [docs](https://opencode.ai/docs/permissions/) | Yes |
+| Zed | `agent.tool_permissions.tools["mcp:kaboom-browser-devtools:<tool>"] = {default:"allow"}` (per-tool; no server wildcard) — [docs](https://zed.dev/docs/ai/tool-permissions) | Yes |
+| Codex CLI | `[mcp_servers.kaboom-browser-devtools] default_tools_approval_mode = "approve"` — [docs](https://developers.openai.com/codex/mcp) | Yes |
+| Claude Desktop | none (no official `autoApprove` field; UI approval only) | UI-only |
+| Cursor | none (mcp.json has no trust field; UI Run Modes) — [docs](https://cursor.com/docs/context/mcp) | UI-only |
+| Windsurf | none (mcp_config.json has no trust field; UI Turbo) | UI-only |
+| VS Code | only a **global** `chat.tools.global.autoApprove` (trusts every server) — out of scope for a Kaboom-scoped installer — [docs](https://code.visualstudio.com/docs/agents/approvals) | UI-only |
+| Antigravity | none in mcp_config.json (auto-approve is a separate UI-managed policy) | UI-only |

--- a/npm/kaboom-agentic-browser/lib/auto-approve.js
+++ b/npm/kaboom-agentic-browser/lib/auto-approve.js
@@ -1,0 +1,304 @@
+// auto-approve.js — Config-based whole-server MCP tool auto-approval.
+// Why: Kaboom is the user's own local tool on their own machine, so the
+// installer trusts ALL of its tools by default (default-ON) in every client
+// that exposes a config-file trust mechanism — no per-call approval prompt.
+// Clients whose only auto-approve is a UI toggle (or a global "trust everything"
+// switch) are left untouched and reported as UI-only; we never invent a field.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  MCP_SERVER_NAME,
+  LEGACY_MCP_SERVER_NAMES,
+  readConfigFile,
+  writeConfigFile,
+} = require('./config');
+
+// The five Kaboom MCP tools. Needed where a client cannot wildcard a whole
+// server and each tool must be named individually (Zed).
+const KABOOM_TOOL_NAMES = ['observe', 'generate', 'configure', 'interact', 'analyze'];
+
+// Legacy server names other than the canonical one (used to clean up stale
+// auto-approve entries from older installs during uninstall).
+const LEGACY_SERVER_NAMES = LEGACY_MCP_SERVER_NAMES.filter((n) => n !== MCP_SERVER_NAME);
+
+// --- Claude Code: ~/.claude/settings.json permissions.allow ---
+// A bare `mcp__<server>` (no tool suffix) wildcard-approves EVERY tool of that
+// server. Verified: https://code.claude.com/docs/en/permissions
+const CLAUDE_ALLOW_RULE = `mcp__${MCP_SERVER_NAME}`;
+const CLAUDE_LEGACY_ALLOW_RULES = LEGACY_SERVER_NAMES.map((n) => `mcp__${n}`);
+
+// --- OpenCode: opencode.json top-level `permission` object ---
+// `<server>_*` covers every tool of the server.
+// Verified: https://opencode.ai/docs/permissions/ + https://opencode.ai/docs/tools/
+const OPENCODE_PERMISSION_KEY = `${MCP_SERVER_NAME}_*`;
+const OPENCODE_LEGACY_PERMISSION_KEYS = LEGACY_SERVER_NAMES.map((n) => `${n}_*`);
+
+// --- Zed: settings.json agent.tool_permissions.tools ---
+// MCP tools are referenced as `mcp:<server>:<tool>`; Zed has no server-level
+// wildcard, so each tool is enumerated.
+// Verified: https://zed.dev/docs/ai/tool-permissions
+function zedToolRefs(serverName) {
+  return KABOOM_TOOL_NAMES.map((t) => `mcp:${serverName}:${t}`);
+}
+
+/**
+ * Get parent[key] as a plain object, creating it when absent. Returns null when
+ * an existing value is a non-object (malformed) so callers refuse to clobber it.
+ */
+function ensureObject(parent, key) {
+  if (parent[key] === undefined || parent[key] === null) {
+    parent[key] = {};
+    return parent[key];
+  }
+  if (typeof parent[key] !== 'object' || Array.isArray(parent[key])) {
+    return null;
+  }
+  return parent[key];
+}
+
+/**
+ * Apply the same-file (JSON) auto-approve for a client into an already-parsed
+ * config object (the same object that carries the freshly-merged server entry),
+ * so the install writes server + trust in one atomic write.
+ * @param {Object} def Client definition (reads def.autoApprove.kind + def.configKey)
+ * @param {Object} configData Parsed config to mutate in place
+ * @returns {boolean} true when auto-approve was written
+ */
+function applyToConfig(def, configData) {
+  const kind = def.autoApprove && def.autoApprove.kind;
+
+  if (kind === 'gemini-trust') {
+    // trust lives on the server entry itself; the entry is created before this.
+    const key = def.configKey || 'mcpServers';
+    const servers = configData[key];
+    if (servers && typeof servers === 'object' && servers[MCP_SERVER_NAME] && typeof servers[MCP_SERVER_NAME] === 'object') {
+      servers[MCP_SERVER_NAME].trust = true;
+      return true;
+    }
+    return false;
+  }
+
+  if (kind === 'opencode-permission') {
+    const permission = ensureObject(configData, 'permission');
+    if (!permission) return false; // malformed existing value — do not clobber
+    for (const legacy of OPENCODE_LEGACY_PERMISSION_KEYS) delete permission[legacy];
+    permission[OPENCODE_PERMISSION_KEY] = 'allow';
+    return true;
+  }
+
+  if (kind === 'zed-tool-permissions') {
+    const agent = ensureObject(configData, 'agent');
+    if (!agent) return false;
+    const toolPermissions = ensureObject(agent, 'tool_permissions');
+    if (!toolPermissions) return false;
+    const tools = ensureObject(toolPermissions, 'tools');
+    if (!tools) return false;
+    for (const ref of zedToolRefs(MCP_SERVER_NAME)) {
+      tools[ref] = { default: 'allow' };
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Remove the same-file (JSON) auto-approve entries for a client from a parsed
+ * config object, cleaning up any empty containers we created. Symmetric with
+ * applyToConfig. gemini-trust needs nothing here — its trust flag lives on the
+ * server entry, which the server-name removal already deletes.
+ * @returns {boolean} true when something was removed
+ */
+function removeFromConfig(def, configData) {
+  const kind = def.autoApprove && def.autoApprove.kind;
+  let changed = false;
+
+  if (kind === 'opencode-permission') {
+    const permission = configData.permission;
+    if (permission && typeof permission === 'object' && !Array.isArray(permission)) {
+      for (const k of [OPENCODE_PERMISSION_KEY, ...OPENCODE_LEGACY_PERMISSION_KEYS]) {
+        if (Object.prototype.hasOwnProperty.call(permission, k)) {
+          delete permission[k];
+          changed = true;
+        }
+      }
+      if (changed && Object.keys(permission).length === 0) delete configData.permission;
+    }
+    return changed;
+  }
+
+  if (kind === 'zed-tool-permissions') {
+    const agent = configData.agent;
+    const toolPermissions = agent && agent.tool_permissions;
+    const tools = toolPermissions && toolPermissions.tools;
+    if (tools && typeof tools === 'object' && !Array.isArray(tools)) {
+      for (const name of [MCP_SERVER_NAME, ...LEGACY_SERVER_NAMES]) {
+        for (const ref of zedToolRefs(name)) {
+          if (Object.prototype.hasOwnProperty.call(tools, ref)) {
+            delete tools[ref];
+            changed = true;
+          }
+        }
+      }
+      if (changed) {
+        if (Object.keys(tools).length === 0) delete toolPermissions.tools;
+        if (Object.keys(toolPermissions).length === 0) delete agent.tool_permissions;
+        if (Object.keys(agent).length === 0) delete configData.agent;
+      }
+    }
+    return changed;
+  }
+
+  return false;
+}
+
+/**
+ * Whether a client's same-file auto-approve entries exist in a parsed config.
+ * Used by uninstall so a config carrying only auto-approve keys (server entry
+ * already gone) is still recognized as configured and cleaned.
+ * @returns {boolean}
+ */
+function autoApprovePresent(def, configData) {
+  const kind = def.autoApprove && def.autoApprove.kind;
+
+  if (kind === 'opencode-permission') {
+    const permission = configData.permission;
+    if (permission && typeof permission === 'object') {
+      return [OPENCODE_PERMISSION_KEY, ...OPENCODE_LEGACY_PERMISSION_KEYS]
+        .some((k) => Object.prototype.hasOwnProperty.call(permission, k));
+    }
+    return false;
+  }
+
+  if (kind === 'zed-tool-permissions') {
+    const tools = configData.agent && configData.agent.tool_permissions && configData.agent.tool_permissions.tools;
+    if (tools && typeof tools === 'object') {
+      return [MCP_SERVER_NAME, ...LEGACY_SERVER_NAMES]
+        .some((name) => zedToolRefs(name).some((ref) => Object.prototype.hasOwnProperty.call(tools, ref)));
+    }
+    return false;
+  }
+
+  return false;
+}
+
+/** Whether this kind of auto-approve is written into the same JSON config file. */
+function isSameFileKind(def) {
+  const kind = def.autoApprove && def.autoApprove.kind;
+  return kind === 'gemini-trust' || kind === 'opencode-permission' || kind === 'zed-tool-permissions';
+}
+
+// --- Claude Code: separate ~/.claude/settings.json ---
+
+/** Default user-scope Claude settings path (env override for hermetic tests). */
+function defaultClaudeSettingsPath(homeDir) {
+  if (process.env.KABOOM_CLAUDE_SETTINGS_PATH) return process.env.KABOOM_CLAUDE_SETTINGS_PATH;
+  return path.join(homeDir || os.homedir(), '.claude', 'settings.json');
+}
+
+/**
+ * Read a settings.json for Claude Code. Returns a plain object (empty when the
+ * file is absent). Throws on malformed JSON or a non-object top-level value so
+ * genuine problems surface instead of clobbering the user's file.
+ */
+function readClaudeSettings(settingsPath) {
+  if (!fs.existsSync(settingsPath)) return {};
+  const read = readConfigFile(settingsPath); // throws InvalidJSONError on bad JSON
+  if (!read.valid) {
+    throw new Error(`Cannot read Claude settings at ${settingsPath}: ${read.error}`);
+  }
+  const data = read.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`Refusing to modify malformed Claude settings at ${settingsPath}`);
+  }
+  return data;
+}
+
+/**
+ * Add the Kaboom allow rule to ~/.claude/settings.json `permissions.allow`.
+ * Merge-safe: preserves every existing setting and rule, dedupes, creates the
+ * keys/file when absent.
+ * @param {{settingsPath?:string, homeDir?:string, dryRun?:boolean}} [options]
+ * @returns {{status:'applied'|'unchanged', path:string, changed:boolean, dryRun?:boolean}}
+ */
+function applyClaudeSettingsAllow(options = {}) {
+  const settingsPath = options.settingsPath || defaultClaudeSettingsPath(options.homeDir);
+  const dryRun = !!options.dryRun;
+  const data = readClaudeSettings(settingsPath);
+
+  const permissions = (data.permissions && typeof data.permissions === 'object' && !Array.isArray(data.permissions))
+    ? data.permissions
+    : {};
+  const allow = Array.isArray(permissions.allow) ? permissions.allow : [];
+
+  if (allow.includes(CLAUDE_ALLOW_RULE)) {
+    return { status: 'unchanged', path: settingsPath, changed: false };
+  }
+  if (dryRun) {
+    return { status: 'applied', path: settingsPath, changed: true, dryRun: true };
+  }
+
+  const nextData = {
+    ...data,
+    permissions: { ...permissions, allow: [...allow, CLAUDE_ALLOW_RULE] },
+  };
+  writeConfigFile(settingsPath, nextData, false, { skipValidation: true });
+  return { status: 'applied', path: settingsPath, changed: true };
+}
+
+/**
+ * Remove the Kaboom (and legacy) allow rules from ~/.claude/settings.json,
+ * pruning now-empty `allow`/`permissions` containers. Never deletes the file
+ * (it is a shared user settings file).
+ * @returns {{status:'removed'|'notConfigured', path:string, changed:boolean, dryRun?:boolean}}
+ */
+function removeClaudeSettingsAllow(options = {}) {
+  const settingsPath = options.settingsPath || defaultClaudeSettingsPath(options.homeDir);
+  const dryRun = !!options.dryRun;
+  if (!fs.existsSync(settingsPath)) {
+    return { status: 'notConfigured', path: settingsPath, changed: false };
+  }
+  const data = readClaudeSettings(settingsPath);
+  const permissions = data.permissions;
+  if (!permissions || typeof permissions !== 'object' || !Array.isArray(permissions.allow)) {
+    return { status: 'notConfigured', path: settingsPath, changed: false };
+  }
+
+  const rules = [CLAUDE_ALLOW_RULE, ...CLAUDE_LEGACY_ALLOW_RULES];
+  const nextAllow = permissions.allow.filter((r) => !rules.includes(r));
+  if (nextAllow.length === permissions.allow.length) {
+    return { status: 'notConfigured', path: settingsPath, changed: false };
+  }
+  if (dryRun) {
+    return { status: 'removed', path: settingsPath, changed: true, dryRun: true };
+  }
+
+  const nextPermissions = { ...permissions };
+  if (nextAllow.length === 0) delete nextPermissions.allow;
+  else nextPermissions.allow = nextAllow;
+
+  const nextData = { ...data };
+  if (Object.keys(nextPermissions).length === 0) delete nextData.permissions;
+  else nextData.permissions = nextPermissions;
+
+  writeConfigFile(settingsPath, nextData, false, { skipValidation: true });
+  return { status: 'removed', path: settingsPath, changed: true };
+}
+
+module.exports = {
+  KABOOM_TOOL_NAMES,
+  CLAUDE_ALLOW_RULE,
+  CLAUDE_LEGACY_ALLOW_RULES,
+  OPENCODE_PERMISSION_KEY,
+  zedToolRefs,
+  applyToConfig,
+  removeFromConfig,
+  autoApprovePresent,
+  isSameFileKind,
+  defaultClaudeSettingsPath,
+  applyClaudeSettingsAllow,
+  removeClaudeSettingsAllow,
+};

--- a/npm/kaboom-agentic-browser/lib/auto-approve.test.js
+++ b/npm/kaboom-agentic-browser/lib/auto-approve.test.js
@@ -1,0 +1,371 @@
+// Purpose: Validate config-based whole-server MCP tool auto-approval writers.
+// Why: Wrong permission/trust fields silently break a user's config; these lock
+// the verified per-client mechanisms and the merge-safe round-trip.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const {
+  KABOOM_TOOL_NAMES,
+  CLAUDE_ALLOW_RULE,
+  OPENCODE_PERMISSION_KEY,
+  applyToConfig,
+  removeFromConfig,
+  autoApprovePresent,
+  isSameFileKind,
+  applyClaudeSettingsAllow,
+  removeClaudeSettingsAllow,
+} = require('./auto-approve');
+const { getClientById } = require('./config');
+const { installToClient } = require('./install');
+const { uninstallFromClient } = require('./uninstall');
+
+const SERVER = 'kaboom-browser-devtools';
+
+function tmpdir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-autoapprove-'));
+}
+
+// --- constants ---
+
+test('CLAUDE_ALLOW_RULE is the bare server rule (approves ALL tools of the server)', () => {
+  assert.equal(CLAUDE_ALLOW_RULE, 'mcp__kaboom-browser-devtools');
+});
+
+test('OPENCODE_PERMISSION_KEY wildcards the whole server with the underscore form', () => {
+  assert.equal(OPENCODE_PERMISSION_KEY, 'kaboom-browser-devtools_*');
+});
+
+test('KABOOM_TOOL_NAMES lists exactly the five MCP tools', () => {
+  assert.deepEqual(KABOOM_TOOL_NAMES, ['observe', 'generate', 'configure', 'interact', 'analyze']);
+});
+
+// --- applyToConfig / removeFromConfig (pure) ---
+
+test('applyToConfig gemini-trust sets trust:true on the server entry only', () => {
+  const def = { autoApprove: { kind: 'gemini-trust' }, configKey: 'mcpServers' };
+  const cfg = { mcpServers: { [SERVER]: { command: 'x', args: [] }, other: { command: 'y' } } };
+  assert.equal(applyToConfig(def, cfg), true);
+  assert.equal(cfg.mcpServers[SERVER].trust, true);
+  assert.equal(cfg.mcpServers.other.trust, undefined, 'other servers untouched');
+});
+
+test('applyToConfig opencode-permission adds the wildcard allow and preserves existing permissions', () => {
+  const def = { autoApprove: { kind: 'opencode-permission' } };
+  const cfg = { mcp: { [SERVER]: {} }, permission: { bash: 'ask' } };
+  assert.equal(applyToConfig(def, cfg), true);
+  assert.equal(cfg.permission[OPENCODE_PERMISSION_KEY], 'allow');
+  assert.equal(cfg.permission.bash, 'ask', 'existing permission keys preserved');
+});
+
+test('applyToConfig zed-tool-permissions enumerates all five tools and preserves user agent settings', () => {
+  const def = { autoApprove: { kind: 'zed-tool-permissions' } };
+  const cfg = { agent: { play_sound_when_agent_done: true } };
+  assert.equal(applyToConfig(def, cfg), true);
+  const tools = cfg.agent.tool_permissions.tools;
+  for (const t of KABOOM_TOOL_NAMES) {
+    assert.deepEqual(tools[`mcp:${SERVER}:${t}`], { default: 'allow' });
+  }
+  assert.equal(cfg.agent.play_sound_when_agent_done, true, 'user agent settings preserved');
+});
+
+test('applyToConfig zed-tool-permissions refuses to clobber a non-object agent', () => {
+  const def = { autoApprove: { kind: 'zed-tool-permissions' } };
+  const cfg = { agent: 'not-an-object' };
+  assert.equal(applyToConfig(def, cfg), false);
+  assert.equal(cfg.agent, 'not-an-object', 'malformed value left intact');
+});
+
+test('removeFromConfig opencode-permission removes the key and prunes an emptied permission map', () => {
+  const def = { autoApprove: { kind: 'opencode-permission' } };
+  const cfg = { permission: { [OPENCODE_PERMISSION_KEY]: 'allow' } };
+  assert.equal(removeFromConfig(def, cfg), true);
+  assert.equal(cfg.permission, undefined, 'empty permission map pruned');
+});
+
+test('removeFromConfig opencode-permission keeps other permission keys', () => {
+  const def = { autoApprove: { kind: 'opencode-permission' } };
+  const cfg = { permission: { [OPENCODE_PERMISSION_KEY]: 'allow', edit: 'deny' } };
+  assert.equal(removeFromConfig(def, cfg), true);
+  assert.equal(cfg.permission[OPENCODE_PERMISSION_KEY], undefined);
+  assert.equal(cfg.permission.edit, 'deny');
+});
+
+test('removeFromConfig zed-tool-permissions removes tool refs and prunes empty containers', () => {
+  const def = { autoApprove: { kind: 'zed-tool-permissions' } };
+  const cfg = {};
+  applyToConfig(def, cfg);
+  assert.equal(removeFromConfig(def, cfg), true);
+  assert.equal(cfg.agent, undefined, 'agent container pruned when we created it');
+});
+
+test('removeFromConfig zed-tool-permissions keeps user agent settings and other tool perms', () => {
+  const def = { autoApprove: { kind: 'zed-tool-permissions' } };
+  const cfg = {
+    agent: {
+      play_sound_when_agent_done: true,
+      tool_permissions: { tools: { 'mcp:other:foo': { default: 'confirm' } } },
+    },
+  };
+  applyToConfig(def, cfg);
+  assert.equal(removeFromConfig(def, cfg), true);
+  assert.equal(cfg.agent.play_sound_when_agent_done, true);
+  assert.deepEqual(cfg.agent.tool_permissions.tools, { 'mcp:other:foo': { default: 'confirm' } });
+});
+
+test('autoApprovePresent detects opencode and zed auto-approve keys', () => {
+  const oc = { autoApprove: { kind: 'opencode-permission' } };
+  assert.equal(autoApprovePresent(oc, { permission: { [OPENCODE_PERMISSION_KEY]: 'allow' } }), true);
+  assert.equal(autoApprovePresent(oc, { permission: {} }), false);
+  const zed = { autoApprove: { kind: 'zed-tool-permissions' } };
+  const cfg = {};
+  applyToConfig(zed, cfg);
+  assert.equal(autoApprovePresent(zed, cfg), true);
+  assert.equal(autoApprovePresent(zed, {}), false);
+});
+
+test('isSameFileKind is true only for the JSON same-file kinds', () => {
+  assert.equal(isSameFileKind({ autoApprove: { kind: 'gemini-trust' } }), true);
+  assert.equal(isSameFileKind({ autoApprove: { kind: 'opencode-permission' } }), true);
+  assert.equal(isSameFileKind({ autoApprove: { kind: 'zed-tool-permissions' } }), true);
+  assert.equal(isSameFileKind({ autoApprove: { kind: 'claude-settings' } }), false);
+  assert.equal(isSameFileKind({ autoApprove: { kind: 'ui-only' } }), false);
+  assert.equal(isSameFileKind({}), false);
+});
+
+// --- Claude Code settings.json permissions.allow ---
+
+test('applyClaudeSettingsAllow creates the file and adds the bare server allow rule', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, '.claude', 'settings.json');
+  const r = applyClaudeSettingsAllow({ settingsPath });
+  assert.equal(r.status, 'applied');
+  assert.equal(r.changed, true);
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(data.permissions.allow, ['mcp__kaboom-browser-devtools']);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('applyClaudeSettingsAllow merges into existing settings, dedupes, preserves other rules', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify({
+    model: 'opus',
+    permissions: { allow: ['Bash(ls:*)', 'mcp__kaboom-browser-devtools'], deny: ['Read(./secrets/**)'] },
+  }));
+  const r = applyClaudeSettingsAllow({ settingsPath });
+  assert.equal(r.status, 'unchanged', 'already present => no duplicate');
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(
+    data.permissions.allow.filter((x) => x === 'mcp__kaboom-browser-devtools'),
+    ['mcp__kaboom-browser-devtools'],
+    'no duplicate rule'
+  );
+  assert.ok(data.permissions.allow.includes('Bash(ls:*)'), 'user allow rules preserved');
+  assert.deepEqual(data.permissions.deny, ['Read(./secrets/**)'], 'deny rules preserved');
+  assert.equal(data.model, 'opus', 'unrelated settings preserved');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('applyClaudeSettingsAllow appends without dropping existing allow entries', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ['Bash(git:*)'] } }));
+  applyClaudeSettingsAllow({ settingsPath });
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(data.permissions.allow, ['Bash(git:*)', 'mcp__kaboom-browser-devtools']);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('applyClaudeSettingsAllow fails loud on malformed JSON (does not clobber)', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, '{ this is not json ');
+  assert.throws(() => applyClaudeSettingsAllow({ settingsPath }));
+  // File left untouched.
+  assert.equal(fs.readFileSync(settingsPath, 'utf8'), '{ this is not json ');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('removeClaudeSettingsAllow removes the rule, prunes empties, keeps other rules/settings', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify({
+    model: 'opus',
+    permissions: { allow: ['Bash(ls:*)', 'mcp__kaboom-browser-devtools', 'mcp__gasoline'] },
+  }));
+  const r = removeClaudeSettingsAllow({ settingsPath });
+  assert.equal(r.status, 'removed');
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(data.permissions.allow, ['Bash(ls:*)'], 'canonical + legacy rules removed, user rule kept');
+  assert.equal(data.model, 'opus');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('removeClaudeSettingsAllow prunes permissions when it becomes empty', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify({
+    permissions: { allow: ['mcp__kaboom-browser-devtools'] },
+  }));
+  removeClaudeSettingsAllow({ settingsPath });
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.equal(data.permissions, undefined, 'empty permissions object pruned');
+  assert.equal(fs.existsSync(settingsPath), true, 'shared settings file never deleted');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('removeClaudeSettingsAllow returns notConfigured when the rule is absent', () => {
+  const tmp = tmpdir();
+  const settingsPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ['Bash(ls:*)'] } }));
+  const r = removeClaudeSettingsAllow({ settingsPath });
+  assert.equal(r.status, 'notConfigured');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- install/uninstall wiring with REAL client definitions ---
+
+function withTempPath(id, tmp, fileName) {
+  const base = getClientById(id);
+  return { ...base, configPath: { all: path.join(tmp, fileName) }, detectDir: { all: tmp } };
+}
+
+test('installToClient (gemini) writes trust:true alongside the server entry', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('gemini', tmp, 'settings.json');
+  const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  assert.equal(res.autoApprove, 'applied');
+  const data = JSON.parse(fs.readFileSync(path.join(tmp, 'settings.json'), 'utf8'));
+  assert.equal(data.mcpServers[SERVER].trust, true);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installToClient (opencode) writes the permission wildcard allow', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('opencode', tmp, 'opencode.json');
+  const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  assert.equal(res.autoApprove, 'applied');
+  const data = JSON.parse(fs.readFileSync(path.join(tmp, 'opencode.json'), 'utf8'));
+  assert.equal(data.permission[OPENCODE_PERMISSION_KEY], 'allow');
+  assert.ok(data.mcp[SERVER], 'server entry still written');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installToClient (zed) writes the five per-tool allow permissions', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('zed', tmp, 'settings.json');
+  const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  assert.equal(res.autoApprove, 'applied');
+  const data = JSON.parse(fs.readFileSync(path.join(tmp, 'settings.json'), 'utf8'));
+  for (const t of KABOOM_TOOL_NAMES) {
+    assert.deepEqual(data.agent.tool_permissions.tools[`mcp:${SERVER}:${t}`], { default: 'allow' });
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installToClient (claude-code) registers via CLI AND writes settings.json auto-approve', () => {
+  if (process.platform === 'win32') return; // fake CLI uses a unix shebang
+  const tmp = tmpdir();
+  const fakeCli = path.join(tmp, 'fake-claude');
+  fs.writeFileSync(fakeCli, ['#!/usr/bin/env node', 'process.exit(0);', ''].join('\n'), { mode: 0o755 });
+  const settingsPath = path.join(tmp, '.claude', 'settings.json');
+  const def = { ...getClientById('claude-code'), detectCommand: fakeCli };
+
+  const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb', claudeSettingsPath: settingsPath });
+  assert.equal(res.success, true);
+  assert.equal(res.autoApprove, 'applied');
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.ok(data.permissions.allow.includes('mcp__kaboom-browser-devtools'));
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installToClient marks UI-only clients as ui-only (no config field invented)', () => {
+  const tmp = tmpdir();
+  // cursor is UI-only; installing must still write the server entry but never a
+  // trust field, and report ui-only.
+  const def = withTempPath('cursor', tmp, 'mcp.json');
+  const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  assert.equal(res.autoApprove, 'ui-only');
+  const data = JSON.parse(fs.readFileSync(path.join(tmp, 'mcp.json'), 'utf8'));
+  assert.ok(data.mcpServers[SERVER]);
+  assert.equal(data.mcpServers[SERVER].trust, undefined, 'no invented trust field');
+  assert.equal(data.permission, undefined);
+  assert.equal(data.agent, undefined);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- round-trip cleanliness ---
+
+test('install then uninstall leaves no orphan auto-approve keys (opencode)', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('opencode', tmp, 'opencode.json');
+  const cfgPath = path.join(tmp, 'opencode.json');
+  // Seed a user setting to prove the file is preserved and only kaboom is removed.
+  fs.writeFileSync(cfgPath, JSON.stringify({ theme: 'dark', permission: { bash: 'ask' } }));
+  installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  const r = uninstallFromClient(def, { dryRun: false });
+  assert.equal(r.status, 'removed');
+  const data = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.equal(data.mcp && data.mcp[SERVER], undefined, 'server entry removed');
+  assert.equal(data.permission[OPENCODE_PERMISSION_KEY], undefined, 'auto-approve key removed');
+  assert.equal(data.permission.bash, 'ask', 'user permission preserved');
+  assert.equal(data.theme, 'dark', 'user settings preserved');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('install then uninstall leaves no orphan auto-approve keys (zed)', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('zed', tmp, 'settings.json');
+  const cfgPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(cfgPath, JSON.stringify({ theme: 'one-dark' }));
+  installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  const r = uninstallFromClient(def, { dryRun: false });
+  assert.equal(r.status, 'removed');
+  const data = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.equal(data.context_servers && data.context_servers[SERVER], undefined, 'server entry removed');
+  assert.equal(data.agent, undefined, 'tool_permissions container pruned');
+  assert.equal(data.theme, 'one-dark', 'user settings preserved');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('install then uninstall leaves no orphan trust (gemini)', () => {
+  const tmp = tmpdir();
+  const def = withTempPath('gemini', tmp, 'settings.json');
+  const cfgPath = path.join(tmp, 'settings.json');
+  fs.writeFileSync(cfgPath, JSON.stringify({ selectedAuthType: 'oauth' }));
+  installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+  const r = uninstallFromClient(def, { dryRun: false });
+  assert.equal(r.status, 'removed');
+  const data = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  assert.equal(data.mcpServers && data.mcpServers[SERVER], undefined, 'server entry (with trust) removed');
+  assert.equal(data.selectedAuthType, 'oauth', 'user settings preserved');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('uninstallFromClient (claude-code fake CLI) removes the settings.json allow rule', () => {
+  if (process.platform === 'win32') return;
+  const tmp = tmpdir();
+  const fakeCli = path.join(tmp, 'fake-claude');
+  // Fake CLI: nothing configured for `claude mcp remove` (so the removal signal
+  // must come from the settings.json cleanup).
+  fs.writeFileSync(
+    fakeCli,
+    ['#!/usr/bin/env node', "process.stderr.write('not found');", 'process.exit(1);', ''].join('\n'),
+    { mode: 0o755 }
+  );
+  const settingsPath = path.join(tmp, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ['mcp__kaboom-browser-devtools', 'Bash(ls:*)'] } }));
+  const def = { ...getClientById('claude-code'), detectCommand: fakeCli };
+
+  const r = uninstallFromClient(def, { dryRun: false, claudeSettingsPath: settingsPath });
+  assert.equal(r.status, 'removed');
+  const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  assert.deepEqual(data.permissions.allow, ['Bash(ls:*)']);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/npm/kaboom-agentic-browser/lib/cli.js
+++ b/npm/kaboom-agentic-browser/lib/cli.js
@@ -286,10 +286,15 @@ function showHelp() {
   console.log('  Gemini CLI            config file');
   console.log('  OpenCode              config file');
   console.log('  Antigravity           config file');
-  console.log('  Zed                   config file\n');
+  console.log('  Zed                   config file');
+  console.log('  Codex CLI             config file (TOML)\n');
+  console.log('Install auto-approves all Kaboom tools where a client supports it via config');
+  console.log('(Claude Code, Gemini, OpenCode, Zed, Codex), so you are never prompted.');
+  console.log('Cursor, Windsurf, VS Code, Claude Desktop, and Antigravity need an in-app');
+  console.log('approval (no config option); the installer reports which is which.\n');
   console.log('Tool aliases for --install <tool>:');
   console.log('  claude, claude-desktop, cursor, windsurf, vscode, gemini, opencode,');
-  console.log('  antigravity, zed\n');
+  console.log('  antigravity, zed, codex\n');
   console.log('Options (with --install):');
   console.log('  --dry-run             Preview changes without writing');
   console.log('  --env KEY=VALUE       Add environment variables to config (multiple allowed)');

--- a/npm/kaboom-agentic-browser/lib/codex-config.js
+++ b/npm/kaboom-agentic-browser/lib/codex-config.js
@@ -1,0 +1,196 @@
+// codex-config.js — OpenAI Codex CLI (~/.codex/config.toml) MCP registration
+// plus whole-server tool auto-approve.
+// Why: Codex config is TOML, not JSON, so this module does a conservative,
+// comment-preserving SECTION edit (replace/remove only the `[mcp_servers.<name>]`
+// block) instead of re-serializing the whole file — the rest of the user's
+// config, including comments, is left byte-for-byte intact.
+// Auto-approve: `default_tools_approval_mode = "approve"` trusts every tool of
+// the server (never prompts). `auto`/`writes` can still prompt for risk-hinted
+// tools, so only `approve` guarantees no prompt.
+// Verified: https://developers.openai.com/codex/mcp (config.toml schema).
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+const fs = require('fs');
+const path = require('path');
+const { MCP_SERVER_NAME, LEGACY_MCP_SERVER_NAMES } = require('./config');
+
+// Only `approve` unconditionally suppresses tool-call prompts.
+const APPROVAL_MODE = 'approve';
+const APPROVAL_FIELD = 'default_tools_approval_mode';
+
+function knownServerNames() {
+  return [...new Set([MCP_SERVER_NAME, ...LEGACY_MCP_SERVER_NAMES])];
+}
+
+/** Escape a value for a double-quoted TOML basic string. */
+function tomlString(value) {
+  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/** A bare TOML key allows [A-Za-z0-9_-]; anything else must be quoted. */
+function tomlKey(name) {
+  return /^[A-Za-z0-9_-]+$/.test(name) ? name : tomlString(name);
+}
+
+/**
+ * Return the dotted inner path of a TOML table header line (e.g.
+ * `[mcp_servers.foo.env]` -> `mcp_servers.foo.env`), or null when the line is
+ * not a table header. Key/value lines start with the key, never `[`.
+ */
+function headerPath(line) {
+  const m = /^\s*\[\[?\s*([^\]]+?)\s*\]\]?\s*(#.*)?$/.exec(line);
+  return m ? m[1] : null;
+}
+
+/** Whether a table path is `mcp_servers.<name>` (or a sub-table) for a known name. */
+function tableTargetsKnownServer(tablePath, names) {
+  const prefix = 'mcp_servers.';
+  if (!tablePath.startsWith(prefix)) return false;
+  const rest = tablePath.slice(prefix.length);
+  const m = /^("([^"]*)"|[A-Za-z0-9_-]+)/.exec(rest);
+  if (!m) return false;
+  const name = m[2] !== undefined ? m[2] : m[1];
+  return names.includes(name);
+}
+
+/**
+ * Drop every `[mcp_servers.<name>]` block (and its sub-tables) for the given
+ * server names from TOML text, preserving all other content and comments.
+ * @returns {{text:string, changed:boolean}}
+ */
+function stripServerBlocks(content, names) {
+  const lines = content.split('\n');
+  const out = [];
+  let skipping = false;
+  let changed = false;
+  for (const line of lines) {
+    const tablePath = headerPath(line);
+    if (tablePath !== null) {
+      skipping = tableTargetsKnownServer(tablePath, names);
+    }
+    if (skipping) {
+      changed = true;
+      continue;
+    }
+    out.push(line);
+  }
+  return { text: out.join('\n'), changed };
+}
+
+/** Build the managed `[mcp_servers.kaboom-browser-devtools]` block. */
+function buildServerBlock(binaryCommand, envVars) {
+  const key = tomlKey(MCP_SERVER_NAME);
+  const lines = [
+    `[mcp_servers.${key}]`,
+    '# Managed by Kaboom. default_tools_approval_mode="approve" trusts all Kaboom tools.',
+    `command = ${tomlString(binaryCommand)}`,
+    `${APPROVAL_FIELD} = ${tomlString(APPROVAL_MODE)}`,
+  ];
+  const env = envVars && Object.keys(envVars).length > 0 ? envVars : null;
+  if (env) {
+    lines.push(`[mcp_servers.${key}.env]`);
+    for (const [k, v] of Object.entries(env)) {
+      lines.push(`${tomlKey(k)} = ${tomlString(v)}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Atomic text write (temp + rename), mirroring config.writeConfigFile. */
+function writeAtomic(filePath, content) {
+  const tmp = `${filePath}.tmp`;
+  try {
+    fs.writeFileSync(tmp, content, 'utf8');
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch (cleanupErr) {
+      // Best-effort temp cleanup; the original write error is what matters.
+      void cleanupErr;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Register (or refresh) the Kaboom MCP server in Codex config.toml with
+ * whole-server tool auto-approve. Merge-safe: replaces only our block, keeps
+ * everything else. Creates the file/dir when absent.
+ * @param {{configPath:string, binaryCommand:string, envVars?:object, dryRun?:boolean}} opts
+ * @returns {{success:boolean, path:string, isNew:boolean, autoApprove:string, dryRun?:boolean}}
+ */
+function installCodex(opts) {
+  const { configPath, binaryCommand, envVars = {}, dryRun = false } = opts;
+  const existing = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
+  const isNew = existing === '';
+  const { text: stripped } = stripServerBlocks(existing, knownServerNames());
+  const block = buildServerBlock(binaryCommand, envVars);
+  const head = stripped.replace(/\s*$/, '');
+  const next = head.length > 0 ? `${head}\n\n${block}\n` : `${block}\n`;
+
+  if (dryRun) {
+    return { success: true, path: configPath, isNew, autoApprove: 'would-apply', dryRun: true };
+  }
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  writeAtomic(configPath, next);
+  return { success: true, path: configPath, isNew, autoApprove: 'applied' };
+}
+
+/**
+ * Remove the Kaboom (and legacy) MCP server blocks from Codex config.toml.
+ * Never deletes the file (config.toml is a shared settings file).
+ * @param {{configPath:string, dryRun?:boolean}} opts
+ * @returns {{status:'removed'|'notConfigured', path:string}}
+ */
+function uninstallCodex(opts) {
+  const { configPath, dryRun = false } = opts;
+  if (!fs.existsSync(configPath)) return { status: 'notConfigured', path: configPath };
+  const existing = fs.readFileSync(configPath, 'utf8');
+  const { text, changed } = stripServerBlocks(existing, knownServerNames());
+  if (!changed) return { status: 'notConfigured', path: configPath };
+  if (dryRun) return { status: 'removed', path: configPath };
+  // Collapse blank-line runs left by the removed block; keep a trailing newline.
+  const collapsed = text.replace(/\n{3,}/g, '\n\n').replace(/^\n+/, '').replace(/\s*$/, '');
+  writeAtomic(configPath, collapsed.length ? `${collapsed}\n` : '');
+  return { status: 'removed', path: configPath };
+}
+
+/**
+ * Diagnose whether the Kaboom (or a legacy) server table exists in config.toml.
+ * @param {string} configPath
+ * @returns {{configured:boolean, exists:boolean, matchedName?:string, error?:string}}
+ */
+function codexServerConfigured(configPath) {
+  if (!fs.existsSync(configPath)) return { configured: false, exists: false };
+  let content;
+  try {
+    content = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    return { configured: false, exists: true, error: err.message };
+  }
+  const names = knownServerNames();
+  for (const line of content.split('\n')) {
+    const tablePath = headerPath(line);
+    if (tablePath === null) continue;
+    for (const name of names) {
+      if (tablePath === `mcp_servers.${name}` || tablePath === `mcp_servers.${tomlString(name)}`) {
+        return { configured: true, exists: true, matchedName: name };
+      }
+    }
+  }
+  return { configured: false, exists: true };
+}
+
+module.exports = {
+  APPROVAL_MODE,
+  APPROVAL_FIELD,
+  installCodex,
+  uninstallCodex,
+  codexServerConfigured,
+  // exported for tests
+  stripServerBlocks,
+  buildServerBlock,
+  tomlString,
+  tomlKey,
+};

--- a/npm/kaboom-agentic-browser/lib/codex-config.test.js
+++ b/npm/kaboom-agentic-browser/lib/codex-config.test.js
@@ -1,0 +1,276 @@
+// Purpose: Validate Codex CLI (config.toml) MCP registration + tool auto-approve.
+// Why: Codex config is TOML; a wrong table name or approval field silently
+// breaks the user's config. Locks the verified schema and the comment-preserving
+// section edit / round-trip.
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const codex = require('./codex-config');
+const { getClientById } = require('./config');
+const { installToClient } = require('./install');
+const { uninstallFromClient } = require('./uninstall');
+const { runDiagnostics } = require('./doctor');
+
+const SERVER = 'kaboom-browser-devtools';
+
+function tmpdir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-codex-'));
+}
+
+// --- TOML primitives ---
+
+test('tomlString escapes backslashes and quotes', () => {
+  assert.equal(codex.tomlString('/usr/bin/kb'), '"/usr/bin/kb"');
+  assert.equal(codex.tomlString('C:\\kb\\bin.exe'), '"C:\\\\kb\\\\bin.exe"');
+  assert.equal(codex.tomlString('a"b'), '"a\\"b"');
+});
+
+test('tomlKey leaves bare-safe keys unquoted and quotes others', () => {
+  assert.equal(codex.tomlKey('kaboom-browser-devtools'), 'kaboom-browser-devtools');
+  assert.equal(codex.tomlKey('has space'), '"has space"');
+});
+
+test('buildServerBlock uses the mcp_servers table + approve mode', () => {
+  const block = codex.buildServerBlock('/tmp/kb', {});
+  assert.match(block, /^\[mcp_servers\.kaboom-browser-devtools\]$/m);
+  assert.match(block, /command = "\/tmp\/kb"/);
+  assert.match(block, /default_tools_approval_mode = "approve"/);
+});
+
+test('buildServerBlock adds an env sub-table when env vars are present', () => {
+  const block = codex.buildServerBlock('/tmp/kb', { DEBUG: '1' });
+  assert.match(block, /\[mcp_servers\.kaboom-browser-devtools\.env\]/);
+  assert.match(block, /DEBUG = "1"/);
+});
+
+// --- stripServerBlocks ---
+
+test('stripServerBlocks removes only our block and preserves other tables + comments', () => {
+  const content = [
+    '# user preamble',
+    'model = "gpt-5"',
+    '',
+    '[mcp_servers.other]',
+    'command = "other-cmd"',
+    '',
+    '[mcp_servers.kaboom-browser-devtools]',
+    '# Managed by Kaboom.',
+    'command = "/tmp/kb"',
+    'default_tools_approval_mode = "approve"',
+    '',
+    '[tools]',
+    'web_search = true',
+    '',
+  ].join('\n');
+  const { text, changed } = codex.stripServerBlocks(content, [SERVER]);
+  assert.equal(changed, true);
+  assert.match(text, /# user preamble/);
+  assert.match(text, /model = "gpt-5"/);
+  assert.match(text, /\[mcp_servers\.other\]/);
+  assert.match(text, /\[tools\]/);
+  assert.match(text, /web_search = true/);
+  assert.doesNotMatch(text, /kaboom-browser-devtools/);
+  assert.doesNotMatch(text, /default_tools_approval_mode/);
+});
+
+test('stripServerBlocks removes the env sub-table and handles quoted table names', () => {
+  const content = [
+    '[mcp_servers."kaboom-browser-devtools"]',
+    'command = "/tmp/kb"',
+    '[mcp_servers."kaboom-browser-devtools".env]',
+    'TOKEN = "abc"',
+    '',
+    '[other]',
+    'keep = 1',
+  ].join('\n');
+  const { text, changed } = codex.stripServerBlocks(content, [SERVER]);
+  assert.equal(changed, true);
+  assert.doesNotMatch(text, /kaboom-browser-devtools/);
+  assert.doesNotMatch(text, /TOKEN/);
+  assert.match(text, /\[other\]/);
+  assert.match(text, /keep = 1/);
+});
+
+test('stripServerBlocks reports no change when our block is absent', () => {
+  const content = '[mcp_servers.other]\ncommand = "x"\n';
+  const { changed } = codex.stripServerBlocks(content, [SERVER]);
+  assert.equal(changed, false);
+});
+
+// --- installCodex ---
+
+test('installCodex creates config.toml with the server + approve mode', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  const r = codex.installCodex({ configPath, binaryCommand: '/tmp/kb', envVars: {} });
+  assert.equal(r.success, true);
+  assert.equal(r.isNew, true);
+  assert.equal(r.autoApprove, 'applied');
+  const text = fs.readFileSync(configPath, 'utf8');
+  assert.match(text, /\[mcp_servers\.kaboom-browser-devtools\]/);
+  assert.match(text, /default_tools_approval_mode = "approve"/);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installCodex preserves existing config and is idempotent (replaces our block)', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  fs.writeFileSync(configPath, '# my codex config\nmodel = "gpt-5"\n\n[mcp_servers.other]\ncommand = "o"\n');
+  codex.installCodex({ configPath, binaryCommand: '/tmp/kb', envVars: {} });
+  codex.installCodex({ configPath, binaryCommand: '/tmp/kb2', envVars: {} }); // re-run
+  const text = fs.readFileSync(configPath, 'utf8');
+  assert.match(text, /# my codex config/);
+  assert.match(text, /model = "gpt-5"/);
+  assert.match(text, /\[mcp_servers\.other\]/);
+  // Exactly one kaboom block, pointing at the latest binary.
+  assert.equal((text.match(/\[mcp_servers\.kaboom-browser-devtools\]/g) || []).length, 1);
+  assert.match(text, /command = "\/tmp\/kb2"/);
+  assert.doesNotMatch(text, /"\/tmp\/kb"\n/);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('installCodex dry-run does not write the file', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  const r = codex.installCodex({ configPath, binaryCommand: '/tmp/kb', envVars: {}, dryRun: true });
+  assert.equal(r.autoApprove, 'would-apply');
+  assert.equal(fs.existsSync(configPath), false);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- uninstallCodex ---
+
+test('uninstallCodex removes our block, preserves others, never deletes the file', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  const original = '# my codex config\nmodel = "gpt-5"\n\n[mcp_servers.other]\ncommand = "o"\n';
+  fs.writeFileSync(configPath, original);
+  codex.installCodex({ configPath, binaryCommand: '/tmp/kb', envVars: {} });
+  const r = codex.uninstallCodex({ configPath });
+  assert.equal(r.status, 'removed');
+  assert.equal(fs.existsSync(configPath), true, 'shared config.toml must not be deleted');
+  const text = fs.readFileSync(configPath, 'utf8');
+  assert.match(text, /model = "gpt-5"/);
+  assert.match(text, /\[mcp_servers\.other\]/);
+  assert.doesNotMatch(text, /kaboom-browser-devtools/);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('uninstallCodex returns notConfigured when file is absent or block missing', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  assert.equal(codex.uninstallCodex({ configPath }).status, 'notConfigured');
+  fs.writeFileSync(configPath, '[mcp_servers.other]\ncommand = "o"\n');
+  assert.equal(codex.uninstallCodex({ configPath }).status, 'notConfigured');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('install then uninstall restores the user config (no kaboom residue)', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  fs.writeFileSync(configPath, 'model = "gpt-5"\n\n[tools]\nweb_search = true\n');
+  codex.installCodex({ configPath, binaryCommand: '/tmp/kb', envVars: {} });
+  codex.uninstallCodex({ configPath });
+  const text = fs.readFileSync(configPath, 'utf8');
+  assert.match(text, /model = "gpt-5"/);
+  assert.match(text, /\[tools\]/);
+  assert.match(text, /web_search = true/);
+  assert.doesNotMatch(text, /kaboom/);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- codexServerConfigured ---
+
+test('codexServerConfigured reports canonical, legacy, and missing states', () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  assert.equal(codex.codexServerConfigured(configPath).exists, false);
+
+  fs.writeFileSync(configPath, '[mcp_servers.kaboom-browser-devtools]\ncommand = "x"\n');
+  let res = codex.codexServerConfigured(configPath);
+  assert.equal(res.configured, true);
+  assert.equal(res.matchedName, 'kaboom-browser-devtools');
+
+  fs.writeFileSync(configPath, '[mcp_servers.gasoline]\ncommand = "x"\n');
+  res = codex.codexServerConfigured(configPath);
+  assert.equal(res.configured, true);
+  assert.equal(res.matchedName, 'gasoline');
+
+  fs.writeFileSync(configPath, '[mcp_servers.other]\ncommand = "x"\n');
+  assert.equal(codex.codexServerConfigured(configPath).configured, false);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- install/uninstall wiring via the real codex client def + $CODEX_HOME ---
+
+test('installToClient/uninstallFromClient drive Codex via $CODEX_HOME', () => {
+  const tmp = tmpdir();
+  const prev = process.env.CODEX_HOME;
+  try {
+    process.env.CODEX_HOME = tmp;
+    const def = getClientById('codex');
+    const res = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kb' });
+    assert.equal(res.success, true);
+    assert.equal(res.autoApprove, 'applied');
+    const configPath = path.join(tmp, 'config.toml');
+    assert.match(fs.readFileSync(configPath, 'utf8'), /default_tools_approval_mode = "approve"/);
+
+    const un = uninstallFromClient(def, { dryRun: false });
+    assert.equal(un.status, 'removed');
+    assert.doesNotMatch(fs.readFileSync(configPath, 'utf8'), /kaboom-browser-devtools/);
+  } finally {
+    if (prev === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prev;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- doctor understands the TOML client (no false "Invalid JSON") ---
+
+test('runDiagnostics reports Codex ok when the TOML server table is present', async () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  fs.writeFileSync(configPath, '[mcp_servers.kaboom-browser-devtools]\ncommand = "x"\ndefault_tools_approval_mode = "approve"\n');
+  const def = {
+    id: 'codex',
+    name: 'Codex CLI',
+    type: 'file',
+    format: 'toml',
+    configPath: { all: configPath },
+    detectDir: { all: tmp },
+  };
+  const report = await runDiagnostics(false, {
+    clients: [def],
+    fetchHealthFn: async () => ({ reachable: false }),
+  });
+  const codexTool = report.tools.find((t) => t.id === 'codex');
+  assert.equal(codexTool.status, 'ok', 'TOML client must not be misread as invalid JSON');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('runDiagnostics reports Codex error when the server table is missing', async () => {
+  const tmp = tmpdir();
+  const configPath = path.join(tmp, 'config.toml');
+  fs.writeFileSync(configPath, 'model = "gpt-5"\n');
+  const def = {
+    id: 'codex',
+    name: 'Codex CLI',
+    type: 'file',
+    format: 'toml',
+    configPath: { all: configPath },
+    detectDir: { all: tmp },
+  };
+  const report = await runDiagnostics(false, {
+    clients: [def],
+    fetchHealthFn: async () => ({ reachable: false }),
+  });
+  const codexTool = report.tools.find((t) => t.id === 'codex');
+  assert.equal(codexTool.status, 'error');
+  assert.ok(codexTool.issues.some((i) => i.includes('missing')));
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/npm/kaboom-agentic-browser/lib/config.js
+++ b/npm/kaboom-agentic-browser/lib/config.js
@@ -100,11 +100,18 @@ const CLIENT_DEFINITIONS = [
     detectCommand: 'claude',
     installArgs: ['mcp', 'add-json', '--scope', 'user', MCP_SERVER_NAME],
     removeArgs: ['mcp', 'remove', '--scope', 'user', MCP_SERVER_NAME],
+    // Auto-approve: write `mcp__<server>` into ~/.claude/settings.json
+    // permissions.allow (a bare server rule approves ALL its tools).
+    autoApprove: { kind: 'claude-settings' },
   },
   {
     id: 'claude-desktop',
     name: 'Claude Desktop',
     type: 'file',
+    // No config-file auto-approve exists — claude_desktop_config.json has no
+    // official trust/autoApprove field (only third-party injection hacks add
+    // one). Tool approval is a UI action ("Allow for this chat"/"Always allow").
+    autoApprove: { kind: 'ui-only', note: 'Approve in-app; no config field' },
     // claude_desktop_config.json is a dedicated MCP config: safe to delete when emptied.
     dedicatedMcpFile: true,
     configPath: {
@@ -121,6 +128,9 @@ const CLIENT_DEFINITIONS = [
     name: 'Cursor',
     type: 'file',
     dedicatedMcpFile: true,
+    // No config-file auto-approve: mcp.json has no trust field; auto-run is a
+    // UI setting (Run Modes / "auto-run").
+    autoApprove: { kind: 'ui-only', note: 'Enable auto-run in Cursor settings' },
     configPath: { all: '~/.cursor/mcp.json' },
     detectDir: { all: '~/.cursor' },
   },
@@ -129,6 +139,9 @@ const CLIENT_DEFINITIONS = [
     name: 'Windsurf',
     type: 'file',
     dedicatedMcpFile: true,
+    // No config-file auto-approve: mcp_config.json has no trust field;
+    // auto-execution is a UI setting (Cascade Turbo / "allow every tool").
+    autoApprove: { kind: 'ui-only', note: 'Allow the server in Cascade (Turbo)' },
     configPath: { all: '~/.codeium/windsurf/mcp_config.json' },
     detectDir: { all: '~/.codeium/windsurf' },
   },
@@ -137,6 +150,12 @@ const CLIENT_DEFINITIONS = [
     name: 'VS Code',
     type: 'file',
     dedicatedMcpFile: true,
+    // No per-server config auto-approve: mcp.json has no trust field, and the
+    // only file-based auto-approve (settings.json `chat.tools.global.autoApprove`)
+    // trusts EVERY tool of EVERY server globally — out of scope for a
+    // Kaboom-scoped installer, so we don't write it. Per-server = UI ("Always
+    // Allow").
+    autoApprove: { kind: 'ui-only', note: 'Use "Always Allow"; only a global auto-approve exists' },
     // VS Code's mcp.json uses a top-level "servers" key; "mcpServers" entries
     // were written by older Kaboom versions and must still be cleaned up.
     configKey: 'servers',
@@ -156,6 +175,9 @@ const CLIENT_DEFINITIONS = [
     id: 'gemini',
     name: 'Gemini CLI',
     type: 'file',
+    // Auto-approve: `trust: true` on the server entry bypasses all tool-call
+    // confirmations for that server.
+    autoApprove: { kind: 'gemini-trust' },
     configPath: { all: '~/.gemini/settings.json' },
     detectDir: { all: '~/.gemini' },
   },
@@ -163,6 +185,8 @@ const CLIENT_DEFINITIONS = [
     id: 'opencode',
     name: 'OpenCode',
     type: 'file',
+    // Auto-approve: top-level `permission` map, `<server>_*` => "allow".
+    autoApprove: { kind: 'opencode-permission' },
     configPath: { all: '~/.config/opencode/opencode.json' },
     detectDir: { all: '~/.config/opencode' },
     configKey: 'mcp',
@@ -177,6 +201,9 @@ const CLIENT_DEFINITIONS = [
     name: 'Antigravity',
     type: 'file',
     dedicatedMcpFile: true,
+    // No config-file auto-approve for the IDE: mcp_config.json has no trust
+    // field, and auto-approve lives in a separate UI-managed permissions policy.
+    autoApprove: { kind: 'ui-only', note: 'Approve in Antigravity UI; mcp_config.json has no trust field' },
     // Antigravity uses the home-dir path on every OS (matches the Go installer).
     configPath: { all: '~/.gemini/antigravity/mcp_config.json' },
     detectDir: { all: '~/.gemini/antigravity' },
@@ -187,6 +214,9 @@ const CLIENT_DEFINITIONS = [
     id: 'zed',
     name: 'Zed',
     type: 'file',
+    // Auto-approve: agent.tool_permissions.tools["mcp:<server>:<tool>"] =
+    // {default:"allow"} for each tool (Zed has no server-level wildcard).
+    autoApprove: { kind: 'zed-tool-permissions' },
     configPath: { all: '~/.config/zed/settings.json' },
     detectDir: { all: '~/.config/zed' },
     configKey: 'context_servers',

--- a/npm/kaboom-agentic-browser/lib/config.js
+++ b/npm/kaboom-agentic-browser/lib/config.js
@@ -226,6 +226,21 @@ const CLIENT_DEFINITIONS = [
       return entry;
     },
   },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    type: 'file',
+    // Codex config is TOML — handled by lib/codex-config.js, not the JSON path.
+    format: 'toml',
+    // config.toml is a shared settings file; never delete it.
+    // Auto-approve: default_tools_approval_mode = "approve" trusts all tools.
+    autoApprove: { kind: 'codex-toml' },
+    // $CODEX_HOME overrides ~/.codex when set (honored via envHome below).
+    envHome: 'CODEX_HOME',
+    envHomeFile: 'config.toml',
+    configPath: { all: '~/.codex/config.toml' },
+    detectDir: { all: '~/.codex' },
+  },
 ];
 
 /**
@@ -254,6 +269,19 @@ function expandPath(p) {
 }
 
 /**
+ * Resolve a client's env-var home override (e.g. $CODEX_HOME) when the
+ * definition declares one and the env var is set. Returns null otherwise, so
+ * all clients without `envHome` behave exactly as before.
+ * @param {Object} def Client definition
+ * @returns {string|null} Expanded override directory, or null
+ */
+function resolveEnvHome(def) {
+  if (!def.envHome) return null;
+  const val = process.env[def.envHome];
+  return val ? expandPath(val) : null;
+}
+
+/**
  * Get resolved config path for a file-type client definition
  * @param {Object} def Client definition
  * @param {string} [platform] Platform override (defaults to os.platform())
@@ -261,6 +289,10 @@ function expandPath(p) {
  */
 function getClientConfigPath(def, platform) {
   if (def.type === 'cli') return null;
+  const envHome = resolveEnvHome(def);
+  if (envHome && def.envHomeFile) {
+    return path.normalize(path.join(envHome, def.envHomeFile));
+  }
   const plat = platform || os.platform();
   const raw = def.configPath[plat] || def.configPath.all || null;
   return raw ? expandPath(raw) : null;
@@ -290,6 +322,8 @@ function getClientLegacyConfigPaths(def, platform) {
  */
 function getClientDetectDir(def, platform) {
   if (def.type === 'cli') return null;
+  const envHome = resolveEnvHome(def);
+  if (envHome) return envHome;
   const plat = platform || os.platform();
   const raw = def.detectDir[plat] || def.detectDir.all || null;
   return raw ? expandPath(raw) : null;
@@ -361,6 +395,7 @@ const CLIENT_ALIASES = {
   'opencode': 'opencode',
   'antigravity': 'antigravity',
   'zed': 'zed',
+  'codex': 'codex',
 };
 
 /**
@@ -392,11 +427,14 @@ function getValidAliases() {
 
 /**
  * Backward-compat: returns config file paths for detected file-type clients.
- * @returns {Array<string>} Array of config file paths
+ * Excludes non-JSON (TOML) clients like Codex — every consumer of this helper
+ * JSON-parses the returned paths, so a TOML path must never appear here. Codex
+ * is diagnosed/managed directly via CLIENT_DEFINITIONS instead.
+ * @returns {Array<string>} Array of JSON config file paths
  */
 function getConfigCandidates() {
   return CLIENT_DEFINITIONS
-    .filter(def => def.type === 'file')
+    .filter(def => def.type === 'file' && def.format !== 'toml')
     .map(def => getClientConfigPath(def))
     .filter(Boolean);
 }
@@ -424,6 +462,7 @@ function getToolNameFromPath(configPath) {
   if (normalized.includes('.gemini')) return 'Gemini CLI';
   if (normalized.includes(path.join('.config', 'opencode'))) return 'OpenCode';
   if (normalized.includes(path.join('.config', 'zed'))) return 'Zed';
+  if (normalized.includes('.codex')) return 'Codex CLI';
   if (normalized.includes('Code')) return 'VS Code';
   return 'Unknown';
 }

--- a/npm/kaboom-agentic-browser/lib/config.test.js
+++ b/npm/kaboom-agentic-browser/lib/config.test.js
@@ -86,11 +86,11 @@ test('resolveManagedBinaryPath falls back to the command name on an unknown plat
 
 // --- CLIENT_DEFINITIONS ---
 
-test('CLIENT_DEFINITIONS contains all 9 clients', () => {
+test('CLIENT_DEFINITIONS contains all 10 clients (Codex added)', () => {
   const ids = CLIENT_DEFINITIONS.map(c => c.id);
   assert.deepEqual(ids, [
     'claude-code', 'claude-desktop', 'cursor', 'windsurf', 'vscode',
-    'gemini', 'opencode', 'antigravity', 'zed',
+    'gemini', 'opencode', 'antigravity', 'zed', 'codex',
   ]);
 });
 
@@ -373,6 +373,50 @@ test('zed buildEntry produces correct format', () => {
   const zed = CLIENT_DEFINITIONS.find(c => c.id === 'zed');
   const entry = zed.buildEntry({});
   assert.deepEqual(entry, { source: 'custom', command: 'kaboom-agentic-browser', args: [] });
+});
+
+// --- Codex client ---
+
+test('codex is a TOML-format client at ~/.codex/config.toml', () => {
+  const codex = CLIENT_DEFINITIONS.find(c => c.id === 'codex');
+  assert.equal(codex.type, 'file');
+  assert.equal(codex.format, 'toml');
+  assert.ok(codex.configPath.all.includes('.codex/config.toml'));
+  assert.equal(codex.autoApprove.kind, 'codex-toml');
+  // config.toml is shared — must never be flagged for deletion.
+  assert.ok(!codex.dedicatedMcpFile);
+});
+
+test('codex honors $CODEX_HOME for config path and detection', () => {
+  const codex = CLIENT_DEFINITIONS.find(c => c.id === 'codex');
+  const prev = process.env.CODEX_HOME;
+  try {
+    const home = path.join(os.tmpdir(), 'kaboom-codex-home-test');
+    process.env.CODEX_HOME = home;
+    const cfg = getClientConfigPath(codex);
+    assert.equal(cfg, path.normalize(path.join(home, 'config.toml')));
+  } finally {
+    if (prev === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prev;
+  }
+});
+
+test('codex falls back to ~/.codex when CODEX_HOME is unset', () => {
+  const codex = CLIENT_DEFINITIONS.find(c => c.id === 'codex');
+  const prev = process.env.CODEX_HOME;
+  try {
+    delete process.env.CODEX_HOME;
+    const cfg = getClientConfigPath(codex);
+    assert.ok(fwd(cfg).includes('.codex/config.toml'));
+  } finally {
+    if (prev !== undefined) process.env.CODEX_HOME = prev;
+  }
+});
+
+test('getClientByAlias resolves codex; getToolNameFromPath maps the codex path', () => {
+  assert.equal(getClientByAlias('codex').id, 'codex');
+  const homeDir = os.homedir();
+  assert.equal(getToolNameFromPath(path.join(homeDir, '.codex', 'config.toml')), 'Codex CLI');
 });
 
 // --- getClientByAlias ---

--- a/npm/kaboom-agentic-browser/lib/doctor.js
+++ b/npm/kaboom-agentic-browser/lib/doctor.js
@@ -21,6 +21,7 @@ const {
   readConfigFile,
   expandPath,
 } = require('./config');
+const codexConfig = require('./codex-config');
 const { fetchHealth, DEFAULT_PORT } = require('./health');
 
 // Node floor: the launcher and lib/*.js rely on modern Node built-ins
@@ -269,6 +270,70 @@ function diagnoseFileClient(def, verbose) {
 }
 
 /**
+ * Diagnose a TOML-format client (Codex config.toml). Parallels
+ * diagnoseFileClient but reads the TOML section instead of JSON.
+ * @param {Object} def Client definition
+ * @param {boolean} verbose
+ * @returns {Object} Tool diagnostic
+ */
+function diagnoseTomlClient(def, verbose) {
+  const cfgPath = getClientConfigPath(def);
+  const detected = isClientInstalled(def);
+  const tool = {
+    name: def.name,
+    id: def.id,
+    type: 'file',
+    path: cfgPath,
+    detected,
+    status: 'error',
+    issues: [],
+    suggestions: [],
+  };
+
+  if (verbose) {
+    console.log(`[DEBUG] Checking ${def.name} at ${cfgPath}`);
+  }
+
+  if (!detected) {
+    tool.status = 'info';
+    tool.issues.push('Not installed on this system');
+    return tool;
+  }
+  if (!cfgPath) {
+    tool.status = 'info';
+    tool.issues.push('No config path for this platform');
+    return tool;
+  }
+  if (!fs.existsSync(cfgPath)) {
+    tool.status = 'error';
+    tool.issues.push('Config file not found');
+    tool.suggestions.push('Run: kaboom-agentic-browser --install');
+    return tool;
+  }
+
+  const res = codexConfig.codexServerConfigured(cfgPath);
+  if (res.error) {
+    tool.issues.push(`Cannot read config: ${res.error}`);
+    tool.suggestions.push('Fix the file or run: kaboom-agentic-browser --install');
+    return tool;
+  }
+  if (!res.configured) {
+    tool.issues.push(`${MCP_SERVER_NAME} entry missing from mcp_servers`);
+    tool.suggestions.push('Run: kaboom-agentic-browser --install');
+    return tool;
+  }
+  if (res.matchedName !== MCP_SERVER_NAME) {
+    tool.status = 'error';
+    tool.issues.push(`Legacy MCP server name detected (${res.matchedName}); migrate to ${MCP_SERVER_NAME}`);
+    tool.suggestions.push('Run: kaboom-agentic-browser --install');
+    return tool;
+  }
+
+  tool.status = 'ok';
+  return tool;
+}
+
+/**
  * Diagnose a CLI-type client
  * @param {Object} def Client definition
  * @param {boolean} verbose
@@ -406,6 +471,8 @@ async function runDiagnostics(verbose = false, opts = {}) {
   for (const def of clients) {
     if (def.type === 'cli') {
       tools.push(diagnoseCliClient(def, verbose));
+    } else if (def.format === 'toml') {
+      tools.push(diagnoseTomlClient(def, verbose));
     } else {
       tools.push(diagnoseFileClient(def, verbose));
     }

--- a/npm/kaboom-agentic-browser/lib/install.js
+++ b/npm/kaboom-agentic-browser/lib/install.js
@@ -69,7 +69,12 @@ function installViaCli(def, options) {
   const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath() } = options;
   const entryJson = buildMcpEntry(envVars, { binaryCommand });
   const cmd = def.detectCommand;
-  const args = [...def.installArgs];
+  // `claude mcp add-json <name> '<json>'` takes the server JSON as the FINAL
+  // POSITIONAL argument. It was previously piped to stdin, so the CLI aborted
+  // with "missing required argument 'json'". installArgs already ends with the
+  // server name; append the JSON config after it.
+  const baseArgs = [...def.installArgs];
+  const args = [...baseArgs, entryJson];
 
   if (dryRun) {
     return {
@@ -77,7 +82,7 @@ function installViaCli(def, options) {
       name: def.name,
       id: def.id,
       method: 'cli',
-      message: `Would run: ${cmd} ${args.join(' ')} '<json>'`,
+      message: `Would run: ${cmd} ${baseArgs.join(' ')} '<json>'`,
     };
   }
 
@@ -87,7 +92,6 @@ function installViaCli(def, options) {
     delete env.CLAUDECODE;
 
     execFileSync(cmd, args, {
-      input: entryJson,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 15000,

--- a/npm/kaboom-agentic-browser/lib/install.js
+++ b/npm/kaboom-agentic-browser/lib/install.js
@@ -20,6 +20,7 @@ const {
   writeConfigFile,
   resolveManagedBinaryPath,
 } = require('./config');
+const autoApprove = require('./auto-approve');
 const { resolveExtensionDir } = require('./extension');
 
 const LEGACY_INSTALL_SERVER_NAMES = [
@@ -66,7 +67,7 @@ function buildMcpEntry(envVars = {}, options = {}) {
  * @returns {Object} {success, name, method, message}
  */
 function installViaCli(def, options) {
-  const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath() } = options;
+  const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath(), claudeSettingsPath } = options;
   const entryJson = buildMcpEntry(envVars, { binaryCommand });
   const cmd = def.detectCommand;
   // `claude mcp add-json <name> '<json>'` takes the server JSON as the FINAL
@@ -82,6 +83,7 @@ function installViaCli(def, options) {
       name: def.name,
       id: def.id,
       method: 'cli',
+      autoApprove: def.autoApprove && def.autoApprove.kind === 'claude-settings' ? 'would-apply' : undefined,
       message: `Would run: ${cmd} ${baseArgs.join(' ')} '<json>'`,
     };
   }
@@ -97,13 +99,29 @@ function installViaCli(def, options) {
       timeout: 15000,
     });
 
-    return {
+    // Auto-approve: after the server is registered, trust ALL of its tools by
+    // adding `mcp__<server>` to ~/.claude/settings.json permissions.allow. This
+    // is a separate merge-safe write (the CLI has no flag for it). A failure
+    // here is reported (not swallowed) and does not undo the successful server
+    // registration.
+    const result = {
       success: true,
       name: def.name,
       id: def.id,
       method: 'cli',
       message: `Installed via ${cmd} CLI`,
     };
+    if (def.autoApprove && def.autoApprove.kind === 'claude-settings') {
+      try {
+        const aa = autoApprove.applyClaudeSettingsAllow({ settingsPath: claudeSettingsPath });
+        result.autoApprove = aa.changed ? 'applied' : 'unchanged';
+        result.autoApprovePath = aa.path;
+      } catch (aaErr) {
+        result.autoApprove = 'failed';
+        result.autoApproveError = aaErr.message;
+      }
+    }
+    return result;
   } catch (err) {
     return {
       success: false,
@@ -181,6 +199,18 @@ function installViaFile(def, options) {
   }
   configData[configKey][MCP_SERVER_NAME] = kaboomEntry;
 
+  // Fold whole-server tool auto-approve into the SAME atomic write (Gemini
+  // trust, OpenCode permission, Zed tool_permissions). UI-only clients are
+  // left untouched. Default-ON: Kaboom trusts its own tools so the user is
+  // never prompted where a config mechanism exists.
+  let autoApproveStatus = def.autoApprove
+    ? (def.autoApprove.kind === 'ui-only' ? 'ui-only' : 'none')
+    : undefined;
+  if (autoApprove.isSameFileKind(def)) {
+    const applied = autoApprove.applyToConfig(def, configData);
+    autoApproveStatus = applied ? (dryRun ? 'would-apply' : 'applied') : 'skipped';
+  }
+
   const skipValidation = configKey !== 'mcpServers';
   writeConfigFile(cfgPath, configData, dryRun, { skipValidation });
 
@@ -191,6 +221,7 @@ function installViaFile(def, options) {
     method: 'file',
     path: cfgPath,
     isNew,
+    autoApprove: autoApproveStatus,
     message: dryRun ? `Would write to ${cfgPath}` : `Wrote to ${cfgPath}`,
   };
 }
@@ -251,7 +282,7 @@ function executeInstall(options = {}) {
 
   for (const def of clients) {
     try {
-      const installResult = installToClient(def, { dryRun, envVars, binaryCommand });
+      const installResult = installToClient(def, { dryRun, envVars, binaryCommand, claudeSettingsPath: options.claudeSettingsPath });
 
       if (installResult.success) {
         result.installed.push(installResult);

--- a/npm/kaboom-agentic-browser/lib/install.js
+++ b/npm/kaboom-agentic-browser/lib/install.js
@@ -21,6 +21,7 @@ const {
   resolveManagedBinaryPath,
 } = require('./config');
 const autoApprove = require('./auto-approve');
+const codexConfig = require('./codex-config');
 const { resolveExtensionDir } = require('./extension');
 
 const LEGACY_INSTALL_SERVER_NAMES = [
@@ -227,6 +228,32 @@ function installViaFile(def, options) {
 }
 
 /**
+ * Install to a TOML-format client (Codex config.toml): server registration +
+ * whole-server tool auto-approve, handled by lib/codex-config.js.
+ * @param {Object} def Client definition
+ * @param {Object} options {dryRun, envVars, binaryCommand}
+ * @returns {Object} {success, name, method, path, isNew, autoApprove, message}
+ */
+function installViaToml(def, options) {
+  const { dryRun = false, envVars = {}, binaryCommand = resolveManagedBinaryPath() } = options;
+  const cfgPath = getClientConfigPath(def);
+  if (!cfgPath) {
+    return { success: false, name: def.name, id: def.id, method: 'file', message: 'No config path for this platform' };
+  }
+  const r = codexConfig.installCodex({ configPath: cfgPath, binaryCommand, envVars, dryRun });
+  return {
+    success: true,
+    name: def.name,
+    id: def.id,
+    method: 'file',
+    path: cfgPath,
+    isNew: r.isNew,
+    autoApprove: r.autoApprove,
+    message: dryRun ? `Would write to ${cfgPath}` : `Wrote to ${cfgPath}`,
+  };
+}
+
+/**
  * Install to a single client (dispatches by type)
  * @param {Object} def Client definition
  * @param {Object} options {dryRun, envVars}
@@ -235,6 +262,9 @@ function installViaFile(def, options) {
 function installToClient(def, options) {
   if (def.type === 'cli') {
     return installViaCli(def, options);
+  }
+  if (def.format === 'toml') {
+    return installViaToml(def, options);
   }
   return installViaFile(def, options);
 }

--- a/npm/kaboom-agentic-browser/lib/install.test.js
+++ b/npm/kaboom-agentic-browser/lib/install.test.js
@@ -217,6 +217,49 @@ test('installToClient handles CLI type with dry-run', () => {
   assert.ok(result.message.includes('claude'));
 });
 
+test('installToClient passes the MCP server JSON as a positional arg to the CLI (not stdin)', () => {
+  // Regression: installArgs ended at the server NAME and the JSON was piped to
+  // stdin, so `claude mcp add-json` aborted with "missing required argument
+  // 'json'". The JSON config must be the FINAL positional argument.
+  if (process.platform === 'win32') return; // fake CLI uses a unix shebang
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kaboom-install-cli-'));
+  const argvLog = path.join(tmp, 'argv.json');
+  const fakeCli = path.join(tmp, 'fake-claude');
+  fs.writeFileSync(
+    fakeCli,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('fs');",
+      `fs.writeFileSync(${JSON.stringify(argvLog)}, JSON.stringify(process.argv.slice(2)));`,
+      'process.exit(0);',
+      '',
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  const def = {
+    id: 'claude-code',
+    name: 'Claude Code',
+    type: 'cli',
+    detectCommand: fakeCli,
+    installArgs: ['mcp', 'add-json', '--scope', 'user', 'kaboom-browser-devtools'],
+    removeArgs: ['mcp', 'remove', '--scope', 'user', 'kaboom-browser-devtools'],
+  };
+
+  const result = installToClient(def, { dryRun: false, envVars: {}, binaryCommand: '/tmp/kaboom-bin' });
+  assert.equal(result.success, true);
+
+  const argv = JSON.parse(fs.readFileSync(argvLog, 'utf8'));
+  assert.deepEqual(argv.slice(0, 5), ['mcp', 'add-json', '--scope', 'user', 'kaboom-browser-devtools']);
+  // The JSON config must be present as the final positional argument.
+  const jsonArg = argv[argv.length - 1];
+  const parsed = JSON.parse(jsonArg); // throws if the JSON was not passed as an arg
+  assert.equal(parsed.command, '/tmp/kaboom-bin');
+  assert.deepEqual(parsed.args, []);
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
 // --- executeInstall ---
 
 test('executeInstall installs to detected file-type clients', () => {

--- a/npm/kaboom-agentic-browser/lib/output.js
+++ b/npm/kaboom-agentic-browser/lib/output.js
@@ -77,6 +77,27 @@ function installResult(result) {
         output += `   ✅ ${entry.name} (at ${entry.path})\n`;
       }
     });
+
+    // Auto-approve transparency: report EXACTLY which clients had all Kaboom
+    // tools trusted via config (no more prompts), which can only be done in-app,
+    // and any that failed — so the default-ON behavior is never a surprise.
+    const approved = installed
+      .filter(e => e.autoApprove === 'applied' || e.autoApprove === 'would-apply' || e.autoApprove === 'unchanged')
+      .map(e => e.name);
+    const uiOnly = installed.filter(e => e.autoApprove === 'ui-only').map(e => e.name);
+    const failed = installed.filter(e => e.autoApprove === 'failed');
+    if (approved.length > 0 || uiOnly.length > 0 || failed.length > 0) {
+      output += '\n🔓 Tool auto-approve (Kaboom trusts its own tools — no approval prompts):\n';
+      if (approved.length > 0) {
+        output += `   ✅ Auto-approved via config: ${approved.join(', ')}\n`;
+      }
+      if (uiOnly.length > 0) {
+        output += `   🖱  Manual in-app approval (no config option): ${uiOnly.join(', ')}\n`;
+      }
+      failed.forEach(e => {
+        output += `   ⚠️  ${e.name}: could not write auto-approve (${e.autoApproveError || 'unknown error'})\n`;
+      });
+    }
   }
 
   if (result.errors && result.errors.length > 0) {

--- a/npm/kaboom-agentic-browser/lib/output.test.js
+++ b/npm/kaboom-agentic-browser/lib/output.test.js
@@ -1,0 +1,46 @@
+// Purpose: Validate the install-output auto-approve transparency summary.
+// Why: The installer must state exactly which clients were auto-approved via
+// config and which need manual in-app approval (default-ON but transparent).
+// Docs: docs/features/feature/enhanced-cli-config/index.md
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const output = require('./output');
+
+test('installResult lists config auto-approved clients separately from UI-only', () => {
+  const text = output.installResult({
+    installed: [
+      { name: 'Claude Code', method: 'cli', autoApprove: 'applied' },
+      { name: 'Gemini CLI', method: 'file', path: '/g', autoApprove: 'applied' },
+      { name: 'Zed', method: 'file', path: '/z', autoApprove: 'unchanged' },
+      { name: 'Cursor', method: 'file', path: '/c', autoApprove: 'ui-only' },
+      { name: 'VS Code', method: 'file', path: '/v', autoApprove: 'ui-only' },
+    ],
+    total: 10,
+    errors: [],
+  });
+  assert.match(text, /Tool auto-approve/);
+  assert.match(text, /Auto-approved via config: Claude Code, Gemini CLI, Zed/);
+  assert.match(text, /Manual in-app approval \(no config option\): Cursor, VS Code/);
+});
+
+test('installResult surfaces a failed auto-approve with its error', () => {
+  const text = output.installResult({
+    installed: [
+      { name: 'Claude Code', method: 'cli', autoApprove: 'failed', autoApproveError: 'EACCES' },
+    ],
+    total: 10,
+    errors: [],
+  });
+  assert.match(text, /Claude Code: could not write auto-approve \(EACCES\)/);
+});
+
+test('installResult omits the auto-approve section when no entry carries a status', () => {
+  const text = output.installResult({
+    updated: [{ name: 'Claude Desktop', path: '/path' }],
+    total: 4,
+    errors: [],
+  });
+  assert.ok(text.includes('Claude Desktop'));
+  assert.doesNotMatch(text, /Tool auto-approve/);
+});

--- a/npm/kaboom-agentic-browser/lib/uninstall.js
+++ b/npm/kaboom-agentic-browser/lib/uninstall.js
@@ -20,6 +20,7 @@ const {
   writeConfigFile,
 } = require('./config');
 const autoApprove = require('./auto-approve');
+const codexConfig = require('./codex-config');
 const { cleanupInstalledSkills } = require('./skills');
 
 const LEGACY_UNINSTALL_SERVER_NAMES = [
@@ -245,6 +246,23 @@ function uninstallViaFile(def, options) {
 }
 
 /**
+ * Uninstall from a TOML-format client (Codex config.toml).
+ * @param {Object} def Client definition
+ * @param {Object} options {dryRun}
+ * @returns {Object} {status, name, id, method, path}
+ */
+function uninstallViaToml(def, options) {
+  const { dryRun = false } = options;
+  const cfgPath = getClientConfigPath(def);
+  if (!cfgPath) return { status: 'notConfigured', name: def.name, id: def.id };
+  const r = codexConfig.uninstallCodex({ configPath: cfgPath, dryRun });
+  if (r.status === 'removed') {
+    return { status: 'removed', name: def.name, id: def.id, method: 'file', path: cfgPath };
+  }
+  return { status: 'notConfigured', name: def.name, id: def.id };
+}
+
+/**
  * Uninstall from a single client (dispatches by type)
  * @param {Object} def Client definition
  * @param {Object} options {dryRun, verbose}
@@ -253,6 +271,9 @@ function uninstallViaFile(def, options) {
 function uninstallFromClient(def, options) {
   if (def.type === 'cli') {
     return uninstallViaCli(def, options);
+  }
+  if (def.format === 'toml') {
+    return uninstallViaToml(def, options);
   }
   return uninstallViaFile(def, options);
 }

--- a/npm/kaboom-agentic-browser/lib/uninstall.js
+++ b/npm/kaboom-agentic-browser/lib/uninstall.js
@@ -19,6 +19,7 @@ const {
   readConfigFile,
   writeConfigFile,
 } = require('./config');
+const autoApprove = require('./auto-approve');
 const { cleanupInstalledSkills } = require('./skills');
 
 const LEGACY_UNINSTALL_SERVER_NAMES = [
@@ -39,9 +40,10 @@ function knownServerNames() {
  * @returns {Object} {status, name, method, message}
  */
 function uninstallViaCli(def, options) {
-  const { dryRun = false, verbose = false } = options;
+  const { dryRun = false, verbose = false, claudeSettingsPath } = options;
   const cmd = def.detectCommand;
   const canonicalArgs = [...def.removeArgs];
+  const hasSettingsAutoApprove = def.autoApprove && def.autoApprove.kind === 'claude-settings';
 
   if (dryRun) {
     if (verbose) {
@@ -83,22 +85,40 @@ function uninstallViaCli(def, options) {
       }
     }
   }
-  if (removedNames.length > 0) {
+
+  // Also strip the auto-approve allow rule this installer added to
+  // ~/.claude/settings.json. A read/write failure is surfaced (not swallowed).
+  let settingsRemoved = false;
+  let settingsErr = null;
+  if (hasSettingsAutoApprove) {
+    try {
+      const r = autoApprove.removeClaudeSettingsAllow({ settingsPath: claudeSettingsPath });
+      settingsRemoved = r.changed;
+    } catch (e) {
+      settingsErr = e;
+    }
+  }
+
+  if (removedNames.length > 0 || settingsRemoved) {
+    const parts = [];
+    if (removedNames.length > 0) parts.push(removedNames.join(', '));
+    if (settingsRemoved) parts.push('auto-approve');
     return {
       status: 'removed',
       name: def.name,
       id: def.id,
       method: 'cli',
-      message: `Removed via ${cmd} CLI (${removedNames.join(', ')})`,
+      message: `Removed via ${cmd} CLI (${parts.join('; ')})`,
     };
   }
-  if (unexpectedErr) {
+  if (unexpectedErr || settingsErr) {
+    const msg = (unexpectedErr && unexpectedErr.message) || (settingsErr && settingsErr.message);
     return {
       status: 'error',
       name: def.name,
       id: def.id,
       method: 'cli',
-      message: `CLI uninstall failed: ${unexpectedErr.message}`,
+      message: `CLI uninstall failed: ${msg}`,
     };
   }
   return {
@@ -138,10 +158,13 @@ function removeManagedEntriesFromConfigFile(cfgPath, def, options) {
 
   const configKeys = [def.configKey || 'mcpServers', ...(def.legacyConfigKeys || [])];
   const names = knownServerNames();
-  const present = configKeys.some((key) => {
+  const serverPresent = configKeys.some((key) => {
     const servers = readResult.data[key] || {};
     return names.some((name) => Object.prototype.hasOwnProperty.call(servers, name));
   });
+  // A config carrying only auto-approve keys (server entry already gone) is
+  // still ours to clean, so factor auto-approve presence into the decision.
+  const present = serverPresent || autoApprove.autoApprovePresent(def, readResult.data);
   if (!present) {
     return { status: 'notConfigured' };
   }
@@ -162,6 +185,10 @@ function removeManagedEntriesFromConfigFile(cfgPath, def, options) {
     }
     remainingEntries += Object.keys(modified[key]).length;
   }
+
+  // Remove the same-file auto-approve entries this installer added (OpenCode
+  // permission, Zed tool_permissions; Gemini trust rode on the deleted entry).
+  autoApprove.removeFromConfig(def, modified);
 
   if (remainingEntries === 0 && def.dedicatedMcpFile) {
     fs.unlinkSync(cfgPath);
@@ -251,7 +278,7 @@ function executeUninstall(options = {}) {
 
   for (const def of clients) {
     try {
-      const r = uninstallFromClient(def, { dryRun, verbose });
+      const r = uninstallFromClient(def, { dryRun, verbose, claudeSettingsPath: options.claudeSettingsPath });
 
       if (r.status === 'removed') {
         result.removed.push(r);

--- a/tests/cli/config.test.cjs
+++ b/tests/cli/config.test.cjs
@@ -31,8 +31,10 @@ function cleanupTestDir() {
 
 test('config.getConfigCandidates returns expected file-client paths', () => {
   const candidates = config.getConfigCandidates()
-  const fileClientCount = config.CLIENT_DEFINITIONS.filter((def) => def.type === 'file').length
-  assert.strictEqual(candidates.length, fileClientCount, 'Should return one config path per file-based client')
+  // getConfigCandidates excludes non-JSON (TOML) clients like Codex — every
+  // consumer JSON-parses these paths, so only JSON file clients are returned.
+  const fileClientCount = config.CLIENT_DEFINITIONS.filter((def) => def.type === 'file' && def.format !== 'toml').length
+  assert.strictEqual(candidates.length, fileClientCount, 'Should return one config path per JSON file-based client')
   assert.ok(candidates.some((p) => p.includes('Claude')), 'Should include Claude Desktop path')
   assert.ok(candidates.some((p) => p.includes('.cursor')), 'Should include Cursor path')
   assert.ok(candidates.some((p) => p.includes('.codeium')), 'Should include Windsurf path')


### PR DESCRIPTION
## Why

After install, every Kaboom tool call raised a permission prompt in each client. The tools are local-only and read the user's own browser, so prompting per call is pure friction.

## What

New `lib/auto-approve.js` + `lib/codex-config.js`, wired into install/uninstall/doctor, default-ON:

| Client | Mechanism |
|---|---|
| Claude Code | `permissions.allow += mcp__kaboom-browser-devtools` (bare server name wildcard-approves all its tools) |
| Codex | `[mcp_servers.<name>] default_tools_approval_mode = "approve"` in `$CODEX_HOME/config.toml` |
| Gemini CLI | `trust: true` |
| OpenCode | `permission: { "kaboom-browser-devtools_*": "allow" }` |
| Zed | per-tool `agent.tool_permissions` (Zed has no server-level wildcard) |
| Claude Desktop, Cursor, Windsurf, VS Code, Antigravity | **UI-only** — no config field exists; documented as such, not faked |

Also fixes a real install bug: `claude mcp add-json` was invoked without the server JSON as a positional arg.

## Notes for review

- Both non-obvious config formats were verified against official docs, not inferred: Claude Code's docs state `mcp__puppeteer` matches any tool from that server, and Codex's `default_tools_approval_mode = "approve"` skips approval prompts for all of a server's tools.
- All writes are **merge-safe** (existing user config preserved) and **uninstall removes every entry** — round-trip tested.
- The Codex TOML editor is comment-preserving.
- VS Code's *global* "trust every MCP server" flag was deliberately **not** set: it would auto-approve unrelated servers, which is beyond Kaboom's remit.
- Install output now reports which clients were auto-approved and which are UI-only.

## Gates

`node --test npm/kaboom-agentic-browser/lib/*.test.js` → **214 passed / 0 failed** · `npm run lint` clean · scope limited to `npm/…/lib`, its tests, and the feature doc.