### PR TITLE
fix(branding): repair four stale branding assertions red on UNSTABLE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ satisfied. (Flow maps are no longer required — do not create or update them.)
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **kaboom** (40314 symbols, 99330 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -139,7 +139,7 @@ This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relati
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/gasoline/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/kaboom/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -178,10 +178,10 @@ This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relati
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/gasoline/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/gasoline/clusters` | All functional areas |
-| `gitnexus://repo/gasoline/processes` | All execution flows |
-| `gitnexus://repo/gasoline/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/kaboom/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/kaboom/clusters` | All functional areas |
+| `gitnexus://repo/kaboom/processes` | All execution flows |
+| `gitnexus://repo/kaboom/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ satisfied. (Flow maps are no longer required — do not create or update them.)
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **kaboom** (40314 symbols, 99330 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -149,7 +149,7 @@ This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relati
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/gasoline/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/kaboom/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -188,10 +188,10 @@ This project is indexed by GitNexus as **gasoline** (40314 symbols, 99330 relati
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/gasoline/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/gasoline/clusters` | All functional areas |
-| `gitnexus://repo/gasoline/processes` | All execution flows |
-| `gitnexus://repo/gasoline/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/kaboom/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/kaboom/clusters` | All functional areas |
+| `gitnexus://repo/kaboom/processes` | All execution flows |
+| `gitnexus://repo/kaboom/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/tests/cli/clean-old-daemons-branding.test.cjs
+++ b/tests/cli/clean-old-daemons-branding.test.cjs
@@ -14,7 +14,11 @@ test('clean-old-daemons script uses Kaboom copy while targeting legacy processes
 
   assert.match(source, /gasoline.*--daemon|gasoline\.exe|lsof -c gasoline/)
   assert.match(source, /strum.*--daemon|strum\.exe|lsof -c strum/)
-  assert.match(source, /for legacy_name in gasoline strum; do/)
+  // Pin the coverage, not the exact list. The script has since added `kaboom`
+  // to this sweep so it also clears stale current-brand PID files, which is a
+  // strict improvement — but the old exact-match assertion failed on it. This
+  // still goes red if gasoline or strum is dropped from the loop.
+  assert.match(source, /for legacy_name in [^;]*\bgasoline\b[^;]*\bstrum\b[^;]*; do/)
   assert.match(source, /\.\\?\$\{legacy_name\}-\$port\.pid/)
 
   assert.doesNotMatch(source, /STRUM Daemon Cleanup/)

--- a/tests/cli/root-metadata-branding.test.cjs
+++ b/tests/cli/root-metadata-branding.test.cjs
@@ -25,7 +25,13 @@ test('root README uses Kaboom install and repo branding', () => {
   assert.match(readme, /Kaboom/)
   assert.match(readme, /gokaboom\.dev/)
   assert.match(readme, /window\.__kaboom\.annotate\(\)/)
-  assert.match(readme, /~\/\.kaboom\/extension/)
+  // The install directory is whatever native_install.go builds — currently
+  // ~/KaboomAgenticDevtoolExtension, overridable via KABOOM_EXTENSION_DIR.
+  // This previously asserted ~/.kaboom/extension, a path that appears nowhere
+  // in the product; the test was pinning a convention that never shipped, so
+  // it failed against a README that was correct.
+  assert.match(readme, /~\/KaboomAgenticDevtoolExtension/)
+  assert.match(readme, /KABOOM_EXTENSION_DIR/)
   assert.match(readme, /github\.com\/brennhill\/Kaboom-Browser-AI-Devtools-MCP/)
   assert.doesNotMatch(
     readme,
@@ -63,7 +69,11 @@ test('extension shell pages publish only Kaboom branding', () => {
 
   for (const file of files) {
     const source = read(file)
-    assert.match(source, /Kaboom/)
+    // The user-visible brand is styled "KaBOOM!"; "Kaboom" is the prose form.
+    // Accept either rather than forcing the shell pages to restyle the product
+    // name to satisfy a test. The invariant that matters is the second one:
+    // no residue from the Strum/Gasoline eras.
+    assert.match(source, /KaBOOM|Kaboom/)
     assert.doesNotMatch(source, /STRUM|Gasoline|Strum|getstrum|cookwithgasoline/)
   }
 })


### PR DESCRIPTION
Two branding contract tests have been red on `UNSTABLE` since before this session's refactors. **In three of the four cases the test was wrong, not the product** — so repairing the source to match would have broken working behavior.

## `root-metadata-branding.test.cjs`

**README install path.** The test asserted the extension installs to `~/.kaboom/extension`. That path appears nowhere in the product. `cmd/browser-agent/native_install.go:36` builds `~/KaboomAgenticDevtoolExtension` (overridable via `KABOOM_EXTENSION_DIR`), and the README documented it correctly all along. The test was pinning a convention that never shipped.

Had this been "fixed" from the other end, the README would now document a directory users never get.

**Extension shell pages.** Asserted `/Kaboom/` against pages whose user-visible title is the styled `KaBOOM!`. Now accepts either form rather than restyling the product name to satisfy a regex. The `doesNotMatch` half — no Strum/Gasoline residue — is unchanged, and that's the half carrying the real invariant.

## `clean-old-daemons-branding.test.cjs`

Asserted the exact string `for legacy_name in gasoline strum; do`. The script has since added `kaboom` to both of its sweeps so it also clears stale *current*-brand PID files — a strict improvement that the exact-match assertion rejected. Now pins the coverage (gasoline and strum both present) rather than the literal list, so it survives additions but still fails on a removal.

## `CLAUDE.md` / `AGENTS.md` — this one was a real content bug

The managed GitNexus block still referenced `gitnexus://repo/gasoline/` (5 refs in each file) and described the index as "gasoline". `CODEX.md` had already been updated to `kaboom`, so the three agent-instruction files disagreed about the resource namespace. Aligned on `kaboom`.

Worth knowing: there is no `.gitnexus/` index in the repo at all, so neither name currently resolves. This is documentation consistency, not a working lookup — and re-running `npx gitnexus analyze` may regenerate the block under whatever name it picks.

## Verification

Every changed assertion was mutation-tested — break the thing it covers, confirm RED, restore:

| Mutation | Result |
|---|---|
| README install path → wrong dir | RED |
| Inject `Gasoline` into a shell page | RED |
| Revert CLAUDE.md gitnexus to `gasoline` | RED |
| Drop `gasoline` from the legacy sweep | RED |

The last one initially appeared *not* to catch its mutation. The script has **two** `legacy_name` loops (lines 47 and 105) and only one had been mutated — the other kept the assertion satisfied. Breaking both goes red as expected. Worth flagging because a single-site mutation would have wrongly certified the assertion as sound.

All 7 `tests/cli/*branding*` contracts now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbq3NcqFSdTEZZuCNnfs7C