### PR TITLE
fix(daemon): never kill a process reclaimPort cannot prove is ours

### DIFF
--- a/cmd/browser-agent/main_connection_recovery.go
+++ b/cmd/browser-agent/main_connection_recovery.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -120,6 +122,58 @@ func terminatePIDQuiet(pid int, force bool) {
 	}
 }
 
+// daemonProcessCommand looks up a PID's command line. Injectable for tests.
+var daemonProcessCommand = getProcessCommand
+
+// ourDaemonBinaryNames are the binary names this project ships or builds. A
+// leftover daemon may come from a different install path or an older version, so
+// matching only our own absolute executable path would miss the very zombies this
+// reclaim exists to clear.
+var ourDaemonBinaryNames = []string{"kaboom-agentic-browser", "browser-agent"}
+
+// processLooksLikeOurDaemon reports whether `cmdline` is one of OUR daemons.
+//
+// This is deliberately an allow-list on the executable, not a heuristic on the
+// whole command line: the argument vector can contain anything (a port number, a
+// path), and matching on that would let an unrelated process be claimed as ours.
+// An empty cmdline (ps failed, or the process is already gone) is NOT ours — if we
+// cannot prove ownership we must not kill.
+func processLooksLikeOurDaemon(cmdline, ownExecPath string) bool {
+	cmdline = strings.TrimSpace(cmdline)
+	if cmdline == "" {
+		return false
+	}
+	// Only the executable (argv[0]) decides; arguments are never consulted.
+	exe := cmdline
+	if i := strings.IndexByte(exe, ' '); i >= 0 {
+		exe = exe[:i]
+	}
+	if ownExecPath != "" && exe == ownExecPath {
+		return true
+	}
+	base := filepath.Base(exe)
+	if ownExecPath != "" && base == filepath.Base(ownExecPath) {
+		return true
+	}
+	for _, name := range ourDaemonBinaryNames {
+		// `go test` runs the package binary as "<name>.test", which is still ours.
+		if base == name || base == name+".test" || base == name+".exe" {
+			return true
+		}
+	}
+	return false
+}
+
+// isOurDaemonPID reports whether pid is one of our daemons, per the command-line
+// allow-list above. Unknown => false (never kill what we cannot identify).
+func isOurDaemonPID(pid int) bool {
+	ownExec, err := os.Executable()
+	if err != nil {
+		ownExec = ""
+	}
+	return processLooksLikeOurDaemon(daemonProcessCommand(pid), ownExec)
+}
+
 // reclaimPort clears anything already listening on `port` so daemon startup is
 // deterministically single-instance. It finds the owning PID(s), logs them,
 // terminates them (SIGTERM then SIGKILL), and waits for release. This is the
@@ -127,6 +181,13 @@ func terminatePIDQuiet(pid int, force bool) {
 // not cover — a zombie from an un-clean restart or crash. That is exactly the
 // condition that leaves the terminal port (main+1) unreachable and the terminal
 // dead. Returns true if the port is free afterward. Self is never killed.
+//
+// Only OUR daemons are ever terminated. The owning PIDs come from `lsof`, which
+// reports whoever holds the port — previously every one of them was SIGTERM'd and
+// then SIGKILL'd with a self-PID check as the only guard, so an unrelated program
+// the user happened to run on 7890/7891 (a dev server, a database) was killed on
+// startup, and the terminal supervisor repeated that before each restart attempt.
+// A process we cannot positively identify as ours is left alone and logged.
 func reclaimPort(server *Server, port int, purpose string) bool {
 	owners, err := daemonFindProcessOnPort(port)
 	if err != nil || len(owners) == 0 {
@@ -136,6 +197,18 @@ func reclaimPort(server *Server, port int, purpose string) bool {
 	killed := make([]int, 0, len(owners))
 	for _, pid := range owners {
 		if pid <= 0 || pid == self {
+			continue
+		}
+		if !isOurDaemonPID(pid) {
+			// Someone else's process holds the port. Killing it would be destructive
+			// and is never our call — log loudly so "the port is busy" is diagnosable
+			// instead of silently doing nothing (rule 25).
+			cmdline := daemonProcessCommand(pid)
+			server.logLifecycle("port_reclaim_skipped_foreign", port, map[string]any{
+				"purpose": purpose, "owner_pid": pid, "owner_command": cmdline,
+			})
+			stderrf("[Kaboom] port %d is held by another process (pid %d: %s) — not reclaiming it. "+
+				"Free that port or start Kaboom on a different one.\n", port, pid, cmdline)
 			continue
 		}
 		server.logLifecycle("port_reclaim_terminating", port, map[string]any{"purpose": purpose, "owner_pid": pid})

--- a/cmd/browser-agent/reclaim_port_identity_test.go
+++ b/cmd/browser-agent/reclaim_port_identity_test.go
@@ -1,0 +1,163 @@
+// reclaim_port_identity_test.go -- reclaimPort must only ever kill OUR daemon.
+//
+// Regression: reclaimPort took raw PIDs from `lsof -tiTCP:<port> -sTCP:LISTEN` and
+// SIGTERM/SIGKILLed every one of them, with a self-PID check as the ONLY guard.
+// Nothing verified the process was a Kaboom daemon, so any unrelated program the
+// user happened to be running on 7890/7891 — a dev server, a database, another
+// tool — was killed on daemon startup. terminal_supervisor calls this before every
+// restart attempt (up to 8), so a foreign listener could be killed repeatedly.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// swapProcessCommand installs a fake process-command lookup and returns a restore func.
+func swapProcessCommand(f func(int) string) func() {
+	old := daemonProcessCommand
+	daemonProcessCommand = f
+	return func() { daemonProcessCommand = old }
+}
+
+func TestReclaimPort_NeverKillsAForeignProcess(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "foreign.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	const port = 7891
+	var killed []int
+	restore := swapReclaimDeps(
+		func(int) ([]int, error) { return []int{4242}, nil },
+		func(pid int, _ bool) { killed = append(killed, pid) },
+		func(int, time.Duration) bool { return true },
+		func(int) bool { return true }, // still running: we did not free it
+	)
+	defer restore()
+	restoreCmd := swapProcessCommand(func(int) string {
+		return "/opt/homebrew/opt/postgresql@16/bin/postgres -D /opt/homebrew/var/postgresql@16"
+	})
+	defer restoreCmd()
+
+	if reclaimPort(server, port, "terminal") {
+		t.Fatal("a port held by a foreign process must not be reported as freed")
+	}
+	if len(killed) != 0 {
+		t.Fatalf("a foreign process must NEVER be killed, got kills for %v", killed)
+	}
+
+	server.logs.shutdownAsyncLogger(2 * time.Second)
+	// Declining to reclaim is a real, diagnosable outcome — it must not be silent
+	// (rule 25), or "the terminal port is busy" becomes unexplainable.
+	events := readLifecycleEventsFromLogFile(t, logFile)
+	found := false
+	for _, evt := range events {
+		if name, _ := evt["event"].(string); name == "port_reclaim_skipped_foreign" {
+			found = true
+			if pid, _ := evt["owner_pid"].(float64); int(pid) != 4242 {
+				t.Errorf("skipped event owner_pid = %v, want 4242", evt["owner_pid"])
+			}
+		}
+	}
+	if !found {
+		t.Error("declining to kill a foreign process must be logged (port_reclaim_skipped_foreign)")
+	}
+}
+
+func TestReclaimPort_StillKillsOurOwnDaemon(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "ours.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+
+	const port = 7890
+	var killed []int
+	restore := swapReclaimDeps(
+		func(int) ([]int, error) { return []int{4242}, nil },
+		func(pid int, _ bool) { killed = append(killed, pid) },
+		func(int, time.Duration) bool { return true },
+		func(int) bool { return false },
+	)
+	defer restore()
+	// A leftover daemon reports our own executable path — the whole point of the
+	// feature. The identity check must not disable the reclaim it exists for.
+	restoreCmd := swapProcessCommand(func(int) string { return self + " --daemon --port 7890" })
+	defer restoreCmd()
+
+	if !reclaimPort(server, port, "main") {
+		t.Fatal("reclaimPort should free a port held by our own leftover daemon")
+	}
+	if len(killed) != 1 || killed[0] != 4242 {
+		t.Fatalf("our own leftover daemon must still be reclaimed, got kills %v", killed)
+	}
+	server.logs.shutdownAsyncLogger(2 * time.Second)
+}
+
+func TestReclaimPort_UnknownCommandIsNotKilled(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "unknown.log")
+	server, err := NewServer(logFile, 200)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	var killed []int
+	restore := swapReclaimDeps(
+		func(int) ([]int, error) { return []int{4242}, nil },
+		func(pid int, _ bool) { killed = append(killed, pid) },
+		func(int, time.Duration) bool { return true },
+		func(int) bool { return true },
+	)
+	defer restore()
+	// `ps` failed / the process vanished. We cannot prove it is ours, so we must
+	// not kill it: an unidentifiable process is treated as foreign, never as ours.
+	restoreCmd := swapProcessCommand(func(int) string { return "" })
+	defer restoreCmd()
+
+	reclaimPort(server, 7891, "terminal")
+	if len(killed) != 0 {
+		t.Fatalf("an unidentifiable process must not be killed, got kills %v", killed)
+	}
+	server.logs.shutdownAsyncLogger(2 * time.Second)
+}
+
+func TestProcessLooksLikeOurDaemon(t *testing.T) {
+	t.Parallel()
+
+	ours := []string{
+		"/usr/local/bin/kaboom-agentic-browser --daemon",
+		"/Users/x/.kaboom/bin/kaboom-agentic-browser",
+		"/tmp/go-build123/b001/browser-agent.test -test.run=X",
+		"/opt/homebrew/bin/browser-agent --daemon --port 7890",
+	}
+	for _, cmdline := range ours {
+		if !processLooksLikeOurDaemon(cmdline, "/usr/local/bin/kaboom-agentic-browser") {
+			t.Errorf("must recognize our own daemon: %q", cmdline)
+		}
+	}
+
+	foreign := []string{
+		"",
+		"/opt/homebrew/opt/postgresql@16/bin/postgres -D /var/pg",
+		"node /Users/x/project/server.js",
+		"python3 -m http.server 7890",
+		"/Applications/Docker.app/Contents/MacOS/com.docker.backend",
+		// Merely mentioning the port must not qualify anything.
+		"nc -l 7890",
+	}
+	for _, cmdline := range foreign {
+		if processLooksLikeOurDaemon(cmdline, "/usr/local/bin/kaboom-agentic-browser") {
+			t.Errorf("must NOT claim a foreign process: %q", cmdline)
+		}
+	}
+}

--- a/cmd/browser-agent/reclaim_port_test.go
+++ b/cmd/browser-agent/reclaim_port_test.go
@@ -9,11 +9,20 @@ import (
 
 // swapReclaimDeps installs fakes for reclaimPort's injectable dependencies and
 // returns a restore func.
+//
+// It also stubs daemonProcessCommand so every owning PID reports OUR daemon.
+// reclaimPort now refuses to kill a process it cannot identify as ours, so without
+// this the fake PIDs below (which do not exist) would be treated as foreign and
+// skipped — these tests are about the kill/force-kill/self-skip mechanics, not
+// about identity, which reclaim_port_identity_test.go covers directly.
 func swapReclaimDeps(find func(int) ([]int, error), term func(int, bool), wait func(int, time.Duration) bool, running func(int) bool) func() {
 	of, ot, ow, or := daemonFindProcessOnPort, daemonTerminatePID, daemonWaitForPortRelease, daemonIsServerRunning
+	oc := daemonProcessCommand
 	daemonFindProcessOnPort, daemonTerminatePID, daemonWaitForPortRelease, daemonIsServerRunning = find, term, wait, running
+	daemonProcessCommand = func(int) string { return "/usr/local/bin/kaboom-agentic-browser --daemon" }
 	return func() {
 		daemonFindProcessOnPort, daemonTerminatePID, daemonWaitForPortRelease, daemonIsServerRunning = of, ot, ow, or
+		daemonProcessCommand = oc
 	}
 }
 

--- a/docs/features/feature/mcp-persistent-server/index.md
+++ b/docs/features/feature/mcp-persistent-server/index.md
@@ -13,6 +13,7 @@ code_paths:
   - cmd/browser-agent/daemon_lifecycle.go
   - cmd/browser-agent/startup_throttle.go
   - cmd/browser-agent/main_connection_mcp.go
+  - cmd/browser-agent/main_connection_recovery.go
   - cmd/browser-agent/main_connection_mcp_shutdown.go
   - cmd/browser-agent/server_middleware.go
   - cmd/browser-agent/handler_http.go
@@ -22,6 +23,8 @@ code_paths:
   - internal/util/proc_unix.go
   - internal/util/proc_windows.go
 test_paths:
+  - cmd/browser-agent/reclaim_port_identity_test.go
+  - cmd/browser-agent/reclaim_port_test.go
   - cmd/browser-agent/bridge_startup_contention_test.go
   - cmd/browser-agent/bridge_faststart_extended_test.go
   - cmd/browser-agent/handler_http_headers_test.go


### PR DESCRIPTION
## Why

`reclaimPort` took raw PIDs from `lsof -tiTCP:<port> -sTCP:LISTEN` and SIGTERM'd then SIGKILL'd every one of them, with a **self-PID check as the only guard**:

```go
for _, pid := range owners {
    if pid <= 0 || pid == self { continue }
    daemonTerminatePID(pid, false)   // then force-kill 2s later
```

Nothing verified the process was a Kaboom daemon. Any unrelated program the user happened to have on 7890/7891 — a dev server, a database, another tool — was killed when the daemon started. `terminal_supervisor.go` calls this before *every* restart attempt (up to 8), so a foreign listener could be killed repeatedly.

This was a sharp asymmetry with `performDefaultTakeover`, which is careful (lock-PID vs PID-file cross-check, health probe with retries, defer-to-healthy). `reclaimPort` bypassed all of it. `getProcessCommand` already existed in the same file, used only for a diagnostic string.

## What

A PID is terminated only if its **executable** is one of ours.

- The check is an allow-list on **argv[0] only**, never the argument vector — that vector can contain anything, so `nc -l 7890` must not qualify itself by mentioning the port.
- Matching accepts our own executable path, our own basename, and the shipped/built names (`kaboom-agentic-browser`, `browser-agent`, plus `.test`/`.exe` forms), so a leftover daemon from a **different install path or an older version is still reclaimed** — that zombie is the entire point of the feature. There's a dedicated test asserting the guard cannot silently disable it.
- **Safety inversion:** an unidentifiable process (ps failed, or it already exited) is treated as foreign, never as ours.
- Refusing is logged loudly — `port_reclaim_skipped_foreign` with pid + command, plus a stderr line — so "the port is busy" stays diagnosable instead of becoming a silent no-op (rule 25).

## Notes for review

Two pre-existing tests had to be updated (rule 23): they assert kill / force-kill / self-skip mechanics using PIDs that don't exist, which the identity check correctly refuses to kill. `swapReclaimDeps` now stubs `daemonProcessCommand` so they still exercise the mechanics they're about; identity is covered directly by the new tests.

**Known follow-up (not in this PR):** the stderr line above goes to `/dev/null` for a bridge-spawned daemon, because the SIGPIPE fix in #628 sets `cmd.Stdout/Stderr = nil` by design. The structured `logLifecycle` event does survive to `~/.kaboom/logs/kaboom.jsonl`. Making this genuinely easy to diagnose needs `/health` to report terminal-bind failure — today it reports `terminal_port` even when the terminal server failed to bind, which is actively misleading to `configure(what:'health')`.

## Gates

Exact CI invocation `go test -coverprofile ./cmd/browser-agent/...` → **14/14 packages ok, total coverage 70.7%** (gate 70%) · `go vet` + gofmt clean · `verify-llm` passed · docs cross-ref updated (rule 9).