### PR TITLE
test: re-enable 1,800 lines of redaction and SARIF tests CI never ran

### DIFF
--- a/internal/export/export_sarif_test.go
+++ b/internal/export/export_sarif_test.go
@@ -1,11 +1,10 @@
 // Purpose: Tests for SARIF accessibility report export.
 // Docs: docs/features/feature/har-export/index.md
 
-//go:build integration
-// +build integration
-
-// NOTE: These tests require MCP handler types that aren't exported.
-// Run with: go test -tags=integration ./internal/export/...
+// These were gated behind `//go:build integration` with a note saying they "require
+// MCP handler types that aren't exported". They reference no MCP type at all — the
+// imports below are stdlib only, and the file is in package export. The tag is gone
+// and these tests run by default.
 package export
 
 import (

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -1,11 +1,11 @@
 // Purpose: Tests for PII and credential redaction correctness.
 // Docs: docs/features/feature/redaction-patterns/index.md
 
-//go:build integration
-// +build integration
-
-// NOTE: These tests use raceEnabled which needs to be exported or defined here.
-// Run with: go test -tags=integration ./internal/redaction/...
+// These were gated behind `//go:build integration` with a note saying raceEnabled
+// "needs to be exported or defined here". It is defined here — race_enabled_test.go
+// and race_disabled_test.go declare it as a build-tag-selected constant in this same
+// package, so the stated blocker was already solved. The tag is gone and these tests
+// run by default.
 package redaction
 
 import (


### PR DESCRIPTION
The last two `//go:build integration` tags in the repo, both carrying a stated justification that is **false**. Neither test needs the tag — both compile and pass unmodified once it's removed.

| File | Lines | Tests | Claimed blocker | Reality |
|---|---:|---:|---|---|
| `internal/redaction/redaction_test.go` | 823 | 30 | "uses `raceEnabled` which needs to be exported or defined here" | It **is** defined here — `race_enabled_test.go` / `race_disabled_test.go` declare it as a build-tag-selected constant in the same package |
| `internal/export/export_sarif_test.go` | 977 | 27 | "requires MCP handler types that aren't exported" | References no MCP type at all; imports are stdlib only, file is in `package export` |

**374 assertions now run in the default suite.**

## These are real coverage, not vacuous passes

Enabling a test that passes for the wrong reason is worse than leaving it off, so both were mutation-tested — confirmed RED, then restored:

- Breaking the `aws-key` builtin pattern (`AKIA[0-9A-Z]{16}`) → `internal/redaction` FAILs
- Remapping axe `critical` impact away from SARIF level `error` → `internal/export` FAILs

## Fourth and fifth instance of the same pattern

`internal/security` had **1,618 lines** behind "NetworkBody needs to be imported from capture package" — it imported fine. `internal/analysis` had a test tagged with what turned out to be a *run instruction* rather than a constraint.

After this change there are **zero live `//go:build integration` tags in the repo**. The two remaining textual matches are historical comments documenting prior removals.

Worth considering as follow-up: a gate that fails when a build-tag-gated test would compile and pass without its tag. Five instances suggests the tag gets added during a refactor to unblock a build and then never revisited.

## Gates

`go test ./internal/... ./cmd/...` exit 0 · coverage **71.0%** (gate 70%) · `make verify-llm` passed · `npm run docs:ci` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbq3NcqFSdTEZZuCNnfs7C