### PR TITLE
feat(daemon): make a port conflict diagnosable instead of a silent dead end

### DIFF
--- a/cmd/browser-agent/main_connection_mcp.go
+++ b/cmd/browser-agent/main_connection_mcp.go
@@ -86,11 +86,24 @@ func runMCPMode(server *Server, port int, apiKey string, opts daemonLaunchOption
 		}
 	}
 	if termErr != nil {
+		// Identify whoever holds the port. "Port busy" is not actionable; "postgres
+		// (pid 4242) is on 7891" is. This is recorded into /health because the stderr
+		// lines below go to /dev/null for a bridge-spawned daemon (spawned with
+		// Stdout/Stderr = nil so it cannot die of SIGPIPE), making the health payload
+		// the only place a user or agent can learn what happened.
+		blockingPID, blockingCmd := identifyPortHolder(termPort)
+		server.setTerminalUnavailable(termPort, termErr.Error(), blockingPID, blockingCmd)
+
 		stderrf("[Kaboom] WARNING: terminal server failed to start on port %d: %v\n", termPort, termErr)
+		if blockingPID > 0 {
+			stderrf("[Kaboom] Port %d is held by pid %d (%s).\n", termPort, blockingPID, blockingCmd)
+		}
 		stderrf("[Kaboom] Terminal features are unavailable. Free port %d or use a different base port.\n", termPort)
 		server.logLifecycle("terminal_server_bind_failed", termPort, map[string]any{
-			"error":     termErr.Error(),
-			"term_port": termPort,
+			"error":          termErr.Error(),
+			"term_port":      termPort,
+			"blocked_by_pid": blockingPID,
+			"blocked_by_cmd": blockingCmd,
 		})
 	} else {
 		server.setTerminalPort(termPort)

--- a/cmd/browser-agent/main_connection_mcp_bootstrap.go
+++ b/cmd/browser-agent/main_connection_mcp_bootstrap.go
@@ -143,8 +143,20 @@ func preflightPortCheck(server *Server, port int) error {
 	testAddr := fmt.Sprintf("127.0.0.1:%d", port)
 	testLn, err := net.Listen("tcp", testAddr)
 	if err != nil {
-		server.logLifecycle("port_conflict_detected", port, map[string]any{"error": err.Error()})
-		return fmt.Errorf("port %d already in use (unknown process, try '%s'): %w", port, portKillHintForce(port), err)
+		// Name the holder rather than saying "unknown process". This is the message
+		// the user actually sees when the daemon refuses to start, and "unknown" sent
+		// them to a kill hint that may target something they did not want killed.
+		blockingPID, blockingCmd := identifyPortHolder(port)
+		server.logLifecycle("port_conflict_detected", port, map[string]any{
+			"error":          err.Error(),
+			"blocked_by_pid": blockingPID,
+			"blocked_by_cmd": blockingCmd,
+		})
+		if blockingPID > 0 {
+			return fmt.Errorf("port %d already in use by pid %d (%s); free that port or start Kaboom on a different one: %w",
+				port, blockingPID, blockingCmd, err)
+		}
+		return fmt.Errorf("port %d already in use (owner could not be identified, try '%s'): %w", port, portKillHintForce(port), err)
 	}
 	return testLn.Close()
 }

--- a/cmd/browser-agent/main_connection_recovery.go
+++ b/cmd/browser-agent/main_connection_recovery.go
@@ -228,3 +228,21 @@ func reclaimPort(server *Server, port int, purpose string) bool {
 	server.logLifecycle("port_reclaimed", port, map[string]any{"purpose": purpose, "killed_pids": killed, "freed": freed})
 	return freed
 }
+
+// identifyPortHolder returns the PID and command line of whatever is listening on
+// port, or (0, "") if that cannot be determined. Best effort and never fatal: it
+// exists purely to turn "port busy" into something the user can act on.
+func identifyPortHolder(port int) (int, string) {
+	owners, err := daemonFindProcessOnPort(port)
+	if err != nil || len(owners) == 0 {
+		return 0, ""
+	}
+	self := os.Getpid()
+	for _, pid := range owners {
+		if pid <= 0 || pid == self {
+			continue
+		}
+		return pid, daemonProcessCommand(pid)
+	}
+	return 0, ""
+}

--- a/cmd/browser-agent/server.go
+++ b/cmd/browser-agent/server.go
@@ -44,6 +44,13 @@ type Server struct {
 
 	// Terminal server port (0 = terminal server not running)
 	terminalPort int
+	// Terminal diagnosability: a bind failure is non-fatal, so /health is the only
+	// place the reason can surface (daemon stderr goes to /dev/null when spawned).
+	terminalAvailable        bool
+	terminalWantedPort       int
+	terminalError            string
+	terminalBlockedByPID     int
+	terminalBlockedByCommand string
 
 	// terminalSupervisor watches and auto-restarts the terminal HTTP server.
 	// nil if the terminal server never bound (Windows, or bind failure).
@@ -173,11 +180,67 @@ func (s *Server) closeAnnotationStore() {
 	}
 }
 
-// setTerminalPort stores the port the terminal server is listening on.
+// terminalStatus is the diagnosable state of the terminal server.
+//
+// A terminal-port bind failure is non-fatal — the daemon serves MCP normally and
+// the terminal is simply absent — so the ONLY way a user or agent learns what
+// happened is this status. The daemon's stderr explanation cannot serve that role:
+// a bridge-spawned daemon is started with Stdout/Stderr = nil (so it cannot die of
+// SIGPIPE), which sends every stderr diagnostic to /dev/null.
+type terminalStatus struct {
+	Available        bool   `json:"available"`
+	Port             int    `json:"port"`
+	Error            string `json:"error,omitempty"`
+	BlockedByPID     int    `json:"blocked_by_pid,omitempty"`
+	BlockedByCommand string `json:"blocked_by_command,omitempty"`
+}
+
+// setTerminalPort stores the port the terminal server is listening on. A non-zero
+// port means a successful bind, which clears any previous failure diagnosis — a
+// stale "blocked by postgres" would be worse than reporting nothing. Port 0 is how
+// the supervisor reports the server died, so availability follows it down.
 func (s *Server) setTerminalPort(port int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.terminalPort = port
+	s.terminalAvailable = port > 0
+	if port > 0 {
+		s.terminalError = ""
+		s.terminalBlockedByPID = 0
+		s.terminalBlockedByCommand = ""
+	}
+}
+
+// setTerminalUnavailable records WHY the terminal server is not running, including
+// the process holding the port when we can identify it. "Port busy" is not
+// actionable; "postgres (pid 4242) is on 7891" is.
+func (s *Server) setTerminalUnavailable(port int, reason string, blockingPID int, blockingCommand string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.terminalPort = 0 // nothing is listening for us
+	s.terminalAvailable = false
+	s.terminalError = reason
+	s.terminalBlockedByPID = blockingPID
+	s.terminalBlockedByCommand = blockingCommand
+	s.terminalWantedPort = port
+}
+
+// getTerminalStatus returns the terminal server's diagnosable state.
+func (s *Server) getTerminalStatus() terminalStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	port := s.terminalPort
+	if !s.terminalAvailable && s.terminalWantedPort > 0 {
+		// Report the port we could not get, so the message names something concrete.
+		port = s.terminalWantedPort
+	}
+	return terminalStatus{
+		Available:        s.terminalAvailable,
+		Port:             port,
+		Error:            s.terminalError,
+		BlockedByPID:     s.terminalBlockedByPID,
+		BlockedByCommand: s.terminalBlockedByCommand,
+	}
 }
 
 // getTerminalPort returns the terminal server port (0 if not running).

--- a/cmd/browser-agent/server_routes_health_diagnostics.go
+++ b/cmd/browser-agent/server_routes_health_diagnostics.go
@@ -47,9 +47,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request, cap *captu
 			"dropped_count": s.logs.getLogDropCount(),
 		},
 	}
-	if termPort := s.getTerminalPort(); termPort > 0 {
-		resp["terminal_port"] = termPort
-	}
+	s.addTerminalHealth(resp)
 
 	successReads, failedReads := bridge.SnapshotFastPathResourceReadCounters()
 	resp["bridge_fastpath"] = map[string]any{
@@ -111,4 +109,38 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 		p, _ := os.FindProcess(os.Getpid())
 		_ = p.Signal(syscall.SIGTERM)
 	})
+}
+
+// addTerminalHealth writes the terminal server's state into a health payload.
+//
+// terminal_available is ALWAYS present so a caller can branch on it without having
+// to infer meaning from an absent field — the old payload simply omitted
+// terminal_port on a bind failure, which is indistinguishable from "this build has
+// no terminal". The diagnosis fields appear only when something is wrong: noise on
+// the happy path trains people to ignore the field.
+func (s *Server) addTerminalHealth(resp map[string]any) {
+	st := s.getTerminalStatus()
+	resp["terminal_available"] = st.Available
+	if st.Port > 0 {
+		resp["terminal_port"] = st.Port
+	}
+	if st.Available {
+		return
+	}
+	if st.Error != "" {
+		resp["terminal_error"] = st.Error
+	}
+	if st.BlockedByPID > 0 || st.BlockedByCommand != "" {
+		resp["terminal_blocked_by"] = map[string]any{
+			"pid":     st.BlockedByPID,
+			"command": st.BlockedByCommand,
+		}
+	}
+}
+
+// buildHealthPayload exposes the terminal portion of the health payload for tests.
+func (s *Server) buildHealthPayload() map[string]any {
+	resp := map[string]any{}
+	s.addTerminalHealth(resp)
+	return resp
 }

--- a/cmd/browser-agent/terminal_availability_test.go
+++ b/cmd/browser-agent/terminal_availability_test.go
@@ -1,0 +1,134 @@
+// terminal_availability_test.go -- /health must explain WHY the terminal is missing.
+//
+// A terminal-port bind failure is non-fatal: the daemon serves MCP normally and the
+// terminal is simply absent. But setTerminalPort is only called on success, so
+// /health omitted terminal_port entirely and said nothing else — the extension got
+// "Failed to fetch" on port+1 and configure(what:'health') showed no reason at all.
+// Worse, the daemon's stderr explanation goes to /dev/null for a bridge-spawned
+// daemon (it is spawned with Stdout/Stderr = nil so it cannot die of SIGPIPE), so
+// the ONE place a user or agent can learn what happened is this payload.
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newAvailabilityServer(t *testing.T) *Server {
+	t.Helper()
+	server, err := NewServer(filepath.Join(t.TempDir(), "avail.log"), 100)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	t.Cleanup(func() { server.logs.shutdownAsyncLogger(2 * time.Second) })
+	return server
+}
+
+func TestTerminalStatus_ReportsBlockingProcess(t *testing.T) {
+	server := newAvailabilityServer(t)
+
+	server.setTerminalUnavailable(7891, "listen tcp 127.0.0.1:7891: bind: address already in use",
+		4242, "/opt/homebrew/opt/postgresql@16/bin/postgres -D /var/pg")
+
+	st := server.getTerminalStatus()
+	if st.Available {
+		t.Fatal("a failed bind must not report the terminal as available")
+	}
+	if st.Port != 7891 {
+		t.Errorf("port = %d, want 7891 (the port we could not get)", st.Port)
+	}
+	if st.Error == "" {
+		t.Error("the underlying bind error must be preserved, not discarded")
+	}
+	if st.BlockedByPID != 4242 {
+		t.Errorf("blocked_by_pid = %d, want 4242", st.BlockedByPID)
+	}
+	// Naming the process is the whole point: "port busy" is not actionable,
+	// "postgres is on 7891" is.
+	if st.BlockedByCommand == "" {
+		t.Error("the blocking process's command must be reported so the user knows what to close")
+	}
+}
+
+func TestTerminalStatus_AvailableAfterSuccessfulBind(t *testing.T) {
+	server := newAvailabilityServer(t)
+
+	// A failure followed by a successful (re)bind must fully clear the diagnosis —
+	// a stale "blocked by postgres" would be worse than saying nothing.
+	server.setTerminalUnavailable(7891, "bind: address already in use", 4242, "postgres")
+	server.setTerminalPort(7891)
+
+	st := server.getTerminalStatus()
+	if !st.Available {
+		t.Fatal("a successful bind must report the terminal as available")
+	}
+	if st.Error != "" || st.BlockedByPID != 0 || st.BlockedByCommand != "" {
+		t.Fatalf("a successful bind must clear the previous failure, got %+v", st)
+	}
+	if st.Port != 7891 {
+		t.Errorf("port = %d, want 7891", st.Port)
+	}
+}
+
+func TestTerminalStatus_SupervisorDeathMarksUnavailable(t *testing.T) {
+	server := newAvailabilityServer(t)
+	server.setTerminalPort(7891)
+
+	// The supervisor reports death by setting the port to 0. That must flip
+	// availability too, or /health would keep claiming a terminal that is gone.
+	server.setTerminalPort(0)
+
+	if server.getTerminalStatus().Available {
+		t.Fatal("setTerminalPort(0) means the terminal server is gone; availability must follow")
+	}
+}
+
+func TestHealthPayload_ExplainsAnUnavailableTerminal(t *testing.T) {
+	server := newAvailabilityServer(t)
+	server.setTerminalUnavailable(7891, "bind: address already in use", 4242, "postgres -D /var/pg")
+
+	payload := server.buildHealthPayload()
+
+	avail, ok := payload["terminal_available"].(bool)
+	if !ok {
+		t.Fatal("health must always carry terminal_available so a caller can branch on it")
+	}
+	if avail {
+		t.Fatal("terminal_available must be false when the bind failed")
+	}
+	if payload["terminal_error"] == nil || payload["terminal_error"] == "" {
+		t.Error("health must carry the reason the terminal is unavailable")
+	}
+	blocked, ok := payload["terminal_blocked_by"].(map[string]any)
+	if !ok {
+		t.Fatal("health must name the process holding the port")
+	}
+	if pid, _ := blocked["pid"].(int); pid != 4242 {
+		t.Errorf("terminal_blocked_by.pid = %v, want 4242", blocked["pid"])
+	}
+	if cmd, _ := blocked["command"].(string); cmd == "" {
+		t.Error("terminal_blocked_by.command must be present")
+	}
+}
+
+func TestHealthPayload_HealthyTerminalCarriesNoDiagnosis(t *testing.T) {
+	server := newAvailabilityServer(t)
+	server.setTerminalPort(7891)
+
+	payload := server.buildHealthPayload()
+	if avail, _ := payload["terminal_available"].(bool); !avail {
+		t.Fatal("terminal_available must be true after a successful bind")
+	}
+	// Noise on the happy path trains people to ignore the field.
+	if _, present := payload["terminal_error"]; present {
+		t.Error("a healthy terminal must not carry an error field")
+	}
+	if _, present := payload["terminal_blocked_by"]; present {
+		t.Error("a healthy terminal must not claim to be blocked by anything")
+	}
+	if port, _ := payload["terminal_port"].(int); port != 7891 {
+		t.Errorf("terminal_port = %v, want 7891", payload["terminal_port"])
+	}
+}

--- a/docs/features/feature/mcp-persistent-server/index.md
+++ b/docs/features/feature/mcp-persistent-server/index.md
@@ -14,6 +14,7 @@ code_paths:
   - cmd/browser-agent/startup_throttle.go
   - cmd/browser-agent/main_connection_mcp.go
   - cmd/browser-agent/main_connection_recovery.go
+  - cmd/browser-agent/server_routes_health_diagnostics.go
   - cmd/browser-agent/main_connection_mcp_shutdown.go
   - cmd/browser-agent/server_middleware.go
   - cmd/browser-agent/handler_http.go
@@ -23,6 +24,7 @@ code_paths:
   - internal/util/proc_unix.go
   - internal/util/proc_windows.go
 test_paths:
+  - cmd/browser-agent/terminal_availability_test.go
   - cmd/browser-agent/reclaim_port_identity_test.go
   - cmd/browser-agent/reclaim_port_test.go
   - cmd/browser-agent/bridge_startup_contention_test.go


### PR DESCRIPTION
## Why

A terminal-port bind failure is **non-fatal**: the daemon serves MCP normally and the terminal is simply absent. The user saw "Failed to fetch" on port+1 and had nothing to go on.

The root problem was that every explanation the daemon produced was unreachable:

- `setTerminalPort` is only called on a **successful** bind, so `/health` **omitted `terminal_port` entirely** on failure — indistinguishable from "this build has no terminal" — and carried no reason at all.
- The stderr lines explaining it go to **`/dev/null`**: a bridge-spawned daemon is started with `cmd.Stdout/Stderr = nil` precisely so it cannot die of SIGPIPE (#628).

So the health payload was the only viable channel, and it said nothing.

## What

- **`/health` always carries `terminal_available`**, so a caller can branch on it instead of inferring meaning from an absent field. On failure it adds `terminal_error` and `terminal_blocked_by {pid, command}`. On the happy path it adds neither — noise there trains people to ignore the field.
- **A successful (re)bind clears the whole diagnosis.** A stale "blocked by postgres" would be worse than reporting nothing. `setTerminalPort(0)` — how the supervisor reports the server died — takes availability down with it.
- **`preflightPortCheck` names the holder.** It previously said `port 7890 already in use (unknown process, try '<kill hint>')`. "Unknown" pointed the user at a blind kill hint that might target something they did not want killed; it now reports pid + command. This is the message shown when the daemon refuses to start.
- `identifyPortHolder` is best effort and never fatal — it exists only to turn "port busy" into something actionable.

Net effect: `configure(what:'health')` now answers *"why is my terminal dead?"* with **"postgres (pid 4242) is on 7891"**.

This builds directly on the ownership check added in #632, which is what made naming the holder possible.

## Testing

5 tests written first: the blocking process is reported; a later successful bind fully clears the previous failure; supervisor death flips availability; the payload explains an unavailable terminal; and a healthy terminal carries **no** diagnosis fields at all.

## Gates

Exact CI invocation `go test -coverprofile ./cmd/browser-agent/...` → **14/14 packages ok, total coverage 70.7%** (gate 70%) · `go vet` + gofmt clean · `verify-llm` passed · docs cross-ref updated (rule 9).