### PR TITLE
chore(deps): point dependabot at UNSTABLE, not the default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
   # Go modules
   - package-ecosystem: "gomod"
     directory: "/"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -22,6 +26,10 @@ updates:
   # Root npm dependencies (MCP server wrapper)
   - package-ecosystem: "npm"
     directory: "/"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -38,6 +46,10 @@ updates:
   # Browser extension
   - package-ecosystem: "npm"
     directory: "/extension"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -55,6 +67,10 @@ updates:
   # E2E tests
   - package-ecosystem: "npm"
     directory: "/tests/e2e"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -72,6 +88,10 @@ updates:
   # Playwright package
   - package-ecosystem: "npm"
     directory: "/packages/gasoline-playwright"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -89,6 +109,10 @@ updates:
   # CI package
   - package-ecosystem: "npm"
     directory: "/packages/gasoline-ci"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -106,6 +130,10 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Contributions flow into UNSTABLE; STABLE is reached only by the release
+    # squash. Without this, dependabot uses the repo default branch (STABLE) and
+    # resets the base on every rebase, so retargeting a PR by hand never sticks.
+    target-branch: "UNSTABLE"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Why

Every dependabot PR was opened against **STABLE**, which contradicts the repo's own policy — contributions branch from and merge into UNSTABLE, and STABLE is reached only by the release squash. So each bump either sat unmergeable, or (if merged) bypassed CI's UNSTABLE gates entirely.

The config never set `target-branch`, so dependabot fell back to the repository's **default branch (STABLE)**.

That also makes retargeting by hand useless. `gh pr edit --base UNSTABLE` holds only until the next rebase, at which point dependabot recreates the PR against its configured target and silently resets it. That is exactly what happened today: I retargeted 14 PRs, asked dependabot to rebase them onto the new base, and seven came back pointing at STABLE again.

## What

Sets `target-branch: "UNSTABLE"` on all seven ecosystem blocks — `gomod`, the five `npm` directories (`/`, `/extension`, `/tests/e2e`, `/packages/gasoline-playwright`, `/packages/gasoline-ci`), and `github-actions`.

## Follow-up

Once this lands, the open bumps need one `@dependabot rebase` each to pick up the new target. Four already merged cleanly into UNSTABLE today (#580 `@types/chrome`, #581 svelte, #582 next, #583 react).