### PR TITLE
fix(terminal): end the permanent fake "exited", and detect half-open sockets

### DIFF
--- a/cmd/browser-agent/internal/terminal/handlers.go
+++ b/cmd/browser-agent/internal/terminal/handlers.go
@@ -365,6 +365,17 @@ func wsLoop(conn net.Conn, rw *bufio.ReadWriter, deps Deps, sess *pty.Session, r
 					closeConn()
 					return
 				}
+				// Also send an application-level keepalive the BROWSER can observe.
+				// The ping above is a WebSocket control frame: the browser answers it
+				// automatically but never surfaces it to JS, so page code has no way
+				// to tell a live-but-idle terminal from a half-open socket (suspend,
+				// NAT rebind — no FIN/RST, readyState stays OPEN). Without an
+				// observable signal the client shows a connected dot while keystrokes
+				// vanish. A text frame is visible to onmessage, so the client can run
+				// its own liveness watchdog. Non-fatal: the ping already governs
+				// connection health, so a failed keepalive must not tear down a
+				// connection the ping considers fine.
+				_ = writeFrame(0x1, []byte(`{"type":"keepalive"}`))
 			}
 		}
 	})

--- a/cmd/browser-agent/internal/terminal/relay.go
+++ b/cmd/browser-agent/internal/terminal/relay.go
@@ -153,15 +153,43 @@ func (m *Map) Get(id string) *Relay {
 	return m.relays[id]
 }
 
-// GetOrCreate returns the existing relay for id or creates a new one.
+// GetOrCreate returns the existing relay for id, or creates one. If an existing
+// relay is bound to a DIFFERENT session than the caller supplied, it is stale and
+// gets replaced rather than returned.
+//
+// That rebind is the fix for the permanent fake "exited": nothing removes a relay
+// when its shell dies, so the map keeps an entry whose fanout is closed. Manager.Start
+// evicts a dead session before spawning and discards `replaced` if the spawn then
+// fails, so a later successful Start reports Replaced=false and the caller lands
+// here — and this function used to ignore `sess` entirely and hand back the stale
+// dead-bound relay. Every WS connect then hit ErrFanoutClosed and shipped
+// {"type":"exited"}, which permanently disables reconnect in the browser: the panel
+// showed "[Process exited]" over a healthy shell until the daemon restarted.
+//
+// Keeping the invariant here rather than in the handler is deliberate (rule 19):
+// no caller should have to compute `Replaced` correctly for the relay map to stay
+// consistent with the session manager.
 func (m *Map) GetOrCreate(id string, sess *pty.Session, workspaceDir string) *Relay {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.Lock() // lint:manual-unlock — unlock before Close to avoid holding lock during I/O
 	if r := m.relays[id]; r != nil {
-		return r
+		// Rebind ONLY when the bound session is genuinely DEAD. The condition must be
+		// asymmetric: "the sessions differ" is symmetric, so a concurrent reconnect
+		// still holding the OLD session would rebind the map backwards and undo a
+		// just-completed ReplaceRelay — finding H in reverse. A corpse can never win
+		// that race, because a dead session is never something to rebind *to*.
+		if r.sess == sess || r.sess == nil || r.sess.IsAlive() {
+			m.mu.Unlock()
+			return r
+		}
+		fresh := NewRelay(sess, workspaceDir)
+		m.relays[id] = fresh
+		m.mu.Unlock()
+		r.Close() // outside the lock: Close can block briefly
+		return fresh
 	}
 	r := NewRelay(sess, workspaceDir)
 	m.relays[id] = r
+	m.mu.Unlock()
 	return r
 }
 

--- a/cmd/browser-agent/internal/terminal/relay_rebind_test.go
+++ b/cmd/browser-agent/internal/terminal/relay_rebind_test.go
@@ -1,0 +1,82 @@
+// relay_rebind_test.go -- GetOrCreate must never hand back a relay bound to a DEAD
+// session when the caller supplies a live one.
+//
+// Regression (the permanent fake "exited"): nothing removes a relay when its shell
+// dies, so the Map keeps an entry whose fanout is closed. Manager.Start evicts a
+// dead session BEFORE it spawns, and discards `replaced` if the spawn then fails —
+// so the next successful Start reports Replaced=false, the handler takes the
+// GetOrCreate path, and GetOrCreate returned the stale dead-bound relay because it
+// ignored its `sess` argument entirely. Every WS connect then hit ErrFanoutClosed
+// and shipped {"type":"exited"}, which sets processExited=true in the browser and
+// disables reconnect permanently. The terminal showed "[Process exited]" over a
+// perfectly healthy shell until the daemon was restarted.
+//
+// The invariant belongs in the primitive, not in each caller (CLAUDE.md rule 19):
+// the handler must not have to compute `Replaced` correctly for the relay map to
+// stay consistent with the session manager.
+
+package terminal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/internal/pty"
+)
+
+func TestMap_GetOrCreateRebindsWhenSessionDiffers(t *testing.T) {
+	mgr := pty.NewManager()
+	defer mgr.StopAll()
+
+	relays, first := startCatRelay(t, mgr, "rebind")
+
+	// Kill the shell: this is the state that produces the bug — a relay left in the
+	// map bound to a session whose process is gone and whose fanout is closed.
+	if err := first.sess.Close(); err != nil {
+		t.Fatalf("close first session: %v", err)
+	}
+	for i := 0; first.sess.IsAlive() && i < 200; i++ {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if first.sess.IsAlive() {
+		t.Fatal("first session should be dead before the rebind")
+	}
+
+	// A fresh session under the SAME id — exactly what Manager.Start produces after
+	// it self-heals a dead session (or after an evict-then-failed-spawn, where the
+	// caller is told Replaced=false).
+	res2, err := mgr.Start(pty.StartConfig{ID: "rebind-2", Cmd: "/bin/sh", Args: []string{"-c", "exec cat"}})
+	if err != nil {
+		t.Fatalf("start second session: %v", err)
+	}
+	second, err := mgr.Get(res2.SessionID)
+	if err != nil {
+		t.Fatalf("get second session: %v", err)
+	}
+
+	got := relays.GetOrCreate("rebind", second, "/work/dir")
+	if got == first {
+		t.Fatal("GetOrCreate returned the STALE relay for a different session — this is the permanent fake-exited bug")
+	}
+	if got.sess != second {
+		t.Fatalf("the returned relay must be bound to the supplied session")
+	}
+	if cur := relays.Get("rebind"); cur != got {
+		t.Fatal("the map must now hold the rebound relay, not the stale one")
+	}
+}
+
+func TestMap_GetOrCreateStillIdempotentForSameSession(t *testing.T) {
+	mgr := pty.NewManager()
+	defer mgr.StopAll()
+
+	relays, relay := startCatRelay(t, mgr, "same")
+
+	// The rebind guard must not cause churn on the normal path: the same session
+	// must keep returning the same relay, or every WS reconnect would spawn a new
+	// reader loop and drop scrollback.
+	again := relays.GetOrCreate("same", relay.sess, "/other")
+	if again != relay {
+		t.Fatal("GetOrCreate must stay idempotent for the same session")
+	}
+}

--- a/cmd/browser-agent/internal/terminal/terminal_assets/terminal.html
+++ b/cmd/browser-agent/internal/terminal/terminal_assets/terminal.html
@@ -108,6 +108,27 @@
       // (FIFO) behind any reconnect-gap input rather than sent ahead of it (D).
       var replaying = false;
       var lastTypingNotifyAt = 0;
+      // Client-side liveness watchdog.
+      //
+      // Liveness was entirely server-driven: the daemon pings every 30s and closes
+      // after 60s of silence. But a WebSocket ping is a control frame the browser
+      // answers automatically and never surfaces to JS, so page code could not tell
+      // a live-but-idle terminal from a HALF-OPEN socket. On suspend/resume or a NAT
+      // rebind there is no FIN/RST, so readyState stays OPEN, onclose never fires,
+      // and both writers take their non-queueing branch — keystrokes and agent
+      // writes went into the void behind a green status dot.
+      //
+      // The server now also emits an observable {"type":"keepalive"} text frame on
+      // that same 30s tick. Any frame (output, control, keepalive) refreshes
+      // lastFrameAt; if nothing arrives for KEEPALIVE_DEAD_MS while the socket still
+      // claims to be OPEN, we force it closed so the existing reconnect path runs.
+      // The threshold is a multiple of the server tick so a single dropped or
+      // delayed keepalive can never sever a healthy connection.
+      var lastFrameAt = 0;
+      var livenessTimer = null;
+      var SERVER_KEEPALIVE_MS = 30000;
+      var KEEPALIVE_DEAD_MS = SERVER_KEEPALIVE_MS * 2.5;
+      var LIVENESS_POLL_MS = 5000;
       // Reconnect ceiling: a full daemon restart drops every session/token, so a
       // reconnect on the captured token 401s and onopen never fires. Without a cap
       // this loops forever (status dot stuck) with no recovery. After
@@ -188,9 +209,13 @@
 
           // Notify parent frame
           notifyParent('connected', {});
+
+          startLivenessWatchdog();
         };
 
         ws.onmessage = function(event) {
+          // ANY frame proves the socket is alive, including the keepalive below.
+          lastFrameAt = Date.now();
           if (event.data instanceof ArrayBuffer) {
             // Binary frame: terminal output
             term.write(new Uint8Array(event.data));
@@ -214,6 +239,9 @@
                 replaying = false;
                 notifyParent('replay_end', {});
                 flushPendingInput();
+              } else if (msg.type === 'keepalive') {
+                // Liveness only — lastFrameAt is already refreshed above. Handled
+                // explicitly so it is never mistaken for an unknown control message.
               } else if (msg.type === 'alt_screen') {
                 // Alt-screen state changed (e.g., vim, less entered/exited).
                 notifyParent('alt_screen', { active: msg.active });
@@ -234,6 +262,7 @@
         };
 
         ws.onclose = function() {
+          stopLivenessWatchdog();
           statusDot.className = 'status';
           notifyParent('disconnected', {});
           notifyFocusState(false);
@@ -243,6 +272,52 @@
         ws.onerror = function() {
           statusDot.className = 'status error';
         };
+      }
+
+      function stopLivenessWatchdog() {
+        if (livenessTimer) {
+          clearTimeout(livenessTimer);
+          livenessTimer = null;
+        }
+      }
+
+      /**
+       * Watch for a socket that claims to be OPEN but has gone silent.
+       *
+       * Only a socket the browser still reports as OPEN is actionable: a CLOSING or
+       * CLOSED one already has onclose driving recovery. Forcing close() here makes
+       * the half-open case take that exact same path, so there is one recovery
+       * route rather than two.
+       */
+      function startLivenessWatchdog() {
+        stopLivenessWatchdog();
+        lastFrameAt = Date.now();
+        // Self-rescheduling setTimeout rather than setInterval: it matches the
+        // reconnect path's idiom and guarantees only one pending tick at a time, so
+        // a slow turn can never stack overlapping checks.
+        function tick() {
+          livenessTimer = null;
+          if (!ws || ws.readyState !== WebSocket.OPEN) return; // onclose owns recovery
+          if (Date.now() - lastFrameAt < KEEPALIVE_DEAD_MS) {
+            livenessTimer = setTimeout(tick, LIVENESS_POLL_MS);
+            return;
+          }
+          // Silent past the threshold: the socket is half-open. Do NOT reschedule —
+          // close() drives onclose, which owns reconnect (with its existing backoff
+          // and exhaustion caps), so there is exactly one recovery route.
+          console.warn('[KaBOOM! terminal] no server frame for ' + KEEPALIVE_DEAD_MS +
+            'ms while socket was OPEN — treating as half-open and reconnecting');
+          notifyParent('disconnected', {});
+          try {
+            ws.close();
+          } catch (e) {
+            // close() can throw on an already-torn-down socket. The reconnect is the
+            // point, so fall through to it rather than swallowing the failure.
+            console.warn('[KaBOOM! terminal] forced close failed: ' + e);
+            scheduleReconnect();
+          }
+        }
+        livenessTimer = setTimeout(tick, LIVENESS_POLL_MS);
       }
 
       function scheduleReconnect() {

--- a/docs/features/feature/terminal/index.md
+++ b/docs/features/feature/terminal/index.md
@@ -40,6 +40,8 @@ code_paths:
   - internal/pty/upload.go
   - npm/kaboom-agentic-browser/lib/kill-daemon.js
 test_paths:
+  - tests/extension/terminal-html-liveness.test.js
+  - cmd/browser-agent/internal/terminal/relay_rebind_test.go
   - cmd/browser-agent/internal/terminal/spawn_retry_test.go
   - cmd/browser-agent/internal/terminal/sandbox_error_test.go
   - cmd/browser-agent/internal/terminal/handlers_start_decisions_test.go

--- a/tests/extension/terminal-html-liveness.test.js
+++ b/tests/extension/terminal-html-liveness.test.js
@@ -1,0 +1,168 @@
+// @ts-nocheck
+/**
+ * terminal-html-liveness.test.js — the client must detect a HALF-OPEN socket.
+ *
+ * Liveness used to be entirely server-driven: the daemon pings every 30s and closes
+ * after 60s of silence. But a WebSocket ping is a control frame the browser answers
+ * automatically and never surfaces to JS, so page code could not distinguish a
+ * live-but-idle terminal from a half-open one. After suspend/resume or a NAT rebind
+ * there is no FIN/RST — readyState stays OPEN, onclose never fires, and both writers
+ * take their non-queueing branch. Keystrokes and agent writes went into the void
+ * behind a green status dot.
+ *
+ * The server now also emits an observable {"type":"keepalive"} text frame on its ping
+ * tick; this asserts the client acts on its absence, and — just as important — that it
+ * does NOT sever a healthy idle connection.
+ */
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+const html = readFileSync(new URL('../../cmd/browser-agent/internal/terminal/terminal_assets/terminal.html', import.meta.url), 'utf8')
+const iife = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]).find((s) => s.includes('term.onData'))
+assert.ok(iife && iife.includes('KEEPALIVE_DEAD_MS'), 'could not extract terminal.html IIFE with the liveness watchdog')
+
+function runTerminalPage() {
+  const parentMsgs = []
+  const timers = []
+  let timerSeq = 1
+  let nowMs = 1_000_000
+  const stateRef = { ws: null, onData: null }
+  let closeCalls = 0
+
+  const makeEl = () => ({
+    className: '', textContent: '', title: '',
+    addEventListener() {}, clientWidth: 0, clientHeight: 0
+  })
+
+  const term = {
+    _core: { _renderService: { dimensions: { css: { cell: { width: 0, height: 0 } } } } },
+    cols: 80, rows: 24,
+    textarea: { addEventListener() {} },
+    open() {}, reset() {}, focus() {}, refresh() {}, resize() {}, write() {},
+    onData(cb) { stateRef.onData = cb }
+  }
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url
+      this.binaryType = ''
+      this.readyState = 0
+      this.onopen = this.onmessage = this.onclose = this.onerror = null
+      stateRef.ws = this
+    }
+    send() {}
+    close() {
+      closeCalls++
+      this.readyState = 3
+      if (this.onclose) this.onclose()
+    }
+  }
+  FakeWebSocket.CONNECTING = 0
+  FakeWebSocket.OPEN = 1
+  FakeWebSocket.CLOSING = 2
+  FakeWebSocket.CLOSED = 3
+
+  const win = {
+    location: { search: '?token=abc', protocol: 'http:', host: 'localhost:7891' },
+    addEventListener() {}, removeEventListener() {}
+  }
+  win.parent = { postMessage(msg) { parentMsgs.push(msg) } }
+
+  const sandbox = {
+    window: win,
+    document: { getElementById: () => makeEl(), addEventListener() {}, activeElement: null },
+    Terminal: function () { return term },
+    WebSocket: FakeWebSocket,
+    URLSearchParams, TextEncoder, TextDecoder,
+    setTimeout: (fn, ms) => { const id = timerSeq++; timers.push({ id, fn, ms }); return id },
+    clearTimeout: (id) => { const i = timers.findIndex((t) => t.id === id); if (i >= 0) timers.splice(i, 1) },
+    Date: { now: () => nowMs },
+    console: { log() {}, warn() {}, error() {} }
+  }
+  vm.createContext(sandbox)
+  vm.runInContext(iife, sandbox)
+
+  return {
+    get ws() { return stateRef.ws },
+    closeCalls: () => closeCalls,
+    parentEvents: () => parentMsgs.map((m) => m && m.event),
+    advance: (ms) => { nowMs += ms },
+    // Fire only the watchdog's pending tick (the shortest-delay timer), leaving
+    // reconnect timers alone so the two paths stay distinguishable.
+    fireWatchdog: () => {
+      const idx = timers.reduce((best, t, i) => (best < 0 || t.ms < timers[best].ms ? i : best), -1)
+      if (idx < 0) return false
+      const [t] = timers.splice(idx, 1)
+      t.fn()
+      return true
+    }
+  }
+}
+
+function openSocket(h) {
+  h.ws.readyState = 1
+  h.ws.onopen()
+}
+
+describe('terminal.html half-open socket detection', () => {
+  test('a socket silent past the threshold is force-closed and recovery starts', () => {
+    const h = runTerminalPage()
+    openSocket(h)
+    assert.strictEqual(h.closeCalls(), 0, 'a freshly opened socket must not be closed')
+
+    // No frames at all — the suspend/resume case. readyState stays OPEN, so nothing
+    // in the old code would ever have noticed.
+    h.advance(76_000) // > KEEPALIVE_DEAD_MS (30s * 2.5)
+    assert.ok(h.fireWatchdog(), 'the watchdog should have a pending tick')
+
+    assert.strictEqual(h.closeCalls(), 1, 'a half-open socket must be force-closed')
+    assert.ok(
+      h.parentEvents().includes('disconnected'),
+      'the parent must learn the terminal is disconnected so the dot stops lying'
+    )
+  })
+
+  test('a healthy idle connection is NEVER severed', () => {
+    const h = runTerminalPage()
+    openSocket(h)
+
+    // An idle terminal produces no output for minutes, but the server keepalive
+    // keeps arriving. Severing here would be a self-inflicted outage — the whole
+    // reason the threshold is a multiple of the server tick.
+    for (let i = 0; i < 20; i++) {
+      h.advance(29_000)
+      h.ws.onmessage({ data: JSON.stringify({ type: 'keepalive' }) })
+      h.fireWatchdog()
+    }
+    assert.strictEqual(h.closeCalls(), 0, 'keepalives must keep a healthy idle socket alive')
+  })
+
+  test('ordinary terminal output also counts as liveness', () => {
+    const h = runTerminalPage()
+    openSocket(h)
+
+    // A busy terminal may never idle long enough for a keepalive; its output frames
+    // must refresh liveness too, or a chatty session would be killed mid-stream.
+    for (let i = 0; i < 10; i++) {
+      h.advance(40_000)
+      h.ws.onmessage({ data: new TextEncoder().encode('output').buffer })
+      h.fireWatchdog()
+    }
+    assert.strictEqual(h.closeCalls(), 0, 'binary output frames must refresh liveness')
+  })
+
+  test('the watchdog stops once the socket is closed (no reconnect storm)', () => {
+    const h = runTerminalPage()
+    openSocket(h)
+    h.advance(76_000)
+    h.fireWatchdog()
+    const afterFirst = h.closeCalls()
+
+    // Fire every remaining timer: the watchdog must not still be running and
+    // re-closing a socket that onclose already handed to the reconnect path.
+    for (let i = 0; i < 5; i++) h.fireWatchdog()
+    assert.strictEqual(h.closeCalls(), afterFirst, 'the watchdog must not keep closing after it fired')
+  })
+})


### PR DESCRIPTION
Two independent ways the terminal died without recovering. Both from the resilience audit (R3, R5).

---

## 1. The permanent fake "exited" (`9e437a69`)

The panel could show `[Process exited with code 0]` over a perfectly healthy shell and never recover — no retry helped, only a daemon restart.

Two facts combined:
- Nothing removes a relay when its shell dies, so `Map` keeps an entry whose fanout is closed.
- `Manager.Start` evicts a dead session **before** it spawns and discards `replaced` if the spawn then fails. So the next successful `Start` reports `Replaced=false`, the handler takes the `GetOrCreate` path — and `GetOrCreate` ignored its `sess` argument entirely, handing back the stale dead-bound relay.

Every WS connect then hit `ErrFanoutClosed` and shipped `{"type":"exited"}`, which sets `processExited = true` in the browser and **disables reconnect permanently**.

`GetOrCreate` now replaces a relay bound to a DEAD session instead of returning it.

**The condition is deliberately asymmetric — dead, not merely "different".** My first attempt rebound whenever the sessions differed, and the 60-round finding-H concurrency test caught it immediately: a concurrent WS reconnect still holding the OLD session rebound the map backwards and undid a just-completed `ReplaceRelay` — finding H in reverse. Keying on liveness makes it one-way, because a corpse is never something to rebind *to*.

Keeping the invariant in the primitive rather than the handler is deliberate (rule 19): no caller should have to compute `Replaced` correctly for the relay map to stay consistent with the session manager.

---

## 2. Half-open sockets lose keystrokes behind a green dot (`48871b0a`)

After suspend/resume or a NAT rebind there is no FIN/RST: `readyState` stays `OPEN`, `onclose` never fires, `state.terminalConnected` is never cleared — so both writers take their non-queueing branch and every keystroke and agent write goes into the void while the status dot stays green.

The browser could not have fixed this alone: **a WebSocket ping is a control frame the browser answers automatically and never surfaces to JS**, so page code cannot distinguish a live-but-idle terminal from a dead socket. (The only `heartbeat`-named symbol, `notifyTypingHeartbeat`, is typing telemetry for the write guard — unrelated.)

- **Server:** on the existing ping tick, also emit an observable `{"type":"keepalive"}` text frame. Non-fatal if it fails — the ping already governs connection health, so a failed keepalive must not tear down a connection the ping considers fine.
- **Client:** any frame (output, control, keepalive) refreshes `lastFrameAt`; if nothing arrives for **2.5× the server tick** while `readyState` is still `OPEN`, force `close()` so the **existing** `onclose` path drives reconnect with its established backoff and exhaustion caps — one recovery route, not two.

Implemented as a self-rescheduling `setTimeout`, not `setInterval`: one pending tick at a time (a slow turn cannot stack overlapping checks), it matches the reconnect path's idiom, and `setInterval` broke all three existing terminal.html vm harnesses, which stub `setTimeout`/`clearTimeout` only.

---

## Testing

- R3: the new test kills the shell and waits for it to actually die (modelling the real state), then asserts a correctly-bound relay comes back. **Verified RED against unmodified `relay.go` and GREEN after.** A second test pins that the guard causes no churn on the normal path — the same session must keep returning the same relay, or every reconnect would spawn a new reader loop and drop scrollback.
- R5: 4 tests — a silent socket is force-closed and the parent is told; a healthy idle connection is **never** severed across 20 keepalive cycles; ordinary binary output also counts as liveness so a chatty session is not killed mid-stream; the watchdog stops after firing so it cannot storm a socket `onclose` already owns.

## Gates

`go vet` clean · terminal + pty packages under `-race` including the 60-round finding-H test · **2954/2954** extension tests · eslint clean · `verify-llm` passed · docs cross-ref updated (rule 9).

The 3 gofmt-flagged files in this package are pre-existing on UNSTABLE (Go 1.26 struct alignment), not from this change; every file touched here is gofmt-clean.