### PR TITLE
docs: add OpenAI Codex MCP integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Useful flags: `--dry-run` (preview), `--keep-data` (keep logs/recordings/project
 
 **Captures what others can't.** WebSocket messages, full request/response bodies, user action recording, Web Vitals, automatic regression detection, visual annotations, and Playwright test generation from real browser sessions — features no other MCP browser tool offers.
 
-**Works with every MCP tool.** Claude Code, Cursor, Windsurf, Zed, Claude Desktop, VS Code + Continue. Switch AI tools without changing your debugging setup.
+**Works with every MCP tool.** Claude Code, OpenAI Codex, Cursor, Windsurf, Zed, Claude Desktop, VS Code + Continue. Switch AI tools without changing your debugging setup.
 
 **Enterprise-safe by design.** Binds to `127.0.0.1` only. Auth headers are stripped automatically. No accounts, no cloud. Anonymous usage stats only (see Privacy). Audit the source — it's AGPL-3.0.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ Your browser logs stay on your hardware. The AI reads a local file via stdio. At
 Kaboom implements the open **[Model Context Protocol](https://modelcontextprotocol.io/)** standard. Swap AI tools without changing your debugging setup:
 
 - **[Claude Code](/mcp-integration/claude-code/)** — `.mcp.json` in project root
+- **[OpenAI Codex](/mcp-integration/codex/)** — `~/.codex/config.toml`
 - **[Cursor](/mcp-integration/cursor/)** — `~/.cursor/mcp.json`
 - **[Windsurf](/mcp-integration/windsurf/)** — `~/.codeium/windsurf/mcp_config.json`
 - **[Claude Desktop](/mcp-integration/claude-desktop/)** — OS-specific config

--- a/docs/mcp-integration/codex.md
+++ b/docs/mcp-integration/codex.md
@@ -1,0 +1,86 @@
+---
+title: "Kaboom + OpenAI Codex"
+description: "Configure Kaboom as an MCP server for OpenAI Codex. Give Codex access to browser console logs, network errors, and DOM state."
+keywords: "OpenAI Codex MCP server, Codex browser errors, Codex debugging, Codex MCP integration"
+permalink: /mcp-integration/codex/
+header:
+  overlay_image: /assets/images/hero-banner.png
+  overlay_filter: 0.85
+  excerpt: "Fuel OpenAI Codex with live browser data."
+toc: true
+toc_sticky: true
+status: reference
+last_reviewed: 2026-07-26
+---
+
+Kaboom is an open-source MCP server that gives OpenAI Codex access to browser console logs, network errors, exceptions, WebSocket events, and live DOM state.
+
+Codex stores MCP servers in `~/.codex/config.toml` (TOML), not JSON like the other supported clients.
+
+## <i class="fas fa-bolt"></i> Auto-Install
+
+The npm CLI can write the Codex config for you:
+
+```bash
+kaboom-agentic-browser --install codex
+```
+
+This writes a managed `[mcp_servers.kaboom-browser-devtools]` block to `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) and sets whole-server tool approval. The edit is section-scoped: your other settings and comments are left byte-for-byte intact.
+
+**The `install.sh` / `install.ps1` bootstrap does not cover Codex.** That script runs the native binary's `--install`, which configures JSON-based clients only. If you installed that way, use the manual configuration below.
+
+## <i class="fas fa-file-code"></i> Manual Configuration
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.kaboom-browser-devtools]
+command = "npx"
+args = ["kaboom-agentic-browser"]
+```
+
+To trust every Kaboom tool so Codex never prompts for approval:
+
+```toml
+[mcp_servers.kaboom-browser-devtools]
+command = "npx"
+args = ["kaboom-agentic-browser"]
+default_tools_approval_mode = "approve"
+```
+
+`default_tools_approval_mode` is a whole-server setting. Only `approve` suppresses prompts unconditionally — `auto` and `writes` can still prompt for tools that carry a risk hint.
+
+If you installed a standalone binary, replace `command = "npx"` with the full binary path and drop `args`.
+
+## <i class="fas fa-book"></i> Repository Instructions
+
+For Codex project-level instructions, use `AGENTS.md` in your repository root.
+
+## <i class="fas fa-fire-alt"></i> Usage
+
+After configuring, restart Codex and ask:
+
+- _"What browser errors do you see?"_
+- _"Check failed network requests for this page."_
+- _"Run an accessibility audit and summarize issues."_
+
+Codex gets all 5 Kaboom tools: `observe`, `analyze`, `generate`, `configure`, and `interact`.
+
+## <i class="fas fa-cog"></i> Custom Port
+
+If port 7890 is occupied:
+
+```toml
+[mcp_servers.kaboom-browser-devtools]
+command = "npx"
+args = ["kaboom-agentic-browser", "--port", "7891"]
+```
+
+Update the extension's Server URL in Options to match.
+
+## <i class="fas fa-wrench"></i> Troubleshooting
+
+1. **Restart Codex** after editing `config.toml`
+2. **Verify extension** shows "Connected" in popup
+3. **Verify MCP tools** by asking Codex what tools are available
+4. **Avoid duplicate servers** — stop manually started Kaboom processes before using MCP-managed mode

--- a/docs/mcp-integration/index.md
+++ b/docs/mcp-integration/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Fuel Any Agent"
-description: "Connect Kaboom to any MCP-compatible coding agent. Configuration guides for Claude Code, Cursor, Windsurf, Claude Desktop, Zed, and VS Code with Continue."
+description: "Connect Kaboom to any MCP-compatible coding agent. Configuration guides for Claude Code, OpenAI Codex, Cursor, Windsurf, Claude Desktop, Zed, and VS Code with Continue."
 keywords: "MCP server configuration, Model Context Protocol, autonomous coding agent, agentic debugging, browser debugging MCP"
 permalink: /mcp-integration/
 header:
@@ -20,6 +20,7 @@ Kaboom implements the [Model Context Protocol](https://modelcontextprotocol.io/)
 | Tool | Config Location | Guide |
 |------|----------------|-------|
 | <i class="fas fa-terminal"></i> Claude Code | `.mcp.json` (project root) | [Setup →](/mcp-integration/claude-code/) |
+| <i class="fas fa-code"></i> OpenAI Codex | `~/.codex/config.toml` | [Setup →](/mcp-integration/codex/) |
 | <i class="fas fa-i-cursor"></i> Cursor | `~/.cursor/mcp.json` | [Setup →](/mcp-integration/cursor/) |
 | <i class="fas fa-wind"></i> Windsurf | `~/.codeium/windsurf/mcp_config.json` | [Setup →](/mcp-integration/windsurf/) |
 | <i class="fas fa-desktop"></i> Claude Desktop | OS-specific config file | [Setup →](/mcp-integration/claude-desktop/) |

--- a/gokaboom.dev/astro.config.mjs
+++ b/gokaboom.dev/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
           items: [
             { label: 'Overview', slug: 'mcp-integration' },
             { label: 'Claude Code', slug: 'mcp-integration/claude-code' },
+            { label: 'OpenAI Codex', slug: 'mcp-integration/codex' },
             { label: 'Cursor', slug: 'mcp-integration/cursor' },
             { label: 'Windsurf', slug: 'mcp-integration/windsurf' },
             { label: 'Claude Desktop', slug: 'mcp-integration/claude-desktop' },

--- a/gokaboom.dev/src/content/docs/articles/how-to-connect-kaboom-to-codex.md
+++ b/gokaboom.dev/src/content/docs/articles/how-to-connect-kaboom-to-codex.md
@@ -1,0 +1,68 @@
+---
+title: "How to Connect KaBOOM to OpenAI Codex"
+description: "Beginner guide to connect OpenAI Codex with KaBOOM Agentic Devtools and run your first browser-aware workflow."
+date: 2026-07-26
+authors: [brenn]
+tags: [beginner, codex, openai, mcp, setup]
+last_verified_version: 0.8.8
+last_verified_date: 2026-07-26
+normalized_tags: ['beginner', 'codex', 'openai', 'mcp', 'setup', 'articles', 'connect', 'kaboom']
+---
+
+OpenAI Codex is excellent for code changes. KaBOOM makes Codex workflows browser-aware.
+
+Here is the fastest setup path.
+
+<!-- more -->
+
+## Quick Terms
+
+- **MCP (Model Context Protocol):** Connects Codex to external tools. https://modelcontextprotocol.io/specification/
+- **AGENTS.md:** Project-level instruction file used by Codex in your repository.
+
+## Step 1: Confirm KaBOOM command is available
+
+```bash
+npx -y kaboom-agentic-browser --help
+```
+
+## Step 2: Add KaBOOM as an MCP server in Codex
+
+Codex reads MCP servers from `~/.codex/config.toml`, which is TOML rather than JSON. Add this block:
+
+```toml
+[mcp_servers.kaboom]
+command = "npx"
+args = ["-y", "kaboom-agentic-browser"]
+```
+
+If you installed KaBOOM from npm, you can skip the hand-editing and let the Command Line Interface (CLI) write that block:
+
+```bash
+kaboom-agentic-browser --install codex
+```
+
+## Step 3: Restart Codex
+
+Restart so Codex reloads MCP servers.
+
+## Step 4: Run your first runtime checks
+
+```js
+observe({what: "errors"})
+observe({what: "network_bodies", status_min: 400})
+```
+
+## Step 5: Turn findings into a reproducible artifact
+
+```js
+generate({what: "reproduction"})
+```
+
+Now you have a repeatable baseline for debugging instead of one-off console checks.
+
+## Image and Diagram Callouts
+
+> [Image Idea] `~/.codex/config.toml` showing the `mcp_servers.kaboom` table.
+
+> [Diagram Idea] Codex prompt -> KaBOOM observe/analyze -> fix + verification loop.

--- a/gokaboom.dev/src/content/docs/articles/how-to-connect-kaboom-to-codex.md
+++ b/gokaboom.dev/src/content/docs/articles/how-to-connect-kaboom-to-codex.md
@@ -31,7 +31,7 @@ npx -y kaboom-agentic-browser --help
 Codex reads MCP servers from `~/.codex/config.toml`, which is TOML rather than JSON. Add this block:
 
 ```toml
-[mcp_servers.kaboom]
+[mcp_servers.kaboom-browser-devtools]
 command = "npx"
 args = ["-y", "kaboom-agentic-browser"]
 ```
@@ -63,6 +63,6 @@ Now you have a repeatable baseline for debugging instead of one-off console chec
 
 ## Image and Diagram Callouts
 
-> [Image Idea] `~/.codex/config.toml` showing the `mcp_servers.kaboom` table.
+> [Image Idea] `~/.codex/config.toml` showing the `mcp_servers.kaboom-browser-devtools` table.
 
 > [Diagram Idea] Codex prompt -> KaBOOM observe/analyze -> fix + verification loop.

--- a/gokaboom.dev/src/content/docs/downloads.md
+++ b/gokaboom.dev/src/content/docs/downloads.md
@@ -84,7 +84,7 @@ make build
 - **Runtime:** Native Go binary (no Node.js required for standalone binary installs)
 - **Node.js:** 18+ (optional, only if you install via npm)
 - **Platform:** macOS, Linux, Windows
-- **MCP Client:** Claude Code, Cursor, Windsurf, Claude Desktop, Zed, Gemini CLI, OpenCode, Antigravity, or any other MCP-compliant system/agent
+- **MCP Client:** Claude Code, OpenAI Codex, Cursor, Windsurf, Claude Desktop, Zed, Gemini CLI, OpenCode, Antigravity, or any other MCP-compliant system/agent
 
 ## Verification
 
@@ -114,6 +114,7 @@ To verify the binary:
 
 **Issues with MCP integration?**
 - See [Claude Code Integration Guide](/mcp-integration/claude-code)
+- See [OpenAI Codex Integration Guide](/mcp-integration/codex)
 - See [Cursor Integration Guide](/mcp-integration/cursor)
 
 ## Support

--- a/gokaboom.dev/src/content/docs/mcp-integration/codex.md
+++ b/gokaboom.dev/src/content/docs/mcp-integration/codex.md
@@ -25,7 +25,7 @@ If you installed KaBOOM with the `install.sh` / `install.ps1` script instead, us
 Add to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.kaboom]
+[mcp_servers.kaboom-browser-devtools]
 command = "npx"
 args = ["-y", "kaboom-agentic-browser"]
 ```
@@ -33,7 +33,7 @@ args = ["-y", "kaboom-agentic-browser"]
 To trust every KaBOOM tool so Codex never prompts for approval:
 
 ```toml
-[mcp_servers.kaboom]
+[mcp_servers.kaboom-browser-devtools]
 command = "npx"
 args = ["-y", "kaboom-agentic-browser"]
 default_tools_approval_mode = "approve"
@@ -62,7 +62,7 @@ Codex gets all 5 KaBOOM tools: `observe`, `analyze`, `generate`, `configure`, an
 If port 7890 is occupied:
 
 ```toml
-[mcp_servers.kaboom]
+[mcp_servers.kaboom-browser-devtools]
 command = "npx"
 args = ["-y", "kaboom-agentic-browser", "--port", "7891"]
 ```

--- a/gokaboom.dev/src/content/docs/mcp-integration/codex.md
+++ b/gokaboom.dev/src/content/docs/mcp-integration/codex.md
@@ -1,0 +1,77 @@
+---
+title: KaBOOM + OpenAI Codex
+description: "Configure KaBOOM as an MCP server for OpenAI Codex. Give Codex access to browser console logs, network errors, and DOM state."
+last_verified_version: 0.8.8
+last_verified_date: 2026-07-26
+normalized_tags: ['mcp', 'integration', 'openai', 'codex']
+---
+
+KaBOOM is an open-source MCP server that gives OpenAI Codex access to browser console logs, network errors, exceptions, WebSocket events, and live DOM state. Zero dependencies.
+
+## Auto-Install
+
+If you installed KaBOOM from npm, the CLI can write the Codex config for you:
+
+```bash
+kaboom-agentic-browser --install codex
+```
+
+This writes a managed `[mcp_servers.kaboom-browser-devtools]` block to `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`) and sets whole-server tool approval. Your existing settings and comments are preserved — only the KaBOOM block is replaced.
+
+If you installed KaBOOM with the `install.sh` / `install.ps1` script instead, use the manual configuration below. That installer configures JSON-based clients only, so it does not touch `config.toml`.
+
+## Manual Configuration
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.kaboom]
+command = "npx"
+args = ["-y", "kaboom-agentic-browser"]
+```
+
+To trust every KaBOOM tool so Codex never prompts for approval:
+
+```toml
+[mcp_servers.kaboom]
+command = "npx"
+args = ["-y", "kaboom-agentic-browser"]
+default_tools_approval_mode = "approve"
+```
+
+`default_tools_approval_mode` applies to the whole server. Only `approve` suppresses prompts unconditionally — `auto` and `writes` can still prompt for tools that carry a risk hint.
+
+If you installed a standalone binary, replace the `command` value with the full binary path and drop `args`.
+
+## Repository Instructions
+
+For Codex project-level instructions, use `AGENTS.md` in your repository root.
+
+## Usage
+
+After configuring, restart Codex and ask:
+
+- _"What browser errors do you see?"_
+- _"Check failed network requests for this page."_
+- _"Run an accessibility audit and summarize issues."_
+
+Codex gets all 5 KaBOOM tools: `observe`, `analyze`, `generate`, `configure`, and `interact`.
+
+## Custom Port
+
+If port 7890 is occupied:
+
+```toml
+[mcp_servers.kaboom]
+command = "npx"
+args = ["-y", "kaboom-agentic-browser", "--port", "7891"]
+```
+
+Update the extension's Server URL in Options to match.
+
+## Troubleshooting
+
+1. **Restart Codex** after editing `config.toml`
+2. **Verify the KaBOOM extension popup** shows "Connected"
+3. **Check MCP visibility** by asking Codex which MCP tools are available
+4. **Avoid duplicate servers** — stop manually started KaBOOM processes before using MCP-managed mode

--- a/gokaboom.dev/src/content/docs/mcp-integration/index.md
+++ b/gokaboom.dev/src/content/docs/mcp-integration/index.md
@@ -1,6 +1,6 @@
 ---
 title: Fuel Any Agent
-description: "Connect KaBOOM to any MCP-compatible coding agent. Configuration guides for Claude Code, Cursor, Windsurf, Claude Desktop, Zed, Gemini CLI, OpenCode, Antigravity, and VS Code with Continue."
+description: "Connect KaBOOM to any MCP-compatible coding agent. Configuration guides for Claude Code, OpenAI Codex, Cursor, Windsurf, Claude Desktop, Zed, Gemini CLI, OpenCode, Antigravity, and VS Code with Continue."
 last_verified_version: 0.8.0
 last_verified_date: 2026-03-06
 normalized_tags: ['mcp', 'integration']
@@ -13,6 +13,7 @@ KaBOOM is an open-source MCP server that implements the [Model Context Protocol]
 | Tool | Config Location | Guide |
 |------|----------------|-------|
 | Claude Code | `.mcp.json` (project root) | [Setup →](/mcp-integration/claude-code/) |
+| OpenAI Codex | `~/.codex/config.toml` | [Setup →](/mcp-integration/codex/) |
 | Cursor | `~/.cursor/mcp.json` | [Setup →](/mcp-integration/cursor/) |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | [Setup →](/mcp-integration/windsurf/) |
 | Claude Desktop | OS-specific config file | [Setup →](/mcp-integration/claude-desktop/) |


### PR DESCRIPTION
Supersedes #565.

Credit to @Kavipriyan10-2000, who wrote the original guide — the commit carries a `Co-authored-by:` trailer. The PR head is on a fork, so this is a new branch in-repo rather than a push to theirs. #565 is still open; I'm not closing it here.

## Why a rewrite instead of a rebase

#565 was written against the old `Gasoline` brand and the old `cookwithgasoline.com/` site directory. Both have since been renamed (`cookwithgasoline.com/` → `getstrum.dev/` → `gokaboom.dev/`), so every path in the patch is wrong and it conflicts. I read it for content and rewrote the files at their current locations.

## Files

New:
- `gokaboom.dev/src/content/docs/mcp-integration/codex.md` — site page. Site integration pages are flat (no `<tool>/` subdir); frontmatter shape copied from the newest sibling, `gemini.md`.
- `docs/mcp-integration/codex.md` — repo docs page, matching `cursor.md` frontmatter and heading style.
- `gokaboom.dev/src/content/docs/articles/how-to-connect-kaboom-to-codex.md` — long-form article, matching `how-to-connect-kaboom-to-{cursor,claude-code}.md`.

Nav/index:
- `gokaboom.dev/astro.config.mjs` — sidebar entry
- `gokaboom.dev/src/content/docs/mcp-integration/index.md` — Supported Tools table + description
- `docs/mcp-integration/index.md` — Supported Tools table + description
- `docs/index.md` — ecosystem list
- `gokaboom.dev/src/content/docs/downloads.md` — MCP Client list + integration links
- `README.md` — "Works with every MCP tool" compatibility line

## The auto-install claim — scoped, not deleted

#565 documented `gasoline-mcp --install codex` and added "OpenAI Codex" to the "auto-detects and configures: ..." lists. I checked this against the code, and it is **half true**, which matters:

**The npm CLI does support Codex.** `npm/kaboom-agentic-browser/lib/config.js` has a real target:

```js
{
  id: 'codex',
  name: 'Codex CLI',
  type: 'file',
  format: 'toml',
  autoApprove: { kind: 'codex-toml' },
  envHome: 'CODEX_HOME',
  configPath: { all: '~/.codex/config.toml' },
}
```

`codex` is a valid `--install` alias (`getValidAliases()` returns `..., zed, codex`), and `lib/codex-config.js` does a comment-preserving section edit of the `[mcp_servers.<name>]` block.

**The native Go installer does not.** `fileConfigTargets()` in `cmd/browser-agent/native_install.go` lists only Cursor, Windsurf, Gemini CLI, Antigravity, OpenCode, Zed + per-OS Claude Desktop and VS Code — all merged through `mergeJSONConfig()`, so the table is JSON-only by construction. `scripts/install.sh:644` runs `"$CANONICAL_KABOOM_BIN" --install` (the Go binary), so **curl|sh users never get Codex configured**. And the Go `--install` is a plain bool flag (`config_modes.go:42`), so `--install codex` against that binary silently ignores the argument.

So the docs say: `--install codex` is the npm CLI path, and the `install.sh`/`install.ps1` bootstrap does not cover Codex — use manual config. I did **not** add Codex to the "auto-detects and configures: ..." enumerations in `agent-install-guide.md` / `getting-started.md` / `downloads.md`, because those describe the Go installer.

Parity gap filed as **kaboom-vhn** (P2). It's not a one-liner: `mcpFileConfig`/`mergeJSONConfig` assume JSON, so a Go Codex target needs a TOML writer mirroring `lib/codex-config.js` semantics, plus tests. No installer code changed here.

## Other corrections to the original

- **Fabricated TOML.** #565 documented per-tool approval as `[mcp_servers.<name>.tools.observe] approval_mode = "approve"` (×5). That is not a Codex setting. The real field is a whole-server `default_tools_approval_mode`, which is what `lib/codex-config.js` writes and what `developers.openai.com/codex/mcp` documents. Replaced, and noted that only `approve` suppresses prompts unconditionally.
- **No alias stub.** #565 added `docs/mcp-integration/codex/index.md`. Those `<tool>/index.md` files are `doc_type: legacy_alias` redirect stubs for pages that used to live at that path; a brand-new page has no legacy path, so it would redirect to nowhere. Omitted.
- Brand/package/domain rename; server keys matched per tree (`kaboom` on the site — all 9 siblings use it; `kaboom-browser-devtools` in `docs/`, matching `cursor.md` and `MCP_SERVER_NAME`). Both are in `LEGACY_MCP_SERVER_NAMES`, so the installer recognizes and cleans either.
- Version `0.8.8`, date `2026-07-26`. Confirmed 5 tools and port 7890/7891. `npx -y kaboom-agentic-browser` is the real published package.

## Gates

| Gate | Result |
|---|---|
| `npm run lint` | pass (clean) |
| `npm run docs:ci` (integrity + content + style + Vale + 6 contracts) | pass, exit 0 |
| `npm run docs:lint:integrity` | 0 errors (192 pre-existing stale-date warnings, untouched) |
| Vale | 0 errors, 0 warnings, 0 suggestions in 4 files |
| `node scripts/check-folder-size.cjs` | pass — no folder over budget, baseline **not** raised |
| `cd gokaboom.dev && npm run build` | pass — 126 pages, both new pages emitted, slug valid |
| TOML snippets parsed with `tomllib` | all 7 blocks valid |

`tests/cli/root-metadata-branding.test.cjs` has 3 failures (extension shell pages, `CLAUDE.md` gitnexus block, README). Verified identical on a clean `origin/UNSTABLE` via `git stash` — pre-existing, unrelated to this PR.

No feature dir touched, so the CLAUDE.md rule 9 `index.md` contract is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbq3NcqFSdTEZZuCNnfs7C
