### PR TITLE
docs: rewrite known-issues against the current tree

### DIFF
--- a/docs/core/known-issues.md
+++ b/docs/core/known-issues.md
@@ -2,39 +2,280 @@
 status: active
 scope: issues/blockers
 ai-priority: high
-tags: [known-issues, v0.7.x]
-last-verified: 2026-03-05
+tags: [known-issues, v0.8.x]
+last-verified: 2026-07-27
 canonical: true
 ---
 
 # Known Issues
 
-## v0.7.x — Current Release
+Every entry below was re-verified against the working tree on the date in the
+frontmatter, and carries the command that reproduces it. If you cannot reproduce
+one, treat it as fixed and delete it rather than leaving it to rot.
 
-### Open Issues
+## Test infrastructure
 
-| # | Issue | Severity | Details |
-|---|-------|----------|---------|
-| 1 | Extension timeout on first interact() | Medium | Content script may not be fully loaded when first `interact()` command is sent after navigation. **Workaround:** Retry after 2-3 seconds. |
-| 2 | Tracking loss during cross-origin navigation | Medium | Extension can lose tab tracking state during AI-initiated cross-origin navigation via `interact({action: "navigate"})`. **Workaround:** Re-enable tracking via extension popup. |
-| 3 | ~~Pilot test zombies~~ | ~~Low~~ | **Resolved.** Hardcoded `version: '5.2.0'` no longer present in `tests/extension/pilot-*.test.js`. |
+### 1. 30 JavaScript test files are executed by no CI job — HIGH
 
-### Flaky Tests (Pre-existing)
+The only JS test job is `npm run test:ext`, which runs
+`scripts/test-js-sharded.sh`. That script collects exactly:
 
-- `TestAsyncQueueReliability/Slow_polling` — times out at 30s intermittently
+```bash
+rg --files tests/extension extension/background -g '*.test.js'
+```
+
+Two consequences, both live:
+
+- **Whole directories are invisible to CI:** `tests/cli` (17 files),
+  `tests/docs` (5), `tests/packaging` (3), `tests/site` (2).
+- **The glob is `*.test.js` only**, so `.test.cjs` and `.test.mjs` are skipped
+  *even inside the directories it does scan*.
+
+```bash
+# reproduce the count
+find tests scripts -name '*.test.*' \
+  | grep -vE '^tests/extension/.*\.test\.js$|^extension/background/.*\.test\.js$' \
+  | grep -vE 'scripts/release/(install-upgrade-regression\.contract|verify-platform-binaries)\.test\.mjs' \
+  | wc -l   # -> 30
+```
+
+Two of those suites are **currently red**, and were red before the July 2026
+refactor series — nothing regressed them, nothing was ever watching:
+
+| Suite | Result |
+| --- | --- |
+| `tests/extension/integration.test.cjs` | 8 pass, **5 fail** |
+| `tests/site/gokaboom-domain-contract.test.js` | 21 pass, **2 fail** |
+
+`integration.test.cjs` is the sharpest case: it sits in a directory CI does scan
+and is skipped purely because of its file extension.
+
+**Fix direction:** widen the glob to `*.test.{js,cjs,mjs}` and add the missing
+directories, then fix or delete whatever turns red. Expect the widening to
+surface more than the two failures above.
+
+### 2. `scripts/check-dormant-tests.sh` never runs in CI — MEDIUM
+
+The gate written to catch dormant tests is itself dormant.
+
+```bash
+rg -n 'check-dormant-tests' .github/   # -> no matches
+```
+
+It is wired into `make check-structure`, but the CI "Structure Gates" job calls
+`scripts/check-file-length.sh` and `scripts/check-folder-size.cjs` **directly**
+rather than going through the make target, so the third check is silently
+skipped. It is also Go-only, and the dormancy problem is worse on the JS side
+(issue 1).
+
+**Fix direction:** have the CI job call `make check-structure` so newly added
+gates are picked up by default, and extend the script to cover JS.
+
+### 3. `cmd/browser-agent` tests run close to their timeout — MEDIUM
+
+The package takes ~206s of a 600s per-package limit on a two-core CI runner, and
+many of its tests spawn real daemon subprocesses against 1-second budgets. It is
+therefore sensitive to *any* CPU contention elsewhere in the same
+`go test ./cmd/browser-agent/... ./internal/...` invocation.
+
+This is not theoretical: one new unit test in `internal/` that burned ~10s of CPU
+under `-race` was enough to push this package past 600s and fail 21 unrelated
+tests (PR #659, commit `173e8c2c`). It presented as a broad daemon/MCP breakage
+with no visible connection to the change.
+
+**If you see a wall of `cmd/browser-agent` failures at ~30s each ending in
+`panic: test timed out`, suspect CPU cost you just added elsewhere, not the
+daemon.** Confirm the same tests pass in isolation and on UNSTABLE before
+investigating the daemon itself.
+
+### 4. Flaky tests (pre-existing)
+
+- `TestAsyncQueueReliability/Slow_polling` — intermittent 30s timeout
 - `tests/extension/async-timeout.test.js` — 3 tests flaky
+- `TestFastStart_ClientCompatibilityMatrix/claude_code` — fails only under
+  full-suite load; passes in isolation. Local runs are additionally sensitive to
+  anything already holding port 7891.
 
-### Fixed in v0.7.x (was v5.8.0)
+## Test coverage gaps
 
-- Early-patch WebSocket capture — pages creating WS connections before inject script loads now captured
-- camelCase to snake_case field mapping for network waterfall entries
-- Command results routing through /sync endpoint with proper client ID filtering
+### 5. Only one of the `*Deps()` seam builders has a wiring guard — MEDIUM
+
+`daemonlifeDeps()` is guarded by `TestDaemonlifeDeps_AllSeamsWired`
+(`cmd/browser-agent/daemon_lifecycle_wiring_test.go`). These are not:
+
+- `screenrecDeps()` — `cmd/browser-agent/screenrec_bridge.go:19`
+- `generateDeps()` — `cmd/browser-agent/tools_generate_adapter.go:11`
+
+A `Deps` struct of function fields fails silently when a field is left nil or
+mis-wired: the seam still compiles and the feature simply stops doing something.
+For `screenrecDeps()` this was demonstrated by sabotage — the pilot gate and
+audit journaling can both be disabled with the suite staying green.
+
+**Fix direction:** copy the `AllSeamsWired` pattern for each remaining builder.
+
+### 6. Per-package coverage numbers under-report cross-package tests — INFO
+
+Go measures coverage per package. When a function's tests live in a *different*
+package — very common here, because `cmd/browser-agent` tests exercise
+`internal/tools/...` through the MCP dispatch — the function reads 0.0% while
+being fully exercised.
+
+`observe.AnalyzeErrors` reads **0.0%** in a plain `go test ./internal/...` run
+and **100%** when measured correctly:
+
+```bash
+go test ./cmd/browser-agent/ -run TestToolAnalyzeErrors \
+  -coverpkg=github.com/brennhill/Kaboom-Browser-AI-Devtools-MCP/internal/tools/observe \
+  -coverprofile=/tmp/cov.out && go tool cover -func=/tmp/cov.out | grep AnalyzeErrors
+```
+
+**Never conclude "this is untested" from a per-package number alone.** This trap
+produced a false claim in a feature doc during the July 2026 audit. Untested
+*behaviour* and uncounted *coverage* are different problems with different fixes.
+
+## Documentation
+
+### 7. Feature docs reference files that do not exist — LOW
+
+13 paths cited in feature `index.md` files no longer resolve, mostly fallout from
+the July 2026 package extractions (`cmd/browser-agent/bridge*.go` →
+`cmd/browser-agent/internal/bridge/`, `terminal_*.go` → `internal/terminal/`).
+
+```bash
+for p in $(rg -oN '`[a-zA-Z0-9_./-]+\.(go|ts|js|sh|cjs)`' \
+    docs/features/feature/*/index.md | sed 's/.*://' | tr -d '`' | sort -u); do
+  [ -e "$p" ] || echo "MISSING: $p"
+done
+```
+
+Affected features include `bridge-restart`, `terminal`, and `csp-safe-execution`.
+No gate blocks a dangling code path in a feature doc, which is why these
+accumulate silently — the docs cross-reference contract in `CLAUDE.md` is
+enforced by convention only.
+
+### 8. Collateral orphans from deleted packages — LOW
+
+Left behind when four unreachable packages were removed in #657:
+
+- `internal/types/alert.go:54,68` — `PerformanceAlert`, `AlertMetricDelta`
+- `internal/session/doc.go:14-19`
+- `internal/capture/types.go:47-54`
+- `docs/core/code-index.md:283-284`
+- `docs/architecture/diagram-inventory.md:64`
+- `.github/workflows/ci.yml:48` — path filter still references the removed
+  `docs/architecture/flow-maps/` directory
+
+## Architecture
+
+### 9. God objects remain, despite the folder counts — INFO
+
+The July 2026 refactor series reduced *per-folder file counts* and satisfied the
+ratcheting folder gate, but it did not decompose the two large types. Do not read
+the folder-gate numbers as evidence that it did.
+
+| | Current |
+| --- | --- |
+| `Capture` methods behind one `sync.RWMutex` | 165 |
+| `cmd/browser-agent` source files (package `main`) | 160 |
+| …of which declare `*ToolHandler` methods | 67 |
+
+Both are **structurally pinned**: Go only permits methods on a type in the
+package that declares it, so no `*ToolHandler` method can move until
+`ToolHandler` itself does. That is why the extracted `tool*` subpackages hold
+free functions plus a `Deps` struct, with thin method shims left in `main`.
+
+Note also that `src/lib` and `src/background` were **relocated into
+subdirectories, not decomposed** — total file count and LOC are essentially
+unchanged. The folder gate counts files per directory, so nesting satisfies it.
+
+## Release / tooling
+
+### 10. Repo token lacks `workflow` scope — MEDIUM
+
+Any PR touching `.github/workflows/` cannot be merged, or have its branch
+updated, via `gh`:
+
+```
+GraphQL: refusing to allow an OAuth App to create or update workflow
+`.github/workflows/ci.yml` without `workflow` scope (updatePullRequestBranch)
+```
+
+Such PRs must go through the GitHub web UI.
+
+### 11. PR #591 would revert the repository if merged — HIGH
+
+The open dependabot PR (`@playwright/test` 1.59.1 → 1.62.0) is **115 commits
+behind UNSTABLE**. Its real payload is one line in `tests/e2e/package.json`, but
+merging it would touch **1,749 files and revert 26,828 lines**, including pinned
+action SHAs in `ci.yml` and the entire July refactor series.
+
+```bash
+git fetch origin 'refs/pull/591/head:pr591'
+git diff --stat origin/UNSTABLE..pr591 | tail -1
+```
+
+GitHub reports `mergeable=MERGEABLE`, which means *no conflicts* — not *safe*.
+The branch cannot be updated via `gh` because of issue 10.
+
+**Do not merge it.** Close it and let dependabot regenerate against UNSTABLE
+(#637 already retargeted dependabot), or apply the one-line bump by hand.
+
+### 12. Non-blocking CI checks that are permanently red — INFO
+
+These appear on every PR and are not caused by the branch under review:
+
+- `Cloudflare Pages: blazetorch-ai-devtools` — FAILURE (legacy brand project)
+- `Cloudflare Pages: gasoline-agentic-devtools` — FAILURE (legacy brand project)
+- `Codacy Static Code Analysis` — ACTION_REQUIRED
+
+`Cloudflare Pages: gokaboom` (the live site) passes. Also note that **Security
+Scan and JavaScript Checks run ESLint but are not required checks**, so
+auto-merge can land lint-red PRs — run `npm run lint` before merging changes
+under `extension/` or `tests/`.
+
+## Runtime (product)
+
+### 13. Extension timeout on first `interact()` — MEDIUM
+
+The content script may not be fully loaded when the first `interact()` command
+arrives after navigation. **Workaround:** retry after 2-3 seconds.
+
+### 14. Tracking loss during cross-origin navigation — MEDIUM
+
+The extension can lose tab tracking state during an AI-initiated cross-origin
+navigation via `interact({action: "navigate"})`. **Workaround:** re-enable
+tracking from the extension popup.
+
+## Recently fixed
+
+### v0.8.x
+
+- Error clustering fingerprinted on the **raw** message, so errors differing only
+  by an embedded id/uuid/url/timestamp never clustered with their own siblings —
+  300 pseudo-clusters where 109 real ones existed. Now normalized. (#659)
+- `analyze({what:"error_clusters"})` returned clusters and urls in Go map order,
+  a different order on every call for identical input. Now sorted. (#659)
+- `generate`'s CSP builder had the same map-iteration nondeterminism, in two
+  places. (#657)
+- Four repository gates had silently stopped running after their targets moved,
+  including one reporting `PASS: bridge.go not found (skipped)` for ~4 months.
+  (#654)
+- ~3,400 lines of tests dormant behind `//go:build integration` re-enabled. (#651)
+- ~9,500 lines of unreachable code deleted. (#657)
+
+### v0.7.x
+
+- Early-patch WebSocket capture for pages creating connections before inject loads
+- camelCase → snake_case mapping for network waterfall entries
+- Command results routed through `/sync` with client-ID filtering
 - Post-navigation tracking state broadcast for favicon updates
-- Empty arrays return `[]` instead of `null` in JSON responses
-- Bridge timeouts return proper `extension_timeout` error code
+- Empty arrays serialize as `[]` rather than `null`
+- Bridge timeouts return a proper `extension_timeout` error code
+- Pilot test zombies — hardcoded `version: '5.2.0'` removed from
+  `tests/extension/pilot-*.test.js`
 
-### Fixed in v5.7.x
+### v5.7.x
 
 - Extension health check timeout (5s threshold added)
-- Hardcoded version in inject.bundled.js (now reads from VERSION file via esbuild define)
+- Hardcoded version in `inject.bundled.js` (now read from VERSION via esbuild define)
 - Stale compiled JS vs TS source


### PR DESCRIPTION
`docs/core/known-issues.md` was last verified **2026-03-05** and still described v0.7.x; the tree is on 0.8.8.

Rewritten so **every entry carries the command that reproduces it** — an entry nobody can reproduce should be deleted rather than left to rot, and the old format made that impossible to check.

14 open issues in six sections. Both runtime issues survived verification; the pilot-zombie row was already resolved and moved to the fixed list.

## New material (all verified against the tree today)

**30 JS test files run in no CI job.** The cause is narrower than "directories CI misses" — `scripts/test-js-sharded.sh` globs `-g '*.test.js'`, so `.cjs`/`.mjs` are skipped *even inside the directories it does scan*. `tests/extension/integration.test.cjs` has **5 failing tests** and is invisible purely because of its file extension. Also red: `tests/site/gokaboom-domain-contract.test.js` (2 failures). Both predate the July refactors.

**`cmd/browser-agent` runs at ~206s of a 600s package timeout** with daemon subprocess tests on 1-second budgets, making it fragile to CPU cost added anywhere else in the same `go test` invocation. This bit during #659: one ~10s `-race` unit test in `internal/` failed 21 unrelated tests. Documented with the tell, because it presents as a daemon regression with no visible link to the real cause.

**Per-package coverage under-reports cross-package tests.** Written as a rule with the `-coverpkg` invocation — `AnalyzeErrors` reads 0.0% one way and 100% the other. This trap produced a false claim in a feature doc during the July audit.

**PR #591 reports `mergeable=MERGEABLE`** but would touch 1,749 files and revert 26,828 lines including pinned action SHAs. Recorded with the diff command so the hazard is checkable rather than asserted.

**The refactor series moved files without decomposing the god objects** — `Capture` still has 165 methods behind one mutex, and `src/lib`/`src/background` were relocated into subdirectories rather than decomposed. Recorded so the folder-gate numbers aren't read as more than they are.

Also captured: only 1 of 3 `*Deps()` seam builders has a wiring guard, 13 dangling doc paths, collateral orphans from #657, the missing `workflow` token scope, and the permanently-red non-blocking checks.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)